### PR TITLE
replace GAMS-InputDir by `subprocess(cwd=...)`

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1131,6 +1131,7 @@ def run_gams(model_file, args, gams_args=['LogOption=4']):
         - `LogOption=4` prints output to stdout (not console) and the log file
     """
     cmd = 'gams {} {}'.format(model_file, args)
-    cmd = '{} Inputdir={}'.format(cmd, os.path.dirname(model_file))
     cmd = cmd.split() + gams_args
-    check_call(cmd, shell=os.name == 'nt')
+    file_path = os.path.dirname(model_file)
+    file_path = None if file_path == '' else file_path
+    check_call(cmd, shell=os.name == 'nt', cwd=file_path)

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -93,7 +93,3 @@ def test_run_gams_api():
     obs = scen.var('z')['lvl']
     exp = 153.675
     assert np.isclose(obs, exp)
-
-    # remove log and lst file
-    os.remove('transport_ixmp.log')
-    os.remove('transport_ixmp.lst')


### PR DESCRIPTION
GAMS looks for opt-files and writes output files to the working directory irrespective of the option InputDir. This PR replaces the InputDir argument in the `solve()` function calling the subprocess by the cwd argument of the `check_call()`.