### PR TITLE
alllow alternative header cases when adding timeseries

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -22,7 +22,7 @@ import ixmp.model_settings as model_settings
 
 local_path = os.path.expanduser(os.path.join('~', '.local', 'ixmp'))
 
-# %% common definitions
+# %% default settings for column headers
 
 iamc_idx_cols = ['model', 'scenario', 'region', 'variable', 'unit']
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -300,8 +300,8 @@ class TimeSeries(object):
         Parameters
         ----------
         df : a Pandas dataframe either
-             - in tabular form (cols: region, variable, unit, year)
-             - in 'IAMC-style' format (cols: region, variable, unit, [years])
+             - in tabular form (cols: region[/node], variable, unit, year)
+             - in IAMC format (cols: region[/node], variable, unit, <years>)
         meta : boolean
             indicator whether this timeseries is 'meta-data'
             (special treatment during cloning for MESSAGE-scheme scenarios)
@@ -310,6 +310,14 @@ class TimeSeries(object):
 
         if "time" in df.columns:
             raise("sub-annual time slices not supported by Python interface!")
+
+        # rename columns to standard notation
+        cols = {c: str(c).lower() for c in df.columns}
+        cols.update(node='region')
+        df = df.rename(columns=cols)
+        if not set(iamc_idx_cols).issubset(set(df.columns)):
+            missing = list(set(iamc_idx_cols) - set(df.columns))
+            raise ValueError("missing required columns {}!".format(missing))
 
         # if in tabular format
         if ("value" in df.columns):

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -315,8 +315,9 @@ class TimeSeries(object):
         cols = {c: str(c).lower() for c in df.columns}
         cols.update(node='region')
         df = df.rename(columns=cols)
-        if not set(iamc_idx_cols).issubset(set(df.columns)):
-            missing = list(set(iamc_idx_cols) - set(df.columns))
+        required_cols = ['region', 'variable', 'unit']
+        if not set(required_cols).issubset(set(df.columns)):
+            missing = list(set(required_cols) - set(df.columns))
             raise ValueError("missing required columns {}!".format(missing))
 
         # if in tabular format

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -36,8 +36,8 @@ def start_jvm(jvmargs=None):
     if jvmargs is None:
         try:
             import psutil
-            jvmsize = psutil.virtual_memory().available / 10**9 / 2        
-            jvmargs = "-Xmx{}G".format(jvmsize)        
+            jvmsize = psutil.virtual_memory().available / 10**9 / 2
+            jvmargs = "-Xmx{}G".format(int(jvmsize))
         except ImportError:
             jvmargs = "-Xmx4G"              
 

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -176,6 +176,15 @@ def test_new_timeseries(test_mp):
     scen.commit('importing a testing timeseries')
 
 
+def test_new_timeseries_error(test_mp):
+    scen = test_mp.TimeSeries(*test_args, version='new', annotation='testing')
+    df = {'year': [2010, 2020], 'value': [23.5, 23.6]}
+    df = pd.DataFrame.from_dict(df)
+    df['region'] = 'World'
+    df['variable'] = 'Testing'
+    pytest.raises(ValueError, scen.add_timeseries, df)
+
+
 def test_get_timeseries(test_mp):
     scen = test_mp.TimeSeries(*test_args, version=2)
     obs = scen.timeseries(regions='World', variables='Testing', units='???',


### PR DESCRIPTION
This PR checks that all columns required for the IAMC template are present when adding timeseries data to an `ixmp.TimeSeries()` object.

The function now accepts "Title" and "UPPER" header styles, and accepts 'node' instead of 'region'.