### PR TITLE
Java virtual machine Xmx can now be user specified

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -29,7 +29,7 @@ iamc_idx_cols = ['model', 'scenario', 'region', 'variable', 'unit']
 
 # %% Java Virtual Machine start-up
 
-def start_jvm(jvmargs):
+def start_jvm(jvmargs=None):
     if jpype.isJVMStarted():
         return
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -33,15 +33,13 @@ def start_jvm(jvmargs=None):
     if jpype.isJVMStarted():
         return
 
-    try:
-        import psutil
-        if jvmargs is None:
+    if jvmargs is None:
+        try:
+            import psutil
             jvmsize = psutil.virtual_memory().available / 10**9 / 2        
             jvmargs = "-Xmx{}G".format(jvmsize)        
-    except ImportError:
-        if jvmargs is None:
+        except ImportError:
             jvmargs = "-Xmx4G"              
-        pass    
 
     # must add dir and jarfile to support finding ixmp.properties
     module_root = os.path.dirname(__file__)
@@ -81,7 +79,6 @@ class Platform(object):
         the type of the local database (e.g., 'HSQLDB')
         if no 'dbprops' is specified, the local database is
         created/accessed at '~/.local/ixmp/localdb/default'
-        
     jvmargs : string
         the allocated max heap space for the java virtual machine
         eg.: "-Xmx4G"

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -81,7 +81,8 @@ class Platform(object):
         created/accessed at '~/.local/ixmp/localdb/default'
     jvmargs : string
         the allocated max heap space for the java virtual machine
-        eg.: "-Xmx4G"
+        eg.: "-Xmx4G" (for more options see: 
+        https://docs.oracle.com/javase/7/docs/technotes/tools/windows/java.html)
     """
 
     def __init__(self, dbprops=None, dbtype=None, jvmargs=None):


### PR DESCRIPTION
If not specified by the user, the half available memorry is allocated as upper limit to the vitual machine intead of static 4G as before.