### PR TITLE
added 2 tests to test timeseries variable name length

### DIFF
--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -176,6 +176,34 @@ def test_new_timeseries(test_mp):
     scen.commit('importing a testing timeseries')
 
 
+def test_new_timeseries_long_name64(test_mp):
+    scen = test_mp.Scenario(*msg_multiyear_args)
+    scen = scen.clone(keep_sol=False)
+    scen.check_out(timeseries_only=True)
+    df = pd.DataFrame({
+    'region': ['India', ],
+    'variable': ['Emissions|CO2|Energy|Demand|Transportation|Aviation|Domestic|Fre',],
+    'unit': [ 'Mt CO2/yr', ],
+    '2012': [ 0.257009, ]
+    })
+    scen.add_timeseries(df)
+    scen.commit('importing a testing timeseries')
+
+
+def test_new_timeseries_long_name64plus(test_mp):
+    scen = test_mp.Scenario(*msg_multiyear_args)
+    scen = scen.clone(keep_sol=False)
+    scen.check_out(timeseries_only=True)
+    df = pd.DataFrame({
+    'region': ['India', ],
+    'variable': ['Emissions|CO2|Energy|Demand|Transportation|Aviation|Domestic|Freight|Oil',],
+    'unit': [ 'Mt CO2/yr', ],
+    '2012': [ 0.257009, ]
+    })
+    scen.add_timeseries(df)
+    scen.commit('importing a testing timeseries')
+
+
 def test_new_timeseries_error(test_mp):
     scen = test_mp.TimeSeries(*test_args, version='new', annotation='testing')
     df = {'year': [2010, 2020], 'value': [23.5, 23.6]}


### PR DESCRIPTION
When adding a timeseries with a variable which has more than 64 characters, an error message is displayed. The tests below replicate this issue