### PR TITLE
fix string issues and refactor for more pythony code

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -536,7 +536,7 @@ class Scenario(TimeSeries):
         keys : list of strings
             element keys to be added to the category mapping
         """
-        self._jobj.addCatEle(name, cat, to_jlist(keys), is_unique)
+        self._jobj.addCatEle(name, str(cat), to_jlist(keys), is_unique)
 
     def cat(self, name, cat):
         """return a list of all set elements mapped to a category

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -566,7 +566,7 @@ class Scenario(TimeSeries):
         idx_names : list of strings
             index name list (optional, default to 'idx_sets')
         """
-        self._jobj.initializeSet(name, make_dims(idx_sets, idx_names))
+        self._jobj.initializeSet(name, *make_dims(idx_sets, idx_names))
 
     def set(self, name, filters=None, **kwargs):
         """return a dataframe of (filtered) elements for a specific set
@@ -666,7 +666,7 @@ class Scenario(TimeSeries):
         idx_names : list of strings
             index name list (optional, default to 'idx_sets')
         """
-        self._jobj.initializePar(name, make_dims(idx_sets, idx_names))
+        self._jobj.initializePar(name, *make_dims(idx_sets, idx_names))
 
     def par(self, name, filters=None, **kwargs):
         """return a dataframe of (filtered) elements for a specific parameter
@@ -833,7 +833,7 @@ class Scenario(TimeSeries):
         idx_names : list of strings
             index name list (optional, default to 'idx_sets')
         """
-        self._jobj.initializeVar(name, make_dims(idx_sets, idx_names))
+        self._jobj.initializeVar(name, *make_dims(idx_sets, idx_names))
 
     def var(self, name, filters=None, **kwargs):
         """return a dataframe of (filtered) elements for a specific variable
@@ -863,7 +863,7 @@ class Scenario(TimeSeries):
         idx_names : list of strings
             index name list (optional, default to 'idx_sets')
         """
-        self._jobj.initializeEqu(name, make_dims(idx_sets, idx_names))
+        self._jobj.initializeEqu(name, *make_dims(idx_sets, idx_names))
 
     def equ(self, name, filters=None, **kwargs):
         """return a dataframe of (filtered) elements for a specific equation

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -9,6 +9,7 @@ from subprocess import check_call
 
 import numpy as np
 import pandas as pd
+import six
 
 import jpype
 from jpype import JPackage as java
@@ -1064,6 +1065,9 @@ def _getCleanDims(dims, dimsDefault=None):
             cleanDims.add(aDim)
 
     return cleanDims
+def isstr(x):
+    """Returns True if x is a string"""
+    return isinstance(x, six.string_types)
 
 
 def _jdouble(val):

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -566,8 +566,7 @@ class Scenario(TimeSeries):
         idx_names : list of strings
             index name list (optional, default to 'idx_sets')
         """
-        self._jobj.initializeSet(name, _getCleanDims(idx_sets),
-                                 _getCleanDims(idx_names, idx_sets))
+        self._jobj.initializeSet(name, make_dims(idx_sets, idx_names))
 
     def set(self, name, filters=None, **kwargs):
         """return a dataframe of (filtered) elements for a specific set
@@ -667,8 +666,7 @@ class Scenario(TimeSeries):
         idx_names : list of strings
             index name list (optional, default to 'idx_sets')
         """
-        self._jobj.initializePar(name, _getCleanDims(idx_sets),
-                                 _getCleanDims(idx_names, idx_sets))
+        self._jobj.initializePar(name, make_dims(idx_sets, idx_names))
 
     def par(self, name, filters=None, **kwargs):
         """return a dataframe of (filtered) elements for a specific parameter
@@ -835,8 +833,7 @@ class Scenario(TimeSeries):
         idx_names : list of strings
             index name list (optional, default to 'idx_sets')
         """
-        self._jobj.initializeVar(name, _getCleanDims(idx_sets),
-                                 _getCleanDims(idx_names, idx_sets))
+        self._jobj.initializeVar(name, make_dims(idx_sets, idx_names))
 
     def var(self, name, filters=None, **kwargs):
         """return a dataframe of (filtered) elements for a specific variable
@@ -866,8 +863,7 @@ class Scenario(TimeSeries):
         idx_names : list of strings
             index name list (optional, default to 'idx_sets')
         """
-        self._jobj.initializeEqu(name, _getCleanDims(idx_sets),
-                                 _getCleanDims(idx_names, idx_sets))
+        self._jobj.initializeEqu(name, make_dims(idx_sets, idx_names))
 
     def equ(self, name, filters=None, **kwargs):
         """return a dataframe of (filtered) elements for a specific equation
@@ -1054,17 +1050,6 @@ def filtered(df, filters):
     return df[mask]
 
 
-def _getCleanDims(dims, dimsDefault=None):
-    cleanDims = java.LinkedList()
-
-    if dims is not None:
-        for aDim in dims:
-            cleanDims.add(aDim)
-    elif dimsDefault is not None:
-        for aDim in dimsDefault:
-            cleanDims.add(aDim)
-
-    return cleanDims
 def isstr(x):
     """Returns True if x is a string"""
     return isinstance(x, six.string_types)
@@ -1101,6 +1086,11 @@ def to_jlist(pylist, idxName=None):
         for idx in idxName:
             jList.add(str(pylist[idx]))
     return jList
+
+
+def make_dims(idx_sets, idx_names):
+    """Wrapper of `to_jlist()` to generate an index-name and index-set list"""
+    return to_jlist(idx_sets), to_jlist(idx_names or idx_sets)
 
 
 def _getElementList(jItem, filters=None, has_value=False, has_level=False):

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1040,6 +1040,7 @@ class Scenario(TimeSeries):
 
 
 def filtered(df, filters):
+    """Returns a filtered dataframe based on a filters dictionary"""
     if filters is None:
         return df
 
@@ -1056,10 +1057,12 @@ def isstr(x):
 
 
 def _jdouble(val):
+    """Returns a Java.Double"""
     return java.Double(float(val))
 
 
 def to_pylist(jlist):
+    """Transforms a Java.Array or Java.List to a python list"""
     # handling string array
     try:
         return np.array(jlist[:])
@@ -1068,12 +1071,13 @@ def to_pylist(jlist):
         return np.array(jlist.toArray()[:])
 
 
-def to_jlist(pylist, idxName=None):
+def to_jlist(pylist, idx_names=None):
+    """Transforms a python list to a Java.LinkedList"""
     if pylist is None:
         return None
 
     jList = java.LinkedList()
-    if idxName is None:
+    if idx_names is None:
         if type(pylist) is list:
             for key in pylist:
                 jList.add(str(key))
@@ -1083,7 +1087,7 @@ def to_jlist(pylist, idxName=None):
         else:
             jList.add(str(pylist))
     else:
-        for idx in idxName:
+        for idx in idx_names:
             jList.add(str(pylist[idx]))
     return jList
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -9,7 +9,6 @@ from subprocess import check_call
 
 import numpy as np
 import pandas as pd
-import six
 
 import jpype
 from jpype import JPackage as java
@@ -1049,11 +1048,6 @@ def filtered(df, filters):
         isin = df[k].isin(v)
         mask = mask & isin
     return df[mask]
-
-
-def isstr(x):
-    """Returns True if x is a string"""
-    return isinstance(x, six.string_types)
 
 
 def _jdouble(val):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -32,6 +32,12 @@ def test_default_version(test_mp):
     assert scen.version == 2
 
 
+def test_add_set_par(test_mp):
+    scen = test_mp.Scenario(*can_args, version='new')
+    scen.init_set('ii')
+    scen.init_par('new_par', idx_sets='ii')
+    scen.discard_changes()
+
 def test_get_scalar(test_mp):
     scen = test_mp.Scenario(*can_args)
     obs = scen.scalar('f')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -32,11 +32,10 @@ def test_default_version(test_mp):
     assert scen.version == 2
 
 
-def test_add_set_par(test_mp):
+def test_init_par_35(test_mp):
     scen = test_mp.Scenario(*can_args, version='new')
     scen.init_set('ii')
     scen.init_par('new_par', idx_sets='ii')
-    scen.discard_changes()
 
 def test_get_scalar(test_mp):
     scen = test_mp.Scenario(*can_args)


### PR DESCRIPTION
This PR fixes two bugs 
 - when initializing a new set or parameter with only one index dimension, no need to pass the arg explicitly as a list
 - when adding a category-type mapping, no need to cast the type arg to `str` explicitely

closes #35 
closes #37