### PR TITLE
Clean error message for `check_out()` and refactor to `..._solution`

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -859,8 +859,8 @@ class Scenario(TimeSeries):
         """
         return self.element('equ', name, filters, **kwargs)
 
-    def clone(self, model=None, scen=None, annotation=None, keep_sol=True,
-              first_model_year=None):
+    def clone(self, model=None, scen=None, annotation=None, keep_solution=True,
+              first_model_year=None, **kwargs):
         """clone the current scenario and return the new scenario
 
         Parameters
@@ -871,20 +871,26 @@ class Scenario(TimeSeries):
             new scenario name
         annotation : string
             explanatory comment (optional)
-        keep_sol : boolean, default: True
+        keep_solution : boolean, default: True
             indicator whether to include an existing solution
             in the cloned scenario
         first_model_year: int, default None
             new first model year in cloned scenario
             ('slicing', only available for MESSAGE-scheme scenarios)
         """
+        if 'keep_sol' in kwargs:
+            warnings.warn(
+                '`keep_sol` is deprecated and will be removed in the next' +
+                ' release, please use `keep_solution`')
+            keep_solution = kwargs.pop('keep_sol')
+
         first_model_year = first_model_year or 0
 
         model = self.model if not model else model
         scen = self.scenario if not scen else scen
         return Scenario(self.platform, model, scen,
                         self._jobj.clone(model, scen, annotation,
-                                         keep_sol, first_model_year),
+                                         keep_solution, first_model_year),
                         cache=self._cache)
 
     def to_gdx(self, path, filename, include_var_equ=False):
@@ -902,7 +908,7 @@ class Scenario(TimeSeries):
         self._jobj.toGDX(path, filename, include_var_equ)
 
     def read_sol_from_gdx(self, path, filename, comment=None,
-                          var_list=None, equ_list=None, check_sol=True):
+                          var_list=None, equ_list=None, check_solution=True):
         """read solution from GAMS gdx and import it to the scenario
 
         Parameters
@@ -917,23 +923,31 @@ class Scenario(TimeSeries):
             variables (levels and marginals) to be imported from gdx
         equ_list : list of strings
             equations (levels and marginals) to be imported from gdx
-        check_sol : boolean, default True
+        check_solution : boolean, default True
             raise an error if GAMS did not solve to optimality
             (only applicable for a MESSAGE-scheme scenario)
         """
         self.clear_cache()  # reset Python data cache
         self._jobj.readSolutionFromGDX(path, filename, comment,
                                        to_jlist(var_list), to_jlist(equ_list),
-                                       check_sol)
+                                       check_solution)
 
-    def remove_sol(self):
+    def has_solution(self):
+        """check whether the Scenario has been solved and a solution (variables
+        and equations) exists in the database"""
+        return self._jobj.hasSolution()
+
+    def remove_solution(self):
         """delete the solution (variables and equations) from the sceanario"""
-        self.clear_cache()  # reset Python data cache
-        self._jobj.removeSolution()
+        if self.has_solution():
+            self.clear_cache()  # reset Python data cache
+            self._jobj.removeSolution()
+        else:
+            raise ValueError('this Scenario does not have a solution')
 
     def solve(self, model, case=None, model_file=None,
               in_file=None, out_file=None, solve_args=None, comment=None,
-              var_list=None, equ_list=None, check_sol=True):
+              var_list=None, equ_list=None, check_solution=True):
         """solve the model (export to gdx, execute GAMS, import the solution)
 
         Parameters
@@ -956,7 +970,7 @@ class Scenario(TimeSeries):
             variables to be imported from the solution
         equ_list : list of strings (optional)
             equations to be imported from the solution
-        check_sol : boolean, default True
+        check_solution : boolean, default True
             flag whether a non-optimal solution raises an exception
             (only applies to MESSAGE runs)
         """
@@ -985,7 +999,7 @@ class Scenario(TimeSeries):
         self.to_gdx(ipth, ingdx)
         run_gams(model_file, args)
         self.read_sol_from_gdx(opth, outgdx, comment,
-                               var_list, equ_list, check_sol)
+                               var_list, equ_list, check_solution)
 
     def clear_cache(self, name=None):
         """clear the Python cache of item elements

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1,6 +1,7 @@
 import jpype
 import os
 import sys
+import warnings
 
 import numpy as np
 import pandas as pd
@@ -240,6 +241,11 @@ class TimeSeries(object):
 
     def check_out(self, timeseries_only=False):
         """check out from the ixmp database instance for making changes"""
+        if not timeseries_only and self.has_solution():
+            raise ValueError('This Scenario has a solution, '
+                             'use `Scenario.remove_solution()` or '
+                             '`Scenario.clone(..., keep_solution=False)`'
+                             )
         self._jobj.checkOut(timeseries_only)
 
     def commit(self, comment):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -76,7 +76,7 @@ def test_get_scalar(test_mp):
 
 def test_init_scalar(test_mp):
     scen = test_mp.Scenario(*can_args)
-    scen2 = scen.clone(keep_sol=False)
+    scen2 = scen.clone(keep_solution=False)
     scen2.check_out()
     scen2.init_scalar('g', 90.0, 'USD/km')
     scen2.commit("adding a scalar 'g'")
@@ -90,7 +90,7 @@ def test_add_clone(test_mp):
     scen.add_set('h', 'test')
     scen.commit("adding an index set 'h', wiht element 'test'")
 
-    scen2 = scen.clone(keep_sol=False)
+    scen2 = scen.clone(keep_solution=False)
     obs = scen2.set('h')
     npt.assert_array_equal(obs, ['test'])
 
@@ -98,7 +98,7 @@ def test_add_clone(test_mp):
 # make sure that (only) the correct scenario is touched after cloning
 def test_clone_edit(test_mp):
     scen = test_mp.Scenario(*can_args)
-    scen2 = scen.clone(keep_sol=False)
+    scen2 = scen.clone(keep_solution=False)
     scen2.check_out()
     scen2.change_scalar('f', 95.0, 'USD/km')
     scen2.commit('change transport cost')


### PR DESCRIPTION
This PR migrates the error message when checking out a Scenario with a solution from Java to Python, to get the correct function names: `remove_solution()` instead of the underlying Java function `removeSol()`.

In addition, the PR adds a function `has_solution()` and renames `remove_sol()` to `remove_solution()`. The kwarg of `clone()` is changed from `keep_sol` to `keep_solution`, but `keep_sol` continues to work (with a deprecation warning).

Closes #71