### PR TITLE
clean-up of API for TimeSeries and Scenario constructors

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#76](https://github.com/iiasa/ixmp/pull/76): Changing the API from `mp.Scenario(...)` to `ixmp.Scenario(mp, ...)`
 - [#73](https://github.com/iiasa/ixmp/pull/73): Adding a function `has_solution()`, rename kwargs to `..._solution`
 - [#64](https://github.com/iiasa/ixmp/pull/64): Support writing multiple sheets to Excel in utils.pd_write
 - [#58](https://github.com/iiasa/ixmp/pull/58): Add MacOSX support in CI

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -856,8 +856,8 @@ class Scenario(TimeSeries):
         """
         return self.element('equ', name, filters, **kwargs)
 
-    def clone(self, model=None, scenario=None, annotation=None, keep_solution=True,
-              first_model_year=None, **kwargs):
+    def clone(self, model=None, scenario=None, annotation=None,
+              keep_solution=True, first_model_year=None, **kwargs):
         """clone the current scenario and return the new scenario
 
         Parameters

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -58,7 +58,7 @@ def import_timeseries(mp, data, model, scenario, version=None,
 
     if version is not None:
         version = int(version)
-    scen = mp.Scenario(model, scenario, version)
+    scen = ix.Scenario(mp, model, scenario, version)
 
     df = ix.utils.pd_read(data)
     df = df.rename(columns={c: str(c).lower() for c in df.columns})

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,7 +18,7 @@ def test_import_timeseries(test_mp_props):
     subprocess.check_call(cmd, shell=not win)
 
     mp = ix.Platform(test_mp_props)
-    scen = mp.Scenario('canning problem', 'standard', 1)
+    scen = ix.Scenario(mp, 'canning problem', 'standard', 1)
     obs = scen.timeseries()
     df = {'region': ['World'], 'variable': ['Testing'], 'unit': ['???'],
           'year': [2020], 'value': [28.3]}

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -153,7 +153,7 @@ def test_par_filters_unit(test_mp):
 
 
 def test_new_timeseries(test_mp):
-    scen = test_mp.TimeSeries(*test_args, version='new', annotation='testing')
+    scen = ixmp.TimeSeries(test_mp, *test_args, version='new', annotation='fo')
     df = {'year': [2010, 2020], 'value': [23.5, 23.6]}
     df = pd.DataFrame.from_dict(df)
     df['region'] = 'World'
@@ -164,7 +164,7 @@ def test_new_timeseries(test_mp):
 
 
 def test_new_timeseries_error(test_mp):
-    scen = test_mp.TimeSeries(*test_args, version='new', annotation='testing')
+    scen = ixmp.TimeSeries(test_mp, *test_args, version='new', annotation='fo')
     df = {'year': [2010, 2020], 'value': [23.5, 23.6]}
     df = pd.DataFrame.from_dict(df)
     df['region'] = 'World'
@@ -173,7 +173,7 @@ def test_new_timeseries_error(test_mp):
 
 
 def test_get_timeseries(test_mp):
-    scen = test_mp.TimeSeries(*test_args, version=2)
+    scen = ixmp.TimeSeries(test_mp, *test_args, version=2)
     obs = scen.timeseries(regions='World', variables='Testing', units='???',
                           years=2020)
     df = {'region': ['World'], 'variable': ['Testing'], 'unit': ['???'],
@@ -184,7 +184,7 @@ def test_get_timeseries(test_mp):
 
 
 def test_get_timeseries_iamc(test_mp):
-    scen = test_mp.TimeSeries(*test_args, version=2)
+    scen = ixmp.TimeSeries(test_mp, *test_args, version=2)
     obs = scen.timeseries(iamc=True, regions='World', variables='Testing')
     df = {'year': [2010, 2020], 'value': [23.5, 23.6]}
     df = pd.DataFrame.from_dict(df)
@@ -203,7 +203,7 @@ def test_get_timeseries_iamc(test_mp):
 
 def test_timeseries_edit(test_mp_props):
     mp = ixmp.Platform(test_mp_props)
-    scen = mp.TimeSeries(*test_args)
+    scen = ixmp.TimeSeries(mp, *test_args)
     df = {'region': ['World', 'World'], 'variable': ['Testing', 'Testing'],
           'unit': ['???', '???'], 'year': [2010, 2020], 'value': [23.7, 23.8]}
     exp = pd.DataFrame.from_dict(df)
@@ -222,7 +222,7 @@ def test_timeseries_edit(test_mp_props):
     mp.close_db()
 
     mp = ixmp.Platform(test_mp_props)
-    scen = mp.TimeSeries(*test_args)
+    scen = ixmp.TimeSeries(mp, *test_args)
     obs = scen.timeseries().sort_values(by=['year'])
     df = df.append(exp.loc[0]).sort_values(by=['year'])
     npt.assert_array_equal(df[cols_str], obs[cols_str])

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -52,30 +52,30 @@ def test_scen_list(test_mp):
 
 
 def test_new_scen(test_mp):
-    scen = test_mp.Scenario(*can_args, version='new')
+    scen = ixmp.Scenario(test_mp, *can_args, version='new')
     assert scen.version == 0
 
 
 def test_default_version(test_mp):
-    scen = test_mp.Scenario(*can_args)
+    scen = ixmp.Scenario(test_mp, *can_args)
     assert scen.version == 2
 
 
 def test_init_par_35(test_mp):
-    scen = test_mp.Scenario(*can_args, version='new')
+    scen = ixmp.Scenario(test_mp, *can_args, version='new')
     scen.init_set('ii')
     scen.init_par('new_par', idx_sets='ii')
 
 
 def test_get_scalar(test_mp):
-    scen = test_mp.Scenario(*can_args)
+    scen = ixmp.Scenario(test_mp, *can_args)
     obs = scen.scalar('f')
     exp = {'unit': 'USD/km', 'value': 90}
     assert obs == exp
 
 
 def test_init_scalar(test_mp):
-    scen = test_mp.Scenario(*can_args)
+    scen = ixmp.Scenario(test_mp, *can_args)
     scen2 = scen.clone(keep_solution=False)
     scen2.check_out()
     scen2.init_scalar('g', 90.0, 'USD/km')
@@ -84,7 +84,7 @@ def test_init_scalar(test_mp):
 
 # make sure that changes to a scenario are copied over during clone
 def test_add_clone(test_mp):
-    scen = test_mp.Scenario(*can_args, version=1)
+    scen = ixmp.Scenario(test_mp, *can_args, version=1)
     scen.check_out()
     scen.init_set('h')
     scen.add_set('h', 'test')
@@ -97,7 +97,7 @@ def test_add_clone(test_mp):
 
 # make sure that (only) the correct scenario is touched after cloning
 def test_clone_edit(test_mp):
-    scen = test_mp.Scenario(*can_args)
+    scen = ixmp.Scenario(test_mp, *can_args)
     scen2 = scen.clone(keep_solution=False)
     scen2.check_out()
     scen2.change_scalar('f', 95.0, 'USD/km')
@@ -111,25 +111,25 @@ def test_clone_edit(test_mp):
 
 
 def test_idx_name(test_mp):
-    scen = test_mp.Scenario(*can_args)
+    scen = ixmp.Scenario(test_mp, *can_args)
     df = scen.idx_names('d')
     npt.assert_array_equal(df, ['i', 'j'])
 
 
 def test_var_marginal(test_mp):
-    scen = test_mp.Scenario(*can_args)
+    scen = ixmp.Scenario(test_mp, *can_args)
     df = scen.var('x', filters={'i': ['seattle']})
     npt.assert_array_almost_equal(df['mrg'], [0, 0, 0.036])
 
 
 def test_var_level(test_mp):
-    scen = test_mp.Scenario(*can_args)
+    scen = ixmp.Scenario(test_mp, *can_args)
     df = scen.var('x', filters={'i': ['seattle']})
     npt.assert_array_almost_equal(df['lvl'], [50, 300, 0])
 
 
 def test_var_general_str(test_mp):
-    scen = test_mp.Scenario(*can_args)
+    scen = ixmp.Scenario(test_mp, *can_args)
     df = scen.var('x', filters={'i': ['seattle']})
     npt.assert_array_equal(
         df['j'], ['new-york', 'chicago', 'topeka'])
@@ -145,7 +145,7 @@ def test_add_unit(test_mp):
 
 
 def test_par_filters_unit(test_mp):
-    scen = test_mp.Scenario(*can_args)
+    scen = ixmp.Scenario(test_mp, *can_args)
     df = scen.par('d', filters={'i': ['seattle']})
     obs = df.loc[0, 'unit']
     exp = 'km'

--- a/tests/test_run.py
+++ b/tests/test_run.py
@@ -25,7 +25,7 @@ def test_run_gams_api():
     annot = "Dantzig's transportation problem for illustration and testing"
 
     # initialize a new scenario instance
-    scen = mp.Scenario(model, scenario, version='new', annotation=annot)
+    scen = ixmp.Scenario(mp, model, scenario, version='new', annotation=annot)
 
     # define the sets of locations of canning plants and markets
     scen.init_set("i")

--- a/tutorial/transport/py_transport.ipynb
+++ b/tutorial/transport/py_transport.ipynb
@@ -86,7 +86,7 @@
     "\n",
     "# initialize a new ixmp.Scenario\n",
     "# the parameter version='new' indicates that this is a new scenario instamce\n",
-    "scen = mp.Scenario(model, scenario, version='new', annotation=annot)"
+    "scen = ix.Scenario(mp, model, scenario, version='new', annotation=annot)"
    ]
   },
   {

--- a/tutorial/transport/py_transport_scenario.ipynb
+++ b/tutorial/transport/py_transport_scenario.ipynb
@@ -91,7 +91,7 @@
    "outputs": [],
    "source": [
     "# load the default version scenario from the first tutorial\n",
-    "scen = mp.Scenario(model, scenario)"
+    "scen = ix.Scenario(mp, model, scenario)"
    ]
   },
   {


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [x] Tests Added (implicit, see comments)
- [x] Documentation Added
- [x] Description in RELEASE_NOTES.md Added

# Description of PR 

This PR changes the API/constructors from the current `mp.Scenario()` to the cleaner `ixmp.Scenario(mp, ...)`.

For the Scenario class, the existing constructor is deprecated but continues to work. For the TimeSeries (given that this class is not yet widely used), the existing constructor is removed.