### PR TITLE
adding warning for calling class ixmp.Scenario with `scheme=='MESSAGE'`

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#79](https://github.com/iiasa/ixmp/pull/79): Adding a deprecated-warning for `ixmp.Scenario` with `scheme=='MESSAGE'`
 - [#76](https://github.com/iiasa/ixmp/pull/76): Changing the API from `mp.Scenario(...)` to `ixmp.Scenario(mp, ...)`
 - [#73](https://github.com/iiasa/ixmp/pull/73): Adding a function `has_solution()`, rename kwargs to `..._solution`
 - [#64](https://github.com/iiasa/ixmp/pull/64): Support writing multiple sheets to Excel in utils.pd_write

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -428,7 +428,7 @@ class Scenario(TimeSeries):
                                               annotation)
         elif isinstance(version, int):
             self._jobj = mp._jobj.getScenario(model, scenario, version)
-        # constructor for `clone()` function
+        # constructor for `message_ix.Scenario.__init__` or `clone()` function
         elif isinstance(version, JClass('at.ac.iiasa.ixmp.objects.Scenario')):
             self._jobj = version
         else:

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -438,11 +438,10 @@ class Scenario(TimeSeries):
         self.model = model
         self.scenario = scenario
         self.version = self._jobj.getVersion()
-        self.scheme = self._jobj.getScheme()
-        if self.scheme == 'MESSAGE':
-            msg = ('Using the class `ixmp.Scenario` for MESSAGE-scheme '
-                   'scenarios is deprecated, please use `message_ix.Scenario`')
-            warnings.warn(msg)
+        self.scheme = scheme or self._jobj.getScheme()
+        if self.scheme == 'MESSAGE' and not hasattr(self, 'is_message_scheme'):
+            warnings.warn('Using `ixmp.Scenario` for MESSAGE-scheme scenarios '
+                          'is deprecated, please use `message_ix.Scenario`')
 
         self._cache = cache
         self._pycache = {}

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -438,6 +438,12 @@ class Scenario(TimeSeries):
         self.model = model
         self.scenario = scenario
         self.version = self._jobj.getVersion()
+        self.scheme = self._jobj.getScheme()
+        if self.scheme == 'MESSAGE':
+            msg = ('Using the class `ixmp.Scenario` for MESSAGE-scheme '
+                   'scenarios is deprecated, please use `message_ix.Scenario`')
+            warnings.warn(msg)
+
         self._cache = cache
         self._pycache = {}
 


### PR DESCRIPTION
# Please confirm that this PR has done the following:

- [ ] Tests Added - **No additional tests required**
- [ ] Documentation Added - **No additional documentation required**
- [x] Description in RELEASE_NOTES.md Added

# Description

This PR raises a deprecated-warning whenever a (generic) `ixmp.Scenario` is called that is defined as a MESSAGE-scheme scenario. This warning also works when loading existing scenarios from a database.

closes #77