### PR TITLE
Cleanup for generating index dimensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,7 @@
 
 # files generated during install
 build
+dist
 
 # credentials
 config/*.properties

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#110](https://github.com/iiasa/ixmp/pull/105): Generalize the internal functions to format index dimensions for mapping sets and parameters
 - [#105](https://github.com/iiasa/ixmp/pull/105): Replace [deprecated](http://pandas.pydata.org/pandas-docs/stable/indexing.html#ix-indexer-is-deprecated) pandas `.ix` indexer with `.iloc`.
 - [#103](https://github.com/iiasa/ixmp/pull/103): Specify dependencies in setup.py.
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1154,6 +1154,8 @@ def to_jlist(pylist, idx_names=None):
 
 def make_dims(sets, names):
     """Wrapper of `to_jlist()` to generate an index-name and index-set list"""
+    if isinstance(sets, set) or isinstance(names, set):
+        raise ValueError('index dimension must be string or ordered lists!')
     return to_jlist(sets), to_jlist(names if names is not None else sets)
 
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -14,7 +14,7 @@ import ixmp as ix
 from ixmp import model_settings
 from ixmp.default_path_constants import DEFAULT_LOCAL_DB_PATH
 from ixmp.default_paths import default_dbprops_file, find_dbprops
-from ixmp.utils import logger
+from ixmp.utils import logger, islistable
 
 # %% default settings for column headers
 
@@ -1141,11 +1141,8 @@ def to_jlist(pylist, idx_names=None):
 
     jList = java.LinkedList()
     if idx_names is None:
-        if type(pylist) is list:
+        if islistable(pylist):
             for key in pylist:
-                jList.add(str(key))
-        elif type(pylist) is set:
-            for key in list(pylist):
                 jList.add(str(key))
         else:
             jList.add(str(pylist))
@@ -1155,9 +1152,9 @@ def to_jlist(pylist, idx_names=None):
     return jList
 
 
-def make_dims(idx_sets, idx_names):
+def make_dims(sets, names):
     """Wrapper of `to_jlist()` to generate an index-name and index-set list"""
-    return to_jlist(idx_sets), to_jlist(idx_names or idx_sets)
+    return to_jlist(sets), to_jlist(names if names is not None else sets)
 
 
 def _get_ele_list(item, filters=None, has_value=False, has_level=False):

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -1,6 +1,6 @@
 import logging
-
-import numpy as np
+import collections
+import six
 import pandas as pd
 
 import ixmp as ix
@@ -17,6 +17,21 @@ def logger():
         _LOGGER = logging.getLogger()
         _LOGGER.setLevel('INFO')
     return _LOGGER
+
+
+def isstr(x):
+    """Returns True if x is a string"""
+    return isinstance(x, six.string_types)
+
+
+def isscalar(x):
+    """Returns True if x is a scalar"""
+    return not isinstance(x, collections.Iterable) or isstr(x)
+
+
+def islistable(x):
+    """Returns True if x is a list but not a string"""
+    return isinstance(x, collections.Iterable) and not isstr(x)
 
 
 def pd_read(f, *args, **kwargs):

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -3,7 +3,7 @@ import collections
 import six
 import pandas as pd
 
-import ixmp as ix
+import ixmp
 
 # globally accessible logger
 _LOGGER = None
@@ -67,18 +67,18 @@ def numcols(df):
 
 def import_timeseries(mp, data, model, scenario, version=None,
                       firstyear=None, lastyear=None):
-    if not isinstance(mp, ix.Platform):
+    if not isinstance(mp, ixmp.Platform):
         raise ValueError("{} is not a valid 'ixmp.Platform' instance".
                          format(mp))
 
     if version is not None:
         version = int(version)
-    scen = ix.Scenario(mp, model, scenario, version)
+    scen = ixmp.Scenario(mp, model, scenario, version)
 
-    df = ix.utils.pd_read(data)
+    df = ixmp.utils.pd_read(data)
     df = df.rename(columns={c: str(c).lower() for c in df.columns})
 
-    cols = ix.utils.numcols(df)
+    cols = ixmp.utils.numcols(df)
     years = [int(i) for i in cols]
     fyear = int(firstyear or min(years))
     lyear = int(lastyear or max(years))


### PR DESCRIPTION
This PR simplifies the auxiliary functions to generate index dimensions, now taking numpy arrays and other iterables as valid arguments. 

Creating index dimensions from a set rather than a list or other ordered iterable now raises an error message, because the relation between index sets and index names may not be defined correctly.