### PR TITLE
Support iterating with user-supplied callbacks

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#115](https://github.com/iiasa/ixmp/pull/115): Support iterating with user-supplied callbacks.
 - [#130](https://github.com/iiasa/ixmp/pull/130): Recognize `IXMP_DATA` environment variable for configuration and local databases.
 - [#129](https://github.com/iiasa/ixmp/pull/129), [#132](https://github.com/iiasa/ixmp/pull/132): Fully implement `Scenario.clone()` across platforms (databases).
 - [#128](https://github.com/iiasa/ixmp/pull/128): New module `ixmp.testing` for reuse of testing utilities.

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -270,9 +270,10 @@ class Platform(object):
     def add_region(self, region, hierarchy, parent='World'):
         """Define a region including a hierarchy level and a 'parent' region.
 
-        *Before adding a region, please use `regions()` and check whether the
-        region already exists with a different spelling.
-        If so, use `add_region_synonym()` instead.
+        .. tip::
+           On a :class:`Platform` backed by a shared database, a region may
+           already exist with a different spelling. Use :meth:`regions` first
+           to check, and consider calling :meth:`add_region_synonym` instead.
 
         Parameters
         ----------

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1318,6 +1318,8 @@ class Scenario(TimeSeries):
         outgdx = os.path.basename(outp)
 
         # Iterate until convergence
+        warn_none = True
+
         while True:
             # Write model data to file
             self.to_gdx(ipth, ingdx)
@@ -1338,7 +1340,17 @@ class Scenario(TimeSeries):
                     self.iteration = 0
                 self.iteration += 1
 
-                if callback(self):
+                # Invoke the callback
+                cb_result = callback(self)
+
+                if cb_result is None and warn_none:
+                    warnings.warn('solve(callback=...) argument returned None;'
+                                  ' will loop indefinitely unless True is'
+                                  ' returned.')
+                    # Don't repeat the warning
+                    warn_none = False
+
+                if cb_result:
                     # Callback indicates convergence is reached
                     break
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1332,7 +1332,8 @@ class Scenario(TimeSeries):
         if callback is not None and not callable(callback):
             raise ValueError('callback={!r} is not callable'.format(callback))
         elif callback is None:
-            def callback(*args, **kwargs):
+            # Make the callback a no-op
+            def callback(scenario, **kwargs):
                 return True
 
         warn_none = True

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1262,9 +1262,9 @@ class Scenario(TimeSeries):
         If the optional argument `callback` is given, then additional steps are
         performed:
 
-        4. Execute `callback` with the Scenario as an argument. The Scenario
-           has an attribute, `iteration`, that stores the number of the time
-           the model has been solved (#2).
+        4. Execute the `callback` with the Scenario as an argument. The
+           Scenario has an `iteration` attribute that stores the number of
+           times the underlying model has been solved (#2).
         5. If the `callback` returns :obj:`False` or similar, go to #1;
            otherwise exit.
 
@@ -1293,8 +1293,15 @@ class Scenario(TimeSeries):
             (only applies to MESSAGE runs)
         callback : callable, optional
             Method to execute arbitrary non-model code. Must accept a single
-            argument, the Scenario. Must return a :non:`False` value to
+            argument, the Scenario. Must return a non-:obj:`False` value to
             indicate convergence.
+
+        Warns
+        -----
+        UserWarning
+            If `callback` is given and returns :obj:`None`. This may indicate
+            that the user has forgotten a ``return`` statement, in which case
+            the iteration will continue indefinitely.
         """
         config = model_settings.model_config(model) \
             if model_settings.model_registered(model) \

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -333,5 +333,5 @@ def test_solve_callback(test_mp, test_data_path):
         # Model iterates automatically
         scen.solve(callback=change_distance, **solve_args)
 
-    # Solution reached after 4 iterations, i.e. for f[4 - 1] == 90.0
+    # Solution reached after 4 iterations, i.e. for d[4 - 1] == 2.5
     assert scen.iteration == 4

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -331,7 +331,7 @@ def test_solve_callback(test_mp, test_data_path):
                'indefinitely unless True is returned.')
     with pytest.warns(UserWarning, match=message):
         # Model iterates automatically
-        scen.solve(**solve_args, callback=change_distance)
+        scen.solve(callback=change_distance, **solve_args)
 
     # Solution reached after 4 iterations, i.e. for f[4 - 1] == 90.0
     assert scen.iteration == 4

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -293,7 +293,7 @@ def test_solve_callback(test_mp, test_data_path):
     # Store the expected value of the decision variable, x
     expected = scen.var('x')
 
-    # The reference distance between Seattle and New York is 2.5 [10³ miles]
+    # The reference distance between Seattle and New York is 2.5 [10^3 miles]
     d = [3.5, 2.0, 2.7, 2.5, 1.0]
 
     def set_d(scenario, value):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -321,11 +321,17 @@ def test_solve_callback(test_mp, test_data_path):
         # 'iteration' variable stored on the Scenario object
         set_d(scenario, d[scenario.iteration])
 
-        # Trigger another solution of the model
-        return False
+        # commented: see below
+        # # Trigger another solution of the model
+        # return False
 
-    # Model iterates automatically
-    # TODO capturelog
-    scen.solve(**solve_args, callback=change_distance)
+    # Warning is raised because 'return False' is commented above, meaning
+    # user may have forgotten any return statement in the callback
+    message = (r'solve\(callback=...\) argument returned None; will loop '
+               'indefinitely unless True is returned.')
+    with pytest.warns(UserWarning, match=message):
+        # Model iterates automatically
+        scen.solve(**solve_args, callback=change_distance)
+
     # Solution reached after 4 iterations, i.e. for f[4 - 1] == 90.0
     assert scen.iteration == 4


### PR DESCRIPTION
This PR adds a feature to `Scenario.solve()` iteratively, with some user-supplied callback.

This is to generalize and support model variants like MESSAGE-Access and MESSAGE-Transport.

**PR checklist:**
- [x] Tests added
- [x] Documentation added
- [x] Description in RELEASE_NOTES.md added