### PR TITLE
Add PEP 263 mark in core.py for Unicode characters in docstrings

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1,3 +1,4 @@
+# coding=utf-8
 import os
 import sys
 import warnings


### PR DESCRIPTION
For message_ix docs build, e.g. https://travis-ci.org/iiasa/message_ix/jobs/490049103

```
$ make html

sphinx-build -b html -d build/doctrees   source build/html
Running Sphinx v1.8.4

Configuration error:
There is a syntax error in your configuration file: Non-ASCII character '\xe2' in file /home/travis/build/iiasa/message_ix/doc/src/ixmp/ixmp/core.py on line 181, but no encoding declared; see http://python.org/dev/peps/pep-0263/ for details (core.py, line 180)
make: *** [html] Error 2
travis_time:end:1d3f13b4:start=1549547140064976615,finish=1549547140365295087,duration=300318472

The command "make html" exited with 2.

Done. Your build exited with 1.
```