### PR TITLE
Return abspath from find_dbprops()

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#123](https://github.com/iiasa/ixmp/pull/123): Return absolute path from `find_dbprops()`.
 - [#118](https://github.com/iiasa/ixmp/pull/118): Switch to RTD Sphinx theme.
 - [#116](https://github.com/iiasa/ixmp/pull/116): Bugfix and extend functionality for working with IAMC-style timeseries data
 - [#111](https://github.com/iiasa/ixmp/pull/111): Add functions to check if a Scenario has an item (set, par, var, equ)

--- a/ixmp/config.py
+++ b/ixmp/config.py
@@ -7,6 +7,7 @@ from ixmp.utils import logger
 
 def get(key):
     """Return key from configuration file"""
+    # TODO return sensible defaults even if the user has not given ixmp-config
     if not os.path.exists(CONFIG_PATH):
         raise RuntimeError(
             'ixmp has not been configured, do so with `$ ixmp-config -h`')

--- a/ixmp/default_paths.py
+++ b/ixmp/default_paths.py
@@ -1,10 +1,12 @@
 import os
-import sys
 
 from ixmp import config
 
 
-if sys.version[0] == 2:
+try:
+    FileNotFoundError
+except NameError:
+    # Python 2.7
     FileNotFoundError = OSError
 
 

--- a/ixmp/default_paths.py
+++ b/ixmp/default_paths.py
@@ -1,6 +1,11 @@
 import os
+import sys
 
 from ixmp import config
+
+
+if sys.version[0] == 2:
+    FileNotFoundError = OSError
 
 
 def default_dbprops_file():

--- a/ixmp/default_paths.py
+++ b/ixmp/default_paths.py
@@ -12,22 +12,32 @@ def db_config_path():
 
 
 def find_dbprops(fname):
-    """Search directories for file fname. First start in local dir (`.`), then look
-    in ixmp default locations.
+    """Return the absolute path to a database properties file.
+
+    Searches for a file named *fname*, first in the current working directory
+    (`.`), then in the ixmp default location.
 
     Parameters
     ----------
-    fname : string
-        filename
-    """
-    # look local first
-    if os.path.isfile(fname):
-        return fname
+    fname : str
+        Name of a database properties file to locate.
 
-    # otherwise look in default directory
-    config_path = db_config_path()
-    _fname = os.path.join(config_path, fname)
-    if not os.path.isfile(_fname):
-        raise IOError('Could not find {} either locally or in {}'.format(
-            fname, config_path))
-    return _fname
+    Returns
+    -------
+    str
+        Absolute path to *fname*.
+
+    Raises
+    ------
+    FileNotFoundError
+        *fname* is not found in any of the search paths.
+    """
+    # Look in the current directory first, then the configured directory
+    dirs = ['', db_config_path()]
+
+    for dir in dirs:
+        path = os.path.abspath(os.path.join(dir, fname))
+        if os.path.isfile(path):
+            return path
+
+    raise FileNotFoundError('Could not find {} in {!r}'.format(fname, dirs))

--- a/ixmp/default_paths.py
+++ b/ixmp/default_paths.py
@@ -40,8 +40,8 @@ def find_dbprops(fname):
     # Look in the current directory first, then the configured directory
     dirs = ['', db_config_path()]
 
-    for dir in dirs:
-        path = os.path.abspath(os.path.join(dir, fname))
+    for directory in dirs:
+        path = os.path.abspath(os.path.join(directory, fname))
         if os.path.isfile(path):
             return path
 

--- a/ixmp/default_paths.py
+++ b/ixmp/default_paths.py
@@ -38,7 +38,14 @@ def find_dbprops(fname):
         *fname* is not found in any of the search paths.
     """
     # Look in the current directory first, then the configured directory
-    dirs = ['', db_config_path()]
+    dirs = ['']
+
+    try:
+        # Catch exception raised by db_config_path() if no config file exists.
+        # See TODO in config.get().
+        dirs.append(db_config_path())
+    except RuntimeError:
+        pass
 
     for directory in dirs:
         path = os.path.abspath(os.path.join(directory, fname))

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,13 +1,15 @@
 import os
 import os.path
-import sys
 
 import pytest
 
 from ixmp.default_paths import find_dbprops
 
 
-if sys.version[0] == 2:
+try:
+    FileNotFoundError
+except NameError:
+    # Python 2.7
     FileNotFoundError = OSError
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,9 +1,14 @@
 import os
 import os.path
+import sys
 
 import pytest
 
 from ixmp.default_paths import find_dbprops
+
+
+if sys.version[0] == 2:
+    FileNotFoundError = OSError
 
 
 def test_find_dbprops():

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,21 @@
+import os
+import os.path
+
+import pytest
+
+from ixmp.default_paths import find_dbprops
+
+
+def test_find_dbprops():
+    # Returns an absolute path
+    with open('foo.properties', 'w') as f:
+        f.write('bar')
+
+    expected_abs_path = os.path.join(os.getcwd(), 'foo.properties')
+    assert find_dbprops('foo.properties') == expected_abs_path
+
+    os.remove('foo.properties')
+
+    # Exception raised on missing file
+    with pytest.raises(FileNotFoundError):
+        find_dbprops('foo.properties')


### PR DESCRIPTION
When trying to run code like:
```
import ixmp
p = ixmp.Platform('default.properties')
```
…to test #120 / #109, I was encountering exceptions like:
```
INFO:root:launching ixmp.Platform using config file at'default.properties'                                                     
Traceback (most recent call last):                                                                                             
  File "./run", line 20, in <module>                                                                                           
    message_ix.tools.transport.main()                                                                                          
  File "/usr/lib/python3/dist-packages/click/core.py", line 759, in __call__                                                   
    return self.main(*args, **kwargs)                                                                                          
  File "/usr/lib/python3/dist-packages/click/core.py", line 714, in main                                                       
    rv = self.invoke(ctx)                                                                                                      
  File "/usr/lib/python3/dist-packages/click/core.py", line 951, in invoke                                                     
    return ctx.invoke(self.callback, **ctx.params)                                                                             
  File "/usr/lib/python3/dist-packages/click/core.py", line 552, in invoke                                                     
    return callback(*args, **kwargs)                                                                                           
  File "message_ix/tools/transport/__init__.py", line 65, in main                                                              
    mp = get_platform('IIASA')                                                                                                 
  File "message_ix/tools/transport/__init__.py", line 18, in get_platform                                                      
    return ixmp.Platform(base_dbprops_fn)                                                                                      
  File "/home/khaeru/vc/iiasa/ixmp/ixmp/core.py", line 105, in __init__                                                        
    self._jobj = java.ixmp.Platform("Python", dbprops)                                                                         
  File "/usr/lib/python3/dist-packages/jpype/_jclass.py", line 111, in _javaInit                                              
    *args)                                                                                                                    
jpype._jexception.IllegalStateExceptionPyRaisable: java.lang.IllegalStateException: Can't bind method user  
```

@zikolach helped discover this was because the Java code expects an absolute path, and `find_dbprops()` did not always return one.

**PR checklist:**
- [x] Tests added
- [x] Documentation added
- [x] Description in RELEASE_NOTES.md added