### PR TITLE
Improve reporting (phase 2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ rixmp/source/.Rhistory
 .env
 
 # pytest
+.coverage
 .pytest_cache/
 
 # idea

--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@
 #*
 *#
 *.Rproj
+*.Rcheck
 
 # Apple file system
 .DS_Store
@@ -43,7 +44,8 @@ tests/testdb/ixmptest.properties
 tests/testdb/ixmptest.lck
 
 # rixmp build folder and rhistory
-rixmp/rixmp*.zip
+r*ixmp_*.tar.gz
+r*ixmp_*.zip
 rixmp/source/inst/docum/*.html
 rixmp/source/.Rhistory
 !rixmp/source/*.Rproj

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -3,7 +3,7 @@ linters:
     python: 3
     max-line-length: 79
     fixer: false
-    ignore: I002
+    ignore: 'W503,I002'
     # stickler doesn't support 'exclude' for flake8 properly, so we disable it
     # below with files.ignore:
     # https://github.com/markstory/lint-review/issues/184

--- a/.stickler.yml
+++ b/.stickler.yml
@@ -1,5 +1,6 @@
 linters:
   flake8:
+    python: 3
     max-line-length: 79
     fixer: false
     ignore: I002

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,8 @@ matrix:
     include:
         - os: linux
           env: PYENV=py37
-        - os: linux
-          env: PYENV=py27
         - os: osx
           env: PYENV=py37
-        - os: osx
-          env: PYENV=py27
 # turn these on once travis support gets a little better, see pyam for example
 #        - os: windows
 #          env: PYENV=py37

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,14 @@ matrix:
 #        - os: windows
 #          env: PYENV=py27
 
+addons:
+  apt:
+    packages:
+    - graphviz
+  homebrew:
+    packages:
+    - graphviz
+
 before_install:
   - source ./ci/env.sh
   - bash ./ci/travis-install.sh

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,16 +3,13 @@
 
 environment:
   matrix:
-      - PYTHON_VERSION: "2.7"	
-        MINICONDA: "C:\\Miniconda-x64"
-        PYTHON_ARCH: "64"
       - PYTHON_VERSION: "3.6"
         MINICONDA: "C:\\Miniconda36-x64"
         PYTHON_ARCH: "64"
 
 init:
   - "ECHO %PYTHON_VERSION% %MINICONDA%"
-  
+
 install:
   # these correspond to folder naming of miniconda installs on appveyor.  See
   # https://www.appveyor.com/docs/installed-software#python
@@ -28,7 +25,7 @@ install:
   - "SET PATH=%cd%\\gams;%PATH%"
   - conda install --yes -c conda-forge ixmp
   - conda remove --force --yes ixmp
-  
+
   - python setup.py install
 
 build: false

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,7 +23,7 @@ install:
   - ps: Start-FileDownload 'https://d37drm4t2jghv5.cloudfront.net/distributions/25.1.1/windows/windows_x64_64.exe'
   - windows_x64_64.exe /SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS
   - "SET PATH=%cd%\\gams;%PATH%"
-  - conda install --yes -c conda-forge graphviz
+  - choco install graphviz
   - conda install --yes -c conda-forge ixmp
   - conda remove --force --yes ixmp
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,6 +23,7 @@ install:
   - ps: Start-FileDownload 'https://d37drm4t2jghv5.cloudfront.net/distributions/25.1.1/windows/windows_x64_64.exe'
   - windows_x64_64.exe /SP- /VERYSILENT /NORESTART /DIR=.\gams /NOICONS
   - "SET PATH=%cd%\\gams;%PATH%"
+  - conda install --yes -c conda-forge graphviz
   - conda install --yes -c conda-forge ixmp
   - conda remove --force --yes ixmp
 

--- a/doc/source/api/python_reporting.rst
+++ b/doc/source/api/python_reporting.rst
@@ -1,0 +1,120 @@
+.. currentmodule:: ixmp.reporting
+
+Reporting
+=========
+
+.. autoclass:: ixmp.reporting.Reporter
+   :members:
+   :exclude-members: graph, add
+
+   A Reporter is used to postprocess data from from one or more
+   :class:`ixmp.Scenario` objects. The :meth:`get` method can be used to:
+
+   - Generate an entire **report** composed of multiple quantities. A report
+     may:
+
+       - Read in non-model or exogenous data,
+       - Trigger output to files(s) or a database, or have other external
+         side effects.
+
+   - Retrieve individual **quantities**. A quantity has zero or more
+     dimensions and optional units.
+
+   Every report and quantity (including the results of intermediate steps) is
+   identified by a :class:`utils.Key`; all the keys in a Reporter can be
+   listed with :meth:`keys`.
+
+   Reporter uses a :doc:`graph <graphs>` data structure to keep track of
+   *computations*, the atomic steps in postprocessing: for example, a single
+   calculation that multiplies two quantities to create a third. The graph
+   allows :meth:`get` to perform *only* the requested computations. Advanced
+   users may manipulate the graph directly; but common reporting tasks can be
+   handled by using Reporter methods
+
+   .. autoattribute:: graph
+
+   .. automethod:: add
+
+      :meth:`add` may be used to:
+
+      - Provide an alias from one *key* to another:
+
+        >>> r.add('aliased name', 'original name')
+
+      - Define an arbitrarily complex computation in a Python function that
+        operates directly on the :class:`ixmp.Scenario`:
+
+        >>> def my_report(scenario):
+        >>>     # many lines of code
+        >>>     return 'foo'
+        >>> r.add('my report', (my_report, 'scenario'))
+        >>> r.finalize(scenario)
+        >>> r.get('my report')
+        foo
+
+      .. note::
+         Use care when adding literal :class:`str` values (2); these may
+         conflict with keys that identify the results of other
+         computations.
+
+
+Computations
+------------
+
+.. automodule:: ixmp.reporting.computations
+   :members:
+
+
+
+   Calculations:
+
+   .. autosummary::
+      aggregate
+      disaggregate_shares
+      product
+      ratio
+
+   Input and output:
+
+   .. autosummary::
+      load_file
+      write_report
+
+   Conversion:
+
+   .. autosummary::
+      make_dataframe
+
+
+Utilities
+---------
+
+.. autoclass:: ixmp.reporting.utils.Key
+   :members:
+
+   Quantities in a :class:`Scenario` can be indexed by one or more dimensions.
+   For example, a parameter with three dimensions can be initialized with:
+
+   >>> scenario.init_par('foo', ['a', 'b', 'c'], ['apple', 'bird', 'car'])
+
+   Computations for this scenario might use the quantity ``foo`` in different
+   ways:
+
+   1. in its full resolution, i.e. indexed by a, b, and c;
+   2. aggregated (e.g. summed) over any one dimension, e.g. aggregated over c
+      and thus indexed by a and b;
+   3. aggregated over any two dimensions; etc.
+
+   A Key for (1) will hash, display, and evaluate as equal to ``'foo:a-b-c'``.
+   A Key for (2) corresponds to ``'foo:a-b'``, and so forth.
+
+   Keys may be generated concisely by defining a convenience method:
+
+   >>> def foo(dims):
+   >>>     return Key('foo', dims.split(''))
+   >>> foo('a b')
+   foo:a-b
+
+.. automodule:: ixmp.reporting.utils
+   :members:
+   :exclude-members: Key

--- a/doc/source/api/python_reporting.rst
+++ b/doc/source/api/python_reporting.rst
@@ -3,6 +3,8 @@
 Reporting
 =========
 
+.. automethod:: ixmp.reporting.configure
+
 .. autoclass:: ixmp.reporting.Reporter
    :members:
    :exclude-members: graph, add
@@ -29,7 +31,22 @@ Reporting
    calculation that multiplies two quantities to create a third. The graph
    allows :meth:`get` to perform *only* the requested computations. Advanced
    users may manipulate the graph directly; but common reporting tasks can be
-   handled by using Reporter methods
+   handled by using Reporter methods:
+
+   .. autosummary::
+      add
+      add_file
+      aggregate
+      apply
+      configure
+      describe
+      disaggregate
+      finalize
+      full_key
+      get
+      read_config
+      visualize
+      write
 
    .. autoattribute:: graph
 
@@ -64,8 +81,6 @@ Computations
 .. automodule:: ixmp.reporting.computations
    :members:
 
-
-
    Calculations:
 
    .. autosummary::
@@ -73,6 +88,7 @@ Computations
       disaggregate_shares
       product
       ratio
+      sum
 
    Input and output:
 
@@ -117,4 +133,4 @@ Utilities
 
 .. automodule:: ixmp.reporting.utils
    :members:
-   :exclude-members: Key
+   :exclude-members: Key, combo_partition

--- a/doc/source/api/python_reporting.rst
+++ b/doc/source/api/python_reporting.rst
@@ -3,6 +3,12 @@
 Reporting
 =========
 
+.. warning::
+
+   :mod:`ixmp.reporting` is **experimental** in ixmp 0.2. The API and
+   functionality may change without advance notice or a deprecation period in
+   subsequent releases.
+
 .. automethod:: ixmp.reporting.configure
 
 .. autoclass:: ixmp.reporting.Reporter
@@ -12,22 +18,24 @@ Reporting
    A Reporter is used to postprocess data from from one or more
    :class:`ixmp.Scenario` objects. The :meth:`get` method can be used to:
 
+   - Retrieve individual **quantities**. A quantity has zero or more
+     dimensions and optional units. Quantities include the ‘parameters’,
+     ‘variables’, ‘equations’, and ‘scalars’ available in an
+     :class:`ixmp.Scenario`.
+
    - Generate an entire **report** composed of multiple quantities. A report
      may:
 
        - Read in non-model or exogenous data,
-       - Trigger output to files(s) or a database, or have other external
-         side effects.
-
-   - Retrieve individual **quantities**. A quantity has zero or more
-     dimensions and optional units.
+       - Trigger output to files(s) or a database, or
+       - Execute user-defined methods.
 
    Every report and quantity (including the results of intermediate steps) is
    identified by a :class:`utils.Key`; all the keys in a Reporter can be
    listed with :meth:`keys`.
 
    Reporter uses a :doc:`graph <graphs>` data structure to keep track of
-   *computations*, the atomic steps in postprocessing: for example, a single
+   **computations**, the atomic steps in postprocessing: for example, a single
    calculation that multiplies two quantities to create a third. The graph
    allows :meth:`get` to perform *only* the requested computations. Advanced
    users may manipulate the graph directly; but common reporting tasks can be

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -306,6 +306,7 @@ intersphinx_mapping = {
     'dask': ('http://docs.dask.org/en/stable/', None),
     'jpype': ('https://jpype.readthedocs.io/en/latest', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'pint': ('https://pint.readthedocs.io/en/stable/', None),
     'xarray': ('https://xarray.pydata.org/en/stable/', None),
 }
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -303,8 +303,10 @@ texinfo_documents = [
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
     'python': ('https://docs.python.org/', None),
+    'dask': ('http://docs.dask.org/en/stable/', None),
     'jpype': ('https://jpype.readthedocs.io/en/latest', None),
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
+    'xarray': ('https://xarray.pydata.org/en/stable/', None),
 }
 
 

--- a/doc/source/scientific_programming_api.rst
+++ b/doc/source/scientific_programming_api.rst
@@ -11,7 +11,8 @@ Python API
    :maxdepth: 2
 
    api/python_core
- 
+   api/python_reporting
+
 
 R API
 -----
@@ -24,7 +25,7 @@ Two alternative options are available:
 
    api/r_core
    api/r_retixmp
-   
+
 
 
 The Java interface

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -1,4 +1,5 @@
 import argparse
+import sys
 
 import ixmp
 
@@ -10,7 +11,7 @@ def config():
                       'configuration files.')
     parser.add_argument('--db_config_path', help=db_config_path, default=None)
     default_dbprops_file = ('Set default properties file for database '
-                            ' connection.')
+                            'connection.')
     parser.add_argument('--default_dbprops_file',
                         help=default_dbprops_file, default=None)
     args = parser.parse_args()
@@ -47,3 +48,44 @@ def import_timeseries():
     ixmp.utils.import_timeseries(mp, args.data, args.model, args.scenario,
                                  args.version, args.firstyear, args.lastyear)
     mp.close_db()
+
+
+def main():
+    """Command interface, e.g. $ ixmp COMMAND """
+    # Only supported command
+    assert sys.argv[1] == 'report'
+    del sys.argv[1]
+    report()
+
+
+def report():
+    from ixmp.reporting import Reporter, parse_reporting_args
+
+    # Parse reporting-related arguments
+    r_config, remaining = parse_reporting_args(sys.argv)
+    r_config = vars(r_config)
+
+    # Parse non-reporting arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--dbprops', help='database properties file')
+    parser.add_argument('--model', help='model name')
+    parser.add_argument('--scenario', help='scenario name')
+    parser.add_argument('--version', help='version', type=str, default=None)
+    args = parser.parse_args(remaining[1:])
+
+    # Load the indicated scenario
+    mp = ixmp.Platform(args.dbprops)
+    scen = ixmp.Scenario(mp, args.model, args.scenario, version=args.version)
+
+    # Instantiate the Reporter with the given scenario
+    r = Reporter.from_scenario(scen)
+
+    # Read the configuration file, if any
+    if 'config' in r_config:
+        r.read_config(r_config.pop('config'))
+
+    # Process remaining configuration from command-line arguments
+    r.configure(**r_config)
+
+    # Print the default target
+    print(r.get())

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -1,5 +1,4 @@
 import argparse
-import sys
 
 import click
 import ixmp

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -10,7 +10,7 @@ def config():
     db_config_path = ('Set default directory for database connection and '
                       'configuration files.')
     parser.add_argument('--db_config_path', help=db_config_path, default=None)
-    default_dbprops_file = ('Set default properties file for database'
+    default_dbprops_file = ('Set default properties file for database '
                             ' connection.')
     parser.add_argument('--default_dbprops_file',
                         help=default_dbprops_file, default=None)

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -10,8 +10,8 @@ def config():
     db_config_path = ('Set default directory for database connection and '
                       'configuration files.')
     parser.add_argument('--db_config_path', help=db_config_path, default=None)
-    default_dbprops_file = ('Set default properties file for database '
-                            'connection.')
+    default_dbprops_file = ('Set default properties file for database'
+                            ' connection.')
     parser.add_argument('--default_dbprops_file',
                         help=default_dbprops_file, default=None)
     args = parser.parse_args()

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -65,6 +65,7 @@ class Reporter(object):
 
     A Reporter is used to postprocess data from from one or more
     :class:`ixmp.Scenario` objects. :meth:`get` can be used to:
+
     - Generate an entire *report* composed of multiple quantities. Generating a
       report may trigger output to file(s) or a database.
     - Retrieve individual quantities from a Scenario.
@@ -87,6 +88,7 @@ class Reporter(object):
         """Create a Reporter by introspecting *scenario*.
 
         The reporter will contain:
+
         - Every parameter in the *scenario* and all possible aggregations
           across different dimensions.
         """
@@ -124,6 +126,7 @@ class Reporter(object):
         """Add *computation* to the Reporter under *key*.
 
         :meth:`add` may be used to:
+
         - Provide an alias from one *key* to another:
 
           >>> r.add('aliased name', 'original name')
@@ -143,6 +146,7 @@ class Reporter(object):
             A string, Key, or other value identifying the output of *task*.
         computation: object
             One of:
+
             1. any existing *key* in the Reporter.
             2. any other literal value or constant.
             3. a task, i.e. a tuple with a callable followed by one or more
@@ -163,7 +167,12 @@ class Reporter(object):
         return dask_get(self.graph, key)
 
     def finalize(self, scenario):
-        """Prepare the Reporter to act on *scenario*."""
+        """Prepare the Reporter to act on *scenario*.
+
+        The :class:`Scenario <message_ix.Scenario>` object *scenario* is
+        associated with the key ``'scenario'``. All subsequent processing will
+        act on data from this *scenario*.
+        """
         self.graph['scenario'] = scenario
 
     # ixmp data model manipulations
@@ -206,8 +215,8 @@ class Reporter(object):
         """Add exogenous quantities from *path*.
 
         A file at a path like '/path/to/foo.ext' is added at the key
-        'file:foo.ext'. Shorthand for
-        :meth:`ixmp.reporting.computations.load_file`.
+        ``'file:foo.ext'``. See
+        :meth:`load_file <ixmp.reporting.computations.load_file>`.
         """
         self.add('file:{}'.format(path.name), (partial(load_file, path),),
                  strict=True)

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -260,6 +260,9 @@ class Reporter(object):
         """
         return self._index[name]
 
+    def __contains__(self, name):
+        return name in self.graph
+
     def finalize(self, scenario):
         """Prepare the Reporter to act on *scenario*.
 

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -334,6 +334,7 @@ class Reporter(object):
         """
         key = key if key else 'file:{}'.format(path.name)
         self.add(key, (partial(load_file, path),), strict=True)
+        return key
 
     def describe(self, key=None):
         """Return a string describing the computations that produce *key*.

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -17,7 +17,10 @@
 
 from functools import partial
 from itertools import chain, repeat
-from pathlib import Path
+try:
+    from pathlib import Path
+except ImportError:
+    from pathlib2 import Path
 from warnings import warn
 
 from dask.threaded import get as dask_get

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -273,6 +273,41 @@ class Reporter(object):
         self.graph['scenario'] = scenario
 
     # ixmp data model manipulations
+    def add_product(self, name, *quantities, sums=True):
+        """Add a computation that takes the product of *quantities*.
+
+        Parameters
+        ----------
+        name : str
+            Name of the new quantity.
+        sums : bool, optional
+            If :obj:`True`, all partial sums of the new quantity are also
+            added.
+
+        Returns
+        -------
+        Key
+            The full key of the new quantity.
+        """
+        # Fetch the full key for each quantity
+        try:
+            base_keys = [self.full_key(q) for q in quantities]
+        except KeyError:
+            return None
+
+        # Compute a key for the result
+        key = Key.product(name, *base_keys)
+
+        # Add the basic product to the graph and index
+        self.add(key, tuple([computations.product] + base_keys))
+        self._index[name] = key
+
+        if sums:
+            # Add partial sums of the product
+            self.apply(key.iter_sums)
+
+        return key
+
     def aggregate(self, qty, tag, dims_or_groups, weights=None, keep=True):
         """Add a computation that aggregates *qty*.
 

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -20,75 +20,14 @@ from functools import partial
 from itertools import chain, repeat
 
 from dask.threaded import get as dask_get
-import pandas as pd
-import xarray as xr
 
-from .utils import Key
+from .utils import quantity_as_xr, Key
 from . import computations
 from .computations import (   # noqa:F401
     disaggregate_shares,
     load_file,
     write_report,
 )
-
-
-def quantity_as_xr(scenario, name, kind='par'):
-    """Retrieve quantity *name* from *scenario* as an xr.Dataset.
-
-    Parameters
-    ----------
-    *kind* : 'par' or 'equ'
-        Type of quantity to be retrieved.
-
-    Returns
-    -------
-    dict of :class:'xarray.DataArray'
-        Dictionary keys are 'level' (kind='par') or ('lvl', 'mrg')
-        (kind='equ').
-    """
-    # NB this could be moved to ixmp.Scenario
-    data = getattr(scenario, kind)(name)
-
-    if isinstance(data, dict):
-        # ixmp/GAMS scalar is not returned as pd.DataFrame
-        data = pd.DataFrame.from_records([data])
-
-    # Remove the unit from the DataFrame
-    try:
-        unit = pd.unique(data.pop('unit'))
-        assert len(unit) == 1
-        attrs = {'unit': unit[0]}
-    except KeyError:
-        # 'equ' are returned without units
-        attrs = {}
-
-    # List of the dimensions
-    dims = data.columns.tolist()
-
-    # Columns containing values
-    value_columns = {
-        'par': ['value'],
-        'equ': ['lvl', 'mrg'],
-        'var': ['lvl', 'mrg'],
-        }[kind]
-
-    [dims.remove(col) for col in value_columns]
-
-    # Set index if 1 or more dimensions
-    if len(dims):
-        data.set_index(dims, inplace=True)
-
-    # Convert to a series, then Dataset
-    ds = xr.Dataset.from_dataframe(data)
-    try:
-        # Remove length-1 dimensions for scalars
-        ds = ds.squeeze('index', drop=True)
-    except KeyError:
-        pass
-
-    # Assign attributes (units) and name to each xr.DataArray individually
-    return {col: ds[col].assign_attrs(attrs).rename(name)
-            for col in value_columns}
 
 
 class Reporter(object):

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -423,14 +423,3 @@ class Reporter(object):
         """Write the report *key* to the file *path*."""
         # Call the method directly without adding it to the graph
         write_report(self.get(key), path)
-
-
-def parse_reporting_args(args):
-    """Parse command-line arguments."""
-    import argparse
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument('--config', help='reporting configuration file')
-    parser.add_argument('--default', help='default reporting key')
-
-    return parser.parse_known_args(args)

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -367,7 +367,6 @@ class Reporter(object):
         # Combine items
         return ('\n' if depth > 0 else '\n\n').join(result)
 
-
     def visualize(self, filename, **kwargs):
         """Generate an image describing the reporting structure.
 

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -110,7 +110,12 @@ class Reporter(object):
 
         # Add sets
         for name in scenario.set_list():
-            elements = scenario.set(name).tolist()
+            elements = scenario.set(name)
+            try:
+                elements = elements.tolist()
+            except AttributeError:
+                # pd.DataFrame for a multidimensional set; store as-is
+                pass
             rep.add(name, elements)
 
         return rep

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -13,7 +13,6 @@
 #   - an optional attribute 'unit' describing the units of the object.
 #
 # TODO meet the requirements:
-# A8iii. Read CLI arguments for subset reporting.
 # A11. Callable through `retixmp`.
 
 from functools import partial
@@ -50,11 +49,12 @@ class Reporter(object):
     #: The default reporting key.
     default_key = None
 
-    def __init__(self):
+    def __init__(self, **kwargs):
         self.graph = {}
+        self.configure(**kwargs)
 
     @classmethod
-    def from_scenario(cls, scenario):
+    def from_scenario(cls, scenario, **kwargs):
         """Create a Reporter by introspecting *scenario*.
 
         Returns
@@ -68,7 +68,7 @@ class Reporter(object):
           - Each set in the *scenario*.
         """
         # New Reporter
-        rep = cls()
+        rep = cls(**kwargs)
 
         all_keys = []
 
@@ -119,6 +119,7 @@ class Reporter(object):
 
         See :meth:`configure`.
         """
+        path = Path(path)
         with open(path, 'r') as f:
             self.configure(config_dir=path.parent, **yaml.load(f))
 
@@ -306,3 +307,14 @@ class Reporter(object):
         """Write the report *key* to the file *path*."""
         # Call the method directly without adding it to the graph
         write_report(self.get(key), path)
+
+
+def parse_reporting_args(args):
+    """Parse command-line arguments."""
+    import argparse
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--config', help='reporting configuration file')
+    parser.add_argument('--default', help='default reporting key')
+
+    return parser.parse_known_args(args)

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -66,7 +66,7 @@ class Reporter(object):
 
         Returns
         -------
-        Reporter
+        :class:`Reporter <ixmp.reporting.Reporter>`
           …containing:
 
           - A 'scenario' key referring to the *scenario* object.

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -13,7 +13,6 @@
 #
 # TODO meet the requirements:
 # A8iii. Read CLI arguments for subset reporting.
-# A9. Handle units for quantities.
 # A11. Callable through `retixmp`.
 
 from functools import partial
@@ -45,13 +44,11 @@ class Reporter(object):
 
     """
     # TODO meet the requirements:
-    # A2. Use exogenous data: given programmatically; from file.
     # A3i. Weighted sums.
     # A3iii. Interpolation.
     # A6. Duplicate or clone existing operations for multiple other sets of
     #     inputs or outputs. [Sub-graph manipulations.]
     # A7. Renaming of outputs.
-    # A10. Provide description of how quantities are computed.
 
     def __init__(self):
         self.graph = {}
@@ -118,12 +115,27 @@ class Reporter(object):
         return rep
 
     def read_config(self, path):
-        """Configure the Reporter with information from a file at *path*."""
+        """Configure the Reporter with information from a YAML file at *path*.
+
+        See :meth:`configure`.
+        """
         with open(path, 'r') as f:
             self.configure(**yaml.load(f), config_dir=path.parent)
 
     def configure(self, **config):
-        """Configure the reporter."""
+        """Configure the Reporter.
+
+        Valid configuration keys include:
+
+        - *default*: the default reporting target.
+        - *files*: a :py:`dict` mapping keys to file paths.
+        - *alias: a :py:`dict` mapping aliases to original keys.
+
+        Warns
+        -----
+        UserWarning
+            If *config* contains unrecognized keys.
+        """
         config_dir = config.pop('config_dir', '.')
 
         # Read sections
@@ -250,6 +262,10 @@ class Reporter(object):
         """
         key = key if key else 'file:{}'.format(path.name)
         self.add(key, (partial(load_file, path),), strict=True)
+
+    def visualize(self, *args, **kwargs):
+        # TODO Provide description of how quantities are computed (req. A10)
+        raise NotImplementedError
 
     def write(self, key, path):
         """Write the report *key* to the file *path*."""

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -16,8 +16,8 @@
 # A9. Handle units for quantities.
 # A11. Callable through `retixmp`.
 
-from itertools import chain, repeat
 from functools import partial
+from itertools import chain, repeat
 
 from dask.threaded import get as dask_get
 import pandas as pd
@@ -126,13 +126,14 @@ class Reporter(object):
           - A 'scenario' key referring to the *scenario* object.
           - Each parameter, equation, and variable in the *scenario*.
           - All possible aggregations across different sets of dimensions.
+          - Each set in the *scenario*.
         """
         # New Reporter
         rep = cls()
 
         all_keys = []
 
-        # Iterate over parameters and equations together
+        # Add parameters, equations, and variables to the graph
         quantities = chain(
             zip(scenario.par_list(), repeat('par')),
             zip(scenario.equ_list(), repeat('equ')),
@@ -164,10 +165,13 @@ class Reporter(object):
 
                 # (No aggregates for marginals)
 
-        # TODO add sets
-
-        # Add a target which simply collects all raw data.
+        # Add a key which simply collects all quantities
         rep.add('all', all_keys)
+
+        # Add sets
+        for name in scenario.set_list():
+            elements = scenario.set(name).tolist()
+            rep.add(name, elements)
 
         return rep
 

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -33,7 +33,7 @@ from dask.optimization import cull
 
 import yaml
 
-from .utils import Key, keys_for_quantity, replace_units, ureg
+from .utils import Key, keys_for_quantity, rename_dims, replace_units, ureg
 from . import computations
 from .describe import describe_recursive
 
@@ -453,6 +453,9 @@ def configure(path=None, **config):
     # Add replacements
     for old, new in units.get('replace', {}).items():
         replace_units[old] = new
+
+    # Dimensions to be renamed
+    rename_dims.update(config.get('rename_dims', {}))
 
 
 def _config_args(path, keys, sections={}):

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -30,9 +30,8 @@ import dask
 from dask import get as dask_get
 
 import yaml
-import xarray as xr
 
-from .utils import Key, keys_for_quantity, data_for_quantity, ureg
+from .utils import Key, keys_for_quantity, ureg
 from . import computations
 from .describe import describe_recursive
 

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -33,7 +33,7 @@ from dask.optimization import cull
 
 import yaml
 
-from .utils import Key, keys_for_quantity, ureg
+from .utils import Key, keys_for_quantity, replace_units, ureg
 from . import computations
 from .describe import describe_recursive
 
@@ -430,7 +430,11 @@ def configure(path=None, **config):
 
     Valid configuration keys include:
 
-    - *units*: a string, passed to :meth:`pint.UnitRegistry.define`.
+    - *units*:
+
+      - *define*: a string, passed to :meth:`pint.UnitRegistry.define`.
+      - *replace*: a mapping from str to str, used to replace units before they
+        are parsed by pints
 
     Warns
     -----
@@ -440,9 +444,15 @@ def configure(path=None, **config):
     config = _config_args(path, config)
 
     # Units
-    units = config.get('units', '').strip()
-    if units:
-        ureg.define(units)
+    units = config.get('units', {})
+
+    # Define units
+    if 'define' in units:
+        ureg.define(units['define'].strip())
+
+    # Add replacements
+    for old, new in units.get('replace', {}).items():
+        replace_units[old] = new
 
 
 def _config_args(path, keys, sections={}):

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -77,7 +77,7 @@ class Reporter(object):
             zip(scenario.par_list(), repeat('par')),
             zip(scenario.equ_list(), repeat('equ')),
             zip(scenario.var_list(), repeat('var')),
-            )
+        )
 
         for name, kind in quantities:
             # Retrieve data
@@ -120,7 +120,7 @@ class Reporter(object):
         See :meth:`configure`.
         """
         with open(path, 'r') as f:
-            self.configure(**yaml.load(f), config_dir=path.parent)
+            self.configure(config_dir=path.parent, **yaml.load(f))
 
     def configure(self, **config):
         """Configure the Reporter.

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -49,6 +49,9 @@ class Reporter(object):
     #: The default reporting key.
     default_key = None
 
+    # An index of ixmp names → full keys
+    _index = {}
+
     def __init__(self, **kwargs):
         self.graph = {}
         self.configure(**kwargs)
@@ -91,6 +94,9 @@ class Reporter(object):
             # quantities
             full_comps = comps[:(2 if ix_type == 'equ' else 1)]
             all_keys.extend(c[0] for c in full_comps)
+
+            # Index the variable name
+            rep._index[name] = full_comps[0][0]
 
         # Add a key which simply collects all quantities
         rep.add('all', sorted(all_keys))
@@ -236,6 +242,14 @@ class Reporter(object):
 
     def keys(self):
         return self.graph.keys()
+
+    def full_key(self, name):
+        """Return the full-dimensionality key for *name*.
+
+        An ixmp variable 'foo' indexed by a, c, n, q, and x is available in the
+        Reporter at 'foo:a-c-n-q-x'. `full_key('foo')` retrieves this key.
+        """
+        return self._index[name]
 
     def finalize(self, scenario):
         """Prepare the Reporter to act on *scenario*.

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -36,6 +36,7 @@ from .utils import Key, keys_for_quantity, data_for_quantity, ureg
 from . import computations
 from .computations import (   # noqa:F401
     aggregate,
+    aggregate2,
     disaggregate_shares,
     load_file,
     write_report,
@@ -283,6 +284,14 @@ class Reporter(object):
             var,
             weights])
 
+        return key
+
+    def aggregate2(self, var, tag, groups={}, keep=True):
+        if len(groups) > 1:
+            raise NotImplementedError('aggregate2() along >1 dimension')
+        key = Key.from_str_or_key(var)
+        key._tag = tag
+        self.graph[key] = (aggregate2, var, groups, keep)
         return key
 
     def disaggregate(self, var, new_dim, method='shares', args=[]):

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -1,6 +1,6 @@
 """Elementary computations for reporting."""
 # TODO:
-# - Accept pd.DataFrame user input by casting to xr.DataArray with a pd_to_xr
+# - Accept pd.DataFrame user input by casting to xr.DataArray with a pd_to_xr()
 #   method that is a no-op for xr objects.
 
 import pandas as pd
@@ -20,6 +20,7 @@ __all__ = [
 xr.set_options(keep_attrs=True)
 
 
+# Calculation
 def aggregate(quantity, dimensions):
     """Aggregate *quantity* over *dimensions*."""
     return quantity.sum(dim=dimensions)
@@ -28,6 +29,16 @@ def aggregate(quantity, dimensions):
 def disaggregate_shares(quantity, shares):
     """Disaggregate *quantity* by *shares*."""
     return quantity * shares
+
+
+def product(*quantities):
+    # TODO handle units intelligently (req. A9)
+    raise NotImplementedError
+
+
+def ratio(numerator, denominator):
+    # TODO handle units intelligently (req. A9)
+    raise NotImplementedError
 
 
 # Conversion
@@ -48,7 +59,6 @@ def load_file(path):
       'value' column; all others are treated as indices.
 
     """
-    # TODO automatically parse common file formats: yaml, xls(x)
     # TODO optionally cache: if the same Reporter is used repeatedly, then the
     #      file will be read each time; instead cache the contents in memory.
     if path.suffix == '.csv':
@@ -57,6 +67,12 @@ def load_file(path):
         index_columns = data.columns.tolist()
         index_columns.remove('value')
         return xr.DataArray.from_series(data.set_index(index_columns)['value'])
+    elif path.suffix in ('.xls', '.xlsx'):
+        # TODO define expected Excel data input format
+        raise NotImplementedError
+    elif path.suffix == '.yaml':
+        # TODO define expected YAML data input format
+        raise NotImplementedError
     else:
         # Default
         return open(path).read()
@@ -64,5 +80,5 @@ def load_file(path):
 
 def write_report(key, path):
     """Write the report identified by *key* to the file at *path*."""
-    # TODO intelligently handle different formats of *report*
+    # TODO intelligently handle different formats of *report*, e.g. CSV
     path.write_text(key)

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -30,8 +30,8 @@ xr.set_options(keep_attrs=True)
 def sum(quantity, weights, dimensions):
     """Sum *quantity* over *dimensions*, with optional *weights*."""
     if weights is not None:
-        result = ((quantity * weights).sum(dim=dimensions) /
-                   weights.sum(dim=dimensions))
+        result = ((quantity * weights).sum(dim=dimensions)
+                  / weights.sum(dim=dimensions))
     else:
         result = quantity.sum(dim=dimensions)
 

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -9,29 +9,33 @@ import xarray as xr
 xr.set_options(keep_attrs=True)
 
 
-def aggregate(var, dims):
-    return var.sum(dim=dims)
+def aggregate(quantity, dimensions):
+    """Aggregate *quantity* over *dimensions*."""
+    return quantity.sum(dim=dimensions)
 
 
-def disaggregate_shares(var, shares):
-    return var * shares
+def disaggregate_shares(quantity, shares):
+    """Disaggregate *quantity* by *shares*."""
+    return quantity * shares
 
 
 # Conversion
-def make_dataframe(*vars):
-    """Concatenate *vars* into a single pd.DataFrame."""
+def make_dataframe(*quantities):
+    """Concatenate *quantities* into a single pd.DataFrame."""
     # TODO also rename
     raise NotImplementedError
 
 
 # Input and output
 def load_file(path):
+    """Read the file at *path* and return its contents."""
     # TODO automatically parse common file formats: yaml, csv, xls(x)
     # TODO optionally cache: if the same Reporter is used repeatedly, then the
     #      file will be read each time; instead cache the contents in memory.
     return open(path).read()
 
 
-def write_report(report, path):
+def write_report(key, path):
+    """Write the report identified by *key* to the file at *path*."""
     # TODO intelligently handle different formats of *report*
-    path.write_text(report)
+    path.write_text(key)

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -21,9 +21,13 @@ xr.set_options(keep_attrs=True)
 
 
 # Calculation
-def aggregate(quantity, dimensions):
-    """Aggregate *quantity* over *dimensions*."""
-    return quantity.sum(dim=dimensions)
+def aggregate(quantity, weights=None, dimensions=None):
+    """Aggregate *quantity* over *dimensions*, with optional *weights*."""
+    if weights is not None:
+        return ((quantity * weights).sum(dim=dimensions) /
+                weights.sum(dim=dimensions))
+    else:
+        return quantity.sum(dim=dimensions)
 
 
 def disaggregate_shares(quantity, shares):

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -1,4 +1,8 @@
 """Elementary computations for reporting."""
+# Notes:
+# - To avoid ambiguity, computations should not have default arguments. Define
+#   default values for the corresponding methods on the Reporter class.
+#
 # TODO:
 # - Accept pd.DataFrame user input by casting to xr.DataArray with a pd_to_xr()
 #   method that is a no-op for xr objects.
@@ -13,6 +17,7 @@ __all__ = [
     'disaggregate_shares',
     'make_dataframe',
     'load_file',
+    'sum',
     'write_report',
 ]
 
@@ -22,8 +27,8 @@ xr.set_options(keep_attrs=True)
 
 
 # Calculation
-def aggregate(quantity, weights=None, dimensions=None):
-    """Aggregate *quantity* over *dimensions*, with optional *weights*."""
+def sum(quantity, weights, dimensions):
+    """Sum *quantity* over *dimensions*, with optional *weights*."""
     if weights is not None:
         result = ((quantity * weights).sum(dim=dimensions) /
                    weights.sum(dim=dimensions))
@@ -35,7 +40,7 @@ def aggregate(quantity, weights=None, dimensions=None):
     return result
 
 
-def aggregate2(quantity, groups, keep):
+def aggregate(quantity, groups, keep):
     """Aggregate *quantity* by *groups*."""
     for dim, dim_groups in groups.items():
         values = []

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -3,6 +3,7 @@
 # - Accept pd.DataFrame user input by casting to xr.DataArray with a pd_to_xr
 #   method that is a no-op for xr objects.
 
+import pandas as pd
 import xarray as xr
 
 
@@ -38,11 +39,27 @@ def make_dataframe(*quantities):
 
 # Input and output
 def load_file(path):
-    """Read the file at *path* and return its contents."""
-    # TODO automatically parse common file formats: yaml, csv, xls(x)
+    """Read the file at *path* and return its contents.
+
+    Some file formats are automatically converted into objects for direct use
+    in reporting code:
+
+    - *csv*: converted to :class:`xarray.DataArray`. CSV files must have a
+      'value' column; all others are treated as indices.
+
+    """
+    # TODO automatically parse common file formats: yaml, xls(x)
     # TODO optionally cache: if the same Reporter is used repeatedly, then the
     #      file will be read each time; instead cache the contents in memory.
-    return open(path).read()
+    if path.suffix == '.csv':
+        # TODO handle a wider variety of CSV files
+        data = pd.read_csv(path)
+        index_columns = data.columns.tolist()
+        index_columns.remove('value')
+        return xr.DataArray.from_series(data.set_index(index_columns)['value'])
+    else:
+        # Default
+        return open(path).read()
 
 
 def write_report(key, path):

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -13,7 +13,7 @@ __all__ = [
     'make_dataframe',
     'load_file',
     'write_report',
-    ]
+]
 
 
 # Carry unit attributes automatically

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -2,10 +2,6 @@
 # Notes:
 # - To avoid ambiguity, computations should not have default arguments. Define
 #   default values for the corresponding methods on the Reporter class.
-#
-# TODO:
-# - Accept pd.DataFrame user input by casting to xr.DataArray with a pd_to_xr()
-#   method that is a no-op for xr objects.
 
 import pandas as pd
 import xarray as xr
@@ -75,7 +71,7 @@ def product(*quantities):
 
     # Iterate over remaining entries
     for q, u in items:
-        result *= q
+        result = result * q
         u_result *= u
 
     result.attrs['_unit'] = u_result

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -29,12 +29,12 @@ xr.set_options(keep_attrs=True)
 # Calculation
 def sum(quantity, weights, dimensions):
     """Sum *quantity* over *dimensions*, with optional *weights*."""
-    if weights is not None:
-        result = ((quantity * weights).sum(dim=dimensions)
-                  / weights.sum(dim=dimensions))
+    if weights is None:
+        weights, w_total = 1, 1
     else:
-        result = quantity.sum(dim=dimensions)
+        w_total = weights.sum(dim=dimensions)
 
+    result = (quantity * weights).sum(dim=dimensions) / w_total
     result.attrs['_unit'] = collect_units(result)[0]
 
     return result

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -34,6 +34,24 @@ def aggregate(quantity, weights=None, dimensions=None):
 
     return result
 
+
+def aggregate2(quantity, groups, keep):
+    """Aggregate *quantity* by *groups*."""
+    for dim, dim_groups in groups.items():
+        values = []
+        for group, members in dim_groups.items():
+            values.append(quantity.sel({dim: members})
+                                  .sum(dim=dim)
+                                  .assign_coords(**{dim: group}))
+        if keep:
+            # Prepend the original values
+            values.insert(0, quantity)
+
+        # Reassemble to a single dataarray
+        quantity = xr.concat(values, dim=dim)
+    return quantity
+
+
 def disaggregate_shares(quantity, shares):
     """Disaggregate *quantity* by *shares*."""
     return quantity * shares

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -6,6 +6,16 @@
 import xarray as xr
 
 
+__all__ = [
+    'aggregate',
+    'disaggregate_shares',
+    'make_dataframe',
+    'load_file',
+    'write_report',
+    ]
+
+
+# Carry unit attributes automatically
 xr.set_options(keep_attrs=True)
 
 

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -108,7 +108,11 @@ def load_file(path):
         return open(path).read()
 
 
-def write_report(key, path):
+def write_report(quantity, path):
     """Write the report identified by *key* to the file at *path*."""
-    # TODO intelligently handle different formats of *report*, e.g. CSV
-    path.write_text(key)
+    if path.suffix == '.csv':
+        quantity.to_dataframe().to_csv(path)
+    elif path.suffix == '.xlsx':
+        quantity.to_dataframe().to_excel(path, merge_cells=False)
+    else:
+        path.write_text(quantity)

--- a/ixmp/reporting/describe.py
+++ b/ixmp/reporting/describe.py
@@ -1,0 +1,71 @@
+from functools import partial
+from itertools import chain
+
+import xarray as xr
+
+from .utils import Key
+
+
+def describe_recursive(graph, comp, depth=0, seen=None):
+    """Recursive helper for :meth:`ixmp.reporting.Reporter.describe`.
+
+    Parameters
+    ----------
+    graph :
+        A dask graph.
+    comp :
+        A dask computation.
+    depth : int
+        Recursion depth. Used for indentation.
+    seen : set
+        Keys that have already been described. Used to avoid
+        double-printing.
+    """
+    comp = comp if isinstance(comp, tuple) else (comp,)
+    seen = set() if seen is None else seen
+
+    indent = (' ' * 2 * (depth - 1)) + ('- ' if depth > 0 else '')
+
+    # Strings for arguments
+    result = []
+
+    for arg in comp:
+        # Don't fully reprint keys and their ancestors that have been seen
+        try:
+            if arg in seen:
+                if depth > 0:
+                    # Don't print top-level items that have been seen
+                    result.append(f"{indent}'{arg}' (above)")
+                continue
+        except TypeError:
+            pass
+
+        # Convert various types of arguments to string
+        if isinstance(arg, xr.DataArray):
+            # DataArray → just the first line of the string representation
+            item = str(arg).split('\n')[0]
+        elif isinstance(arg, partial):
+            # functools.partial → less verbose format
+            fn_name = arg.func.__name__
+            fn_args = ', '.join(chain(
+                map(repr, arg.args),
+                map('{0[0]}={0[1]}'.format, arg.keywords.items())))
+            item = f'{fn_name}({fn_args}, ...)'
+        elif isinstance(arg, (str, Key)) and arg in graph:
+            # key that exists in the graph → recurse
+            item = "'{}':\n{}".format(
+                arg,
+                describe_recursive(graph, graph[arg], depth + 1, seen))
+            seen.add(arg)
+        elif isinstance(arg, list) and len(arg) and arg[0] in graph:
+            # list → collection of items
+            item = "list of:\n{}".format(
+                describe_recursive(graph, tuple(arg), depth + 1, seen))
+            seen.update(arg)
+        else:
+            item = str(arg)
+
+        result.append(indent + item)
+
+    # Combine items
+    return ('\n' if depth > 0 else '\n\n').join(result)

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -244,13 +244,16 @@ def data_for_quantity(ix_type, name, column, scenario):
         data.rename(columns=rename_dims, inplace=True)
         data.set_index(dims, inplace=True)
 
-        # Check sparseness
+    # Check sparseness
+    try:
         shape = list(map(len, data.index.levels))
-        size = reduce(mul, shape)
-        filled = 100 * len(data) / size
-        need_to_chunk = size > 1e7 and filled < 1
-        info = (name, shape, filled, size, need_to_chunk)
-        log.debug(' '.join(map(str, info)))
+    except AttributeError:
+        shape = [data.index.size]
+    size = reduce(mul, shape)
+    filled = 100 * len(data) / size
+    need_to_chunk = size > 1e7 and filled < 1
+    info = (name, shape, filled, size, need_to_chunk)
+    log.debug(' '.join(map(str, info)))
 
     # Convert to a Dataset, assign attrbutes and name
     ds = xr.Dataset.from_dataframe(data)[column] \

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -1,6 +1,7 @@
-from functools import partial
+from functools import partial, reduce
 from itertools import compress
 import logging
+from operator import mul
 
 import pandas as pd
 import pint
@@ -242,6 +243,13 @@ def data_for_quantity(ix_type, name, column, scenario):
         # First rename, then set index
         data.rename(columns=rename_dims, inplace=True)
         data.set_index(dims, inplace=True)
+
+    # Check sparseness
+    shape = list(map(len, data.index.levels))
+    size = reduce(mul, shape)
+    filled = 100 * len(data) / size
+    need_to_chunk = size > 1e7 and filled < 1
+    log.debug(' '.join(map(str, (name, shape, filled, size, need_to_chunk))))
 
     # Convert to a Dataset, assign attrbutes and name
     log.debug(data[column])

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -115,7 +115,7 @@ def quantity_as_xr(scenario, name, kind='par'):
         'par': ['value'],
         'equ': ['lvl', 'mrg'],
         'var': ['lvl', 'mrg'],
-        }[kind]
+    }[kind]
 
     [dims.remove(col) for col in value_columns]
 

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -244,15 +244,15 @@ def data_for_quantity(ix_type, name, column, scenario):
         data.rename(columns=rename_dims, inplace=True)
         data.set_index(dims, inplace=True)
 
-    # Check sparseness
-    shape = list(map(len, data.index.levels))
-    size = reduce(mul, shape)
-    filled = 100 * len(data) / size
-    need_to_chunk = size > 1e7 and filled < 1
-    log.debug(' '.join(map(str, (name, shape, filled, size, need_to_chunk))))
+        # Check sparseness
+        shape = list(map(len, data.index.levels))
+        size = reduce(mul, shape)
+        filled = 100 * len(data) / size
+        need_to_chunk = size > 1e7 and filled < 1
+        info = (name, shape, filled, size, need_to_chunk)
+        log.debug(' '.join(map(str, info)))
 
     # Convert to a Dataset, assign attrbutes and name
-    log.debug(data[column])
     ds = xr.Dataset.from_dataframe(data)[column] \
            .assign_attrs(attrs) \
            .rename(name + ('-margin' if column == 'mrg' else ''))

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -20,29 +20,7 @@ def combo_partition(iterable):
 
 
 class Key:
-    """A hashable key for a quantity that includes its dimensionality.
-
-    Quantities in `ixmp.Scenario` can be indexed by one or more dimensions:
-
-    >>> scenario.init_par('foo', ['a', 'b', 'c'], ['apple', 'bird', 'car'])
-
-    Reporting computations for this `scenario` might use the quantity `foo`:
-    1. in its full resolution, i.e. indexed by a, b, and c;
-    2. aggregated over any one dimension, e.g. aggregated over c and thus
-       indexed by a and b;
-    3. aggregated over any two dimensions; etc.
-
-    A Key for (1) will hash, display, and evaluate as equal to 'foo:a-b-c'. A
-    key for (2) corresponds to `foo:a-b`, and so forth.
-
-    Keys may be generated concisely by defining a convenience method:
-
-    >>> def foo(dims):
-    >>>     return Key('foo', dims.split(''))
-    >>> foo('a b')
-    foo:a-b
-
-    """
+    """A hashable key for a quantity that includes its dimensionality."""
     # TODO add 'method' attribute to describe the method(s) used to perform
     # (dis)aggregation, other manipulation
     # TODO add tags or other information to describe quantities computed
@@ -78,17 +56,19 @@ class Key:
 
 
 def quantity_as_xr(scenario, name, kind='par'):
-    """Retrieve quantity *name* from *scenario* as an xr.Dataset.
+    """Retrieve *name* from `scenario` as a :class:`xarray.Dataset`.
 
     Parameters
     ----------
-    *kind* : 'par' or 'equ'
+    scenario : ixmp.Scenario
+        Source
+    kind : 'par' or 'equ'
         Type of quantity to be retrieved.
 
     Returns
     -------
-    dict of :class:'xarray.DataArray'
-        Dictionary keys are 'level' (kind='par') or ('lvl', 'mrg')
+    dict of xarray.DataArray
+        Dictionary keys are 'value' (kind='par') or ('lvl', 'mrg')
         (kind='equ').
     """
     # NB this could be moved to ixmp.Scenario

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -43,7 +43,7 @@ class Key:
     foo:a-b
 
     """
-    # TODO add 'method' attribute to describe the method used to perform
+    # TODO add 'method' attribute to describe the method(s) used to perform
     # (dis)aggregation, other manipulation
     # TODO add tags or other information to describe quantities computed
     # multiple ways

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -106,9 +106,23 @@ def quantity_as_xr(scenario, name, kind='par'):
 
     # Remove the unit from the DataFrame
     try:
+        # Ensure there is only one type of unit defined
         unit = pd.unique(data.pop('unit'))
         assert len(unit) == 1
-        attrs = {'_unit': unit[0]}
+        unit = unit[0]
+
+        # Parse units
+        try:
+            unit = ureg.parse_units(unit)
+        except pint.UndefinedUnitError:
+            # Units do not exist; define them in the UnitRegistry
+            definition = f'{unit} = [{unit}]'
+            log.info(f'Definining units {definition} for quantity {name}.')
+            ureg.define(definition)
+            unit = ureg.parse_units(unit)
+
+        # Store
+        attrs = {'_unit': unit}
     except KeyError:
         # 'equ' are returned without units
         attrs = {}

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -23,12 +23,11 @@ class Key:
     """A hashable key for a quantity that includes its dimensionality."""
     # TODO add 'method' attribute to describe the method(s) used to perform
     # (dis)aggregation, other manipulation
-    # TODO add tags or other information to describe quantities computed
-    # multiple ways
     # TODO cache repr() and only recompute when name/dims changed
-    def __init__(self, name, dims=[]):
+    def __init__(self, name, dims=[], tag=None):
         self._name = name
         self._dims = dims
+        self._tag = tag
 
     @classmethod
     def from_str_or_key(cls, value):
@@ -40,7 +39,8 @@ class Key:
 
     def __repr__(self):
         """Representation of the Key, e.g. name:dim1-dim2-dim3."""
-        return ':'.join([self._name, '-'.join(self._dims)])
+        return ':'.join([self._name, '-'.join(self._dims)] +
+                        ([self._tag] if self._tag is not None else []))
 
     def __hash__(self):
         return hash(repr(self))

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -1,12 +1,12 @@
 from functools import partial
 from itertools import compress
-from logging import getLogger
+import logging
 
 import pandas as pd
 import pint
 import xarray as xr
 
-log = getLogger(__name__)
+log = logging.getLogger(__name__)
 
 ureg = pint.UnitRegistry()
 
@@ -197,6 +197,7 @@ def data_for_quantity(ix_type, name, column, scenario):
     -------
     xr.DataArray
     """
+    log.debug('Retrieving data for {}'.format(name))
     # Retrieve quantity data
     data = scenario.element(ix_type, name)
 
@@ -221,6 +222,7 @@ def data_for_quantity(ix_type, name, column, scenario):
         data.set_index(dims, inplace=True)
 
     # Convert to a Dataset, assign attrbutes and name
+    log.debug(data[column])
     ds = xr.Dataset.from_dataframe(data)[column] \
            .assign_attrs(attrs) \
            .rename(name + ('-margin' if column == 'mrg' else ''))

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -11,6 +11,12 @@ log = logging.getLogger(__name__)
 ureg = pint.UnitRegistry()
 
 
+# Replacements to apply to quantity units before parsing by pint
+replace_units = {
+    '%': 'percent',
+}
+
+
 def combo_partition(iterable):
     """Yield pairs of lists with all possible subsets of *iterable*."""
     # Format string for binary conversion, e.g. '04b'
@@ -103,10 +109,9 @@ def clean_units(input_string):
       operator; it is translated to 'percent'.
 
     """
-    input_string = input_string.strip('[]').replace('%', 'percent')
-    # For MESSAGE-GLOBIOM
-    # TODO make this configurable
-    input_string = input_string.replace('???', '')
+    input_string = input_string.strip('[]')
+    for old, new in replace_units.items():
+        input_string = input_string.replace(old, new)
     return input_string
 
 

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -1,19 +1,14 @@
-from copy import deepcopy
-from functools import partial, reduce
+from functools import partial
 from itertools import compress
 from logging import getLogger
-from math import ceil
-from operator import mul
 
 import pandas as pd
 import pint
-import sparse
 import xarray as xr
 
 log = getLogger(__name__)
 
 ureg = pint.UnitRegistry()
-
 
 
 def combo_partition(iterable):
@@ -54,8 +49,8 @@ class Key:
 
     def __repr__(self):
         """Representation of the Key, e.g. name:dim1-dim2-dim3."""
-        return ':'.join([self._name, '-'.join(self._dims)] +
-                        ([self._tag] if self._tag is not None else []))
+        return ':'.join([self._name, '-'.join(self._dims)]
+                        + ([self._tag] if self._tag is not None else []))
 
     def __hash__(self):
         return hash(repr(self))
@@ -159,7 +154,7 @@ def keys_for_quantity(ix_type, name, scenario):
         # Add the marginal values at full resolution, but no aggregates
         mrg_key = Key('{}-margin'.format(name), dims)
         yield (mrg_key, (partial(data_for_quantity, ix_type, name, 'mrg'),
-                        'scenario'))
+                         'scenario'))
 
     # Partial sums
     yield from key.iter_sums()

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -48,6 +48,14 @@ class Key:
     def __eq__(self, other):
         return repr(self) == other
 
+    def __lt__(self, other):
+        if isinstance(other, (self.__class__, str)):
+            return repr(self) < repr(other)
+
+    def __gt__(self, other):
+        if isinstance(other, (self.__class__, str)):
+            return repr(self) > repr(other)
+
     def aggregates(self):
         """Yield (key, task) for all possible aggregations of the Key."""
         for agg_dims, others in combo_partition(self._dims):

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -47,6 +47,23 @@ class Key:
         tag = '+'.join(filter(None, [_tag, tag]))
         return cls(name, dims, tag)
 
+    @classmethod
+    def product(cls, new_name, *keys):
+        """Return a new key that has the union of dimensions on *keys*.
+
+        Dimensions are ordered by their first appearance.
+        """
+        # Dimensions of first key appear first
+        base_dims = keys[0]._dims
+
+        # Accumulate additional dimensions from subsequent keys
+        new_dims = []
+        for key in keys[1:]:
+            new_dims.extend(set(key._dims) - set(base_dims) - set(new_dims))
+
+        # Return new key
+        return cls(new_name, base_dims + new_dims)
+
     def __repr__(self):
         """Representation of the Key, e.g. name:dim1-dim2-dim3."""
         return ':'.join([self._name, '-'.join(self._dims)]

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -250,7 +250,7 @@ def data_for_quantity(ix_type, name, column, scenario):
     except AttributeError:
         shape = [data.index.size]
     size = reduce(mul, shape)
-    filled = 100 * len(data) / size
+    filled = 100 * len(data) / size if size else 'NA'
     need_to_chunk = size > 1e7 and filled < 1
     info = (name, shape, filled, size, need_to_chunk)
     log.debug(' '.join(map(str, info)))

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from functools import partial
 from itertools import compress
 from math import ceil
 
@@ -69,4 +70,5 @@ class Key:
     def aggregates(self):
         """Yield (key, task) for all possible aggregations of the Key."""
         for agg_dims, others in combo_partition(self._dims):
-            yield Key(self._name, agg_dims), (aggregate, self, others)
+            yield Key(self._name, agg_dims), \
+                (partial(aggregate, dimensions=others), self)

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -94,6 +94,7 @@ def clean_units(input_string):
 
 
 def collect_units(*args):
+    """Return an list of '_unit' attributes for *args*."""
     for arg in args:
         if '_unit' in arg.attrs:
             # Convert units if necessary
@@ -126,7 +127,7 @@ def _find_dims(data, ix_type):
 
 
 def keys_for_quantity(ix_type, name, scenario):
-    """Iterate over keys for *name* in *scenario."""
+    """Iterate over keys for *name* in *scenario*."""
     # Retrieve at least one row of the data
     # TODO use the low-level/Java API to avoid retrieving all values at this
     # point

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -130,7 +130,11 @@ def make_dantzig(mp, solve=False):
         for the scenario.
     """
     # add custom units and region for timeseries data
-    mp.add_unit('USD_per_km')
+    try:
+        mp.add_unit('USD_per_km')
+    except Exception:
+        # Unit already exists. Pending bugfix from zikolach
+        pass
     mp.add_region('DantzigLand', 'country')
 
     # initialize a new (empty) instance of an `ixmp.Scenario`

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 JPype1>=0.6.2
-dask
+dask[array]
 jupyter
 numpydoc
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 JPype1>=0.6.2
 dask[array]
+graphviz
 jupyter
 numpydoc
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ jupyter
 numpydoc
 pandas
 pytest>=3.9
+PyYAML
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-bibtex

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 JPype1>=0.6.2
+dask
 jupyter
 numpydoc
 pandas

--- a/requirements.txt
+++ b/requirements.txt
@@ -7,5 +7,6 @@ pytest>=3.9
 sphinx
 sphinx_rtd_theme
 sphinxcontrib-bibtex
+xarray
 xlsxwriter
 xlrd

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ def main():
         'console_scripts': [
             'import-timeseries=ixmp.cli:import_timeseries',
             'ixmp-config=ixmp.cli:config',
+            'ixmp=ixmp.cli:main',
         ],
     }
     lib_files = [x.split('ixmp/')[-1] for x in glob.glob('ixmp/lib/*')]

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ from setuptools import find_packages, setup
 INSTALL_REQUIRES = [
     'JPype1>=0.6.2',
     'dask[array]',
+    'graphviz',
     'pandas',
     'xarray',
     'xlsxwriter',

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,7 @@ INSTALL_REQUIRES = [
     'JPype1>=0.6.2',
     'dask',
     'pandas',
+    'xarray',
     'xlsxwriter',
     'xlrd',
 ]

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ INSTALL_REQUIRES = [
     'dask[array]',
     'graphviz',
     'pandas',
+    'pint',
     'PyYAML',
     'xarray',
     'xlsxwriter',

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from __future__ import print_function
 import glob
 import versioneer
 
-from setuptools import setup
+from setuptools import find_packages, setup
 
 
 INSTALL_REQUIRES = [
@@ -22,9 +22,6 @@ EXTRAS_REQUIRE = {
 
 
 def main():
-    packages = [
-        'ixmp',
-    ]
     pack_dir = {
         'ixmp': 'ixmp',
     }
@@ -53,7 +50,7 @@ def main():
         "url": 'http://github.com/iiasa/message_ix',
         "install_requires": INSTALL_REQUIRES,
         "extras_require": EXTRAS_REQUIRE,
-        "packages": packages,
+        "packages": find_packages(),
         "package_dir": pack_dir,
         "package_data": pack_data,
         "entry_points": entry_points,

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools import find_packages, setup
 
 INSTALL_REQUIRES = [
     'JPype1>=0.6.2',
+    'dask',
     'pandas',
     'xlsxwriter',
     'xlrd',

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,7 @@ INSTALL_REQUIRES = [
     'dask[array]',
     'graphviz',
     'pandas',
+    'PyYAML',
     'xarray',
     'xlsxwriter',
     'xlrd',

--- a/setup.py
+++ b/setup.py
@@ -9,6 +9,7 @@ from setuptools import find_packages, setup
 
 INSTALL_REQUIRES = [
     'JPype1>=0.6.2',
+    'click',
     'dask[array]',
     'graphviz',
     'pandas',

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ from setuptools import find_packages, setup
 
 INSTALL_REQUIRES = [
     'JPype1>=0.6.2',
-    'dask',
+    'dask[array]',
     'pandas',
     'xarray',
     'xlsxwriter',

--- a/tests/data/report-config-0.yaml
+++ b/tests/data/report-config-0.yaml
@@ -5,10 +5,15 @@ default: all
 
 # Exogenous data from files
 files:
-  foo: foo.txt
+  d_check: ./report-input.csv
 
 # Aliases
 alias:
   bar: d
+
+# Unrecognized section raises a warning
+notarealsection:
+  - 0
+  - 1
 
 # TODO specify format for other configurable aspects of reporting

--- a/tests/data/report-describe.txt
+++ b/tests/data/report-describe.txt
@@ -5,28 +5,33 @@
 - ['new-york', 'chicago', 'topeka']
 
 'a:':
-- aggregate(d=i, ...)
+- aggregate(dimensions=['i'], ...)
 - 'a:i':
   - <xarray.DataArray 'a' (i: 2)>
 
 'b:':
-- aggregate(d=i, ...)
+- aggregate(dimensions=['j'], ...)
 - 'b:j':
   - <xarray.DataArray 'b' (j: 3)>
 
 'd:':
-- aggregate(d=i, ...)
+- aggregate(dimensions=['i', 'j'], ...)
+- 'd:i-j':
+  - <xarray.DataArray 'd' (i: 2, j: 3)>
+
+'d:i':
+- aggregate(dimensions=['j'], ...)
 - 'd:i-j' (above)
 
 'd:j':
-- aggregate(d=i, ...)
+- aggregate(dimensions=['i'], ...)
 - 'd:i-j' (above)
 
 'demand-margin:j':
 - <xarray.DataArray 'demand-margin' (j: 0)>
 
 'demand:':
-- aggregate(d=i, ...)
+- aggregate(dimensions=['j'], ...)
 - 'demand:j':
   - <xarray.DataArray 'demand' (j: 0)>
 
@@ -34,16 +39,16 @@
 - <xarray.DataArray 'f' ()>
 
 'x:':
-- aggregate(d=i, ...)
+- aggregate(dimensions=['i', 'j'], ...)
 - 'x:i-j':
   - <xarray.DataArray 'x' (i: 0, j: 0)>
 
 'x:i':
-- aggregate(d=i, ...)
+- aggregate(dimensions=['j'], ...)
 - 'x:i-j' (above)
 
 'x:j':
-- aggregate(d=i, ...)
+- aggregate(dimensions=['i'], ...)
 - 'x:i-j' (above)
 
 'z:':

--- a/tests/data/report-describe.txt
+++ b/tests/data/report-describe.txt
@@ -1,0 +1,61 @@
+'i':
+- ['seattle', 'san-diego']
+
+'j':
+- ['new-york', 'chicago', 'topeka']
+
+'a:':
+- aggregate(d=i, ...)
+- 'a:i':
+  - <xarray.DataArray 'a' (i: 2)>
+
+'b:':
+- aggregate(d=i, ...)
+- 'b:j':
+  - <xarray.DataArray 'b' (j: 3)>
+
+'d:':
+- aggregate(d=i, ...)
+- 'd:i-j' (above)
+
+'d:j':
+- aggregate(d=i, ...)
+- 'd:i-j' (above)
+
+'demand-margin:j':
+- <xarray.DataArray 'demand-margin' (j: 0)>
+
+'demand:':
+- aggregate(d=i, ...)
+- 'demand:j':
+  - <xarray.DataArray 'demand' (j: 0)>
+
+'f:':
+- <xarray.DataArray 'f' ()>
+
+'x:':
+- aggregate(d=i, ...)
+- 'x:i-j':
+  - <xarray.DataArray 'x' (i: 0, j: 0)>
+
+'x:i':
+- aggregate(d=i, ...)
+- 'x:i-j' (above)
+
+'x:j':
+- aggregate(d=i, ...)
+- 'x:i-j' (above)
+
+'z:':
+- <xarray.DataArray 'z' ()>
+
+'all':
+- list of:
+  - 'a:i' (above)
+  - 'b:j' (above)
+  - 'd:i-j' (above)
+  - 'f:' (above)
+  - 'demand:j' (above)
+  - 'demand-margin:j' (above)
+  - 'z:' (above)
+  - 'x:i-j' (above)

--- a/tests/data/report-describe.txt
+++ b/tests/data/report-describe.txt
@@ -4,20 +4,26 @@
 'j':
 - ['new-york', 'chicago', 'topeka']
 
+'scenario':
+- <ixmp.core.Scenario object at {id}>
+
 'a:':
 - aggregate(dimensions=['i'], ...)
 - 'a:i':
-  - <xarray.DataArray 'a' (i: 2)>
+  - data_for_quantity('a', 'par', 'value', ...)
+  - 'scenario' (above)
 
 'b:':
 - aggregate(dimensions=['j'], ...)
 - 'b:j':
-  - <xarray.DataArray 'b' (j: 3)>
+  - data_for_quantity('b', 'par', 'value', ...)
+  - 'scenario' (above)
 
 'd:':
 - aggregate(dimensions=['i', 'j'], ...)
 - 'd:i-j':
-  - <xarray.DataArray 'd' (i: 2, j: 3)>
+  - data_for_quantity('d', 'par', 'value', ...)
+  - 'scenario' (above)
 
 'd:i':
 - aggregate(dimensions=['j'], ...)
@@ -28,20 +34,24 @@
 - 'd:i-j' (above)
 
 'demand-margin:j':
-- <xarray.DataArray 'demand-margin' (j: 0)>
+- data_for_quantity('demand', 'equ', 'mrg', ...)
+- 'scenario' (above)
 
 'demand:':
 - aggregate(dimensions=['j'], ...)
 - 'demand:j':
-  - <xarray.DataArray 'demand' (j: 0)>
+  - data_for_quantity('demand', 'equ', 'lvl', ...)
+  - 'scenario' (above)
 
 'f:':
-- <xarray.DataArray 'f' ()>
+- data_for_quantity('f', 'par', 'value', ...)
+- 'scenario' (above)
 
 'x:':
 - aggregate(dimensions=['i', 'j'], ...)
 - 'x:i-j':
-  - <xarray.DataArray 'x' (i: 0, j: 0)>
+  - data_for_quantity('x', 'var', 'lvl', ...)
+  - 'scenario' (above)
 
 'x:i':
 - aggregate(dimensions=['j'], ...)
@@ -52,15 +62,16 @@
 - 'x:i-j' (above)
 
 'z:':
-- <xarray.DataArray 'z' ()>
+- data_for_quantity('z', 'var', 'lvl', ...)
+- 'scenario' (above)
 
 'all':
 - list of:
   - 'a:i' (above)
   - 'b:j' (above)
   - 'd:i-j' (above)
-  - 'f:' (above)
-  - 'demand:j' (above)
   - 'demand-margin:j' (above)
-  - 'z:' (above)
+  - 'demand:j' (above)
+  - 'f:' (above)
   - 'x:i-j' (above)
+  - 'z:' (above)

--- a/tests/data/report-describe.txt
+++ b/tests/data/report-describe.txt
@@ -8,61 +8,61 @@
 - <ixmp.core.Scenario object at {id}>
 
 'a:':
-- aggregate(dimensions=['i'], ...)
+- sum(dimensions=['i'], weights=None, ...)
 - 'a:i':
-  - data_for_quantity('a', 'par', 'value', ...)
+  - data_for_quantity('par', 'a', 'value', ...)
   - 'scenario' (above)
 
 'b:':
-- aggregate(dimensions=['j'], ...)
+- sum(dimensions=['j'], weights=None, ...)
 - 'b:j':
-  - data_for_quantity('b', 'par', 'value', ...)
+  - data_for_quantity('par', 'b', 'value', ...)
   - 'scenario' (above)
 
 'd:':
-- aggregate(dimensions=['i', 'j'], ...)
+- sum(dimensions=['i', 'j'], weights=None, ...)
 - 'd:i-j':
-  - data_for_quantity('d', 'par', 'value', ...)
+  - data_for_quantity('par', 'd', 'value', ...)
   - 'scenario' (above)
 
 'd:i':
-- aggregate(dimensions=['j'], ...)
+- sum(dimensions=['j'], weights=None, ...)
 - 'd:i-j' (above)
 
 'd:j':
-- aggregate(dimensions=['i'], ...)
+- sum(dimensions=['i'], weights=None, ...)
 - 'd:i-j' (above)
 
 'demand-margin:j':
-- data_for_quantity('demand', 'equ', 'mrg', ...)
+- data_for_quantity('equ', 'demand', 'mrg', ...)
 - 'scenario' (above)
 
 'demand:':
-- aggregate(dimensions=['j'], ...)
+- sum(dimensions=['j'], weights=None, ...)
 - 'demand:j':
-  - data_for_quantity('demand', 'equ', 'lvl', ...)
+  - data_for_quantity('equ', 'demand', 'lvl', ...)
   - 'scenario' (above)
 
 'f:':
-- data_for_quantity('f', 'par', 'value', ...)
+- data_for_quantity('par', 'f', 'value', ...)
 - 'scenario' (above)
 
 'x:':
-- aggregate(dimensions=['i', 'j'], ...)
+- sum(dimensions=['i', 'j'], weights=None, ...)
 - 'x:i-j':
-  - data_for_quantity('x', 'var', 'lvl', ...)
+  - data_for_quantity('var', 'x', 'lvl', ...)
   - 'scenario' (above)
 
 'x:i':
-- aggregate(dimensions=['j'], ...)
+- sum(dimensions=['j'], weights=None, ...)
 - 'x:i-j' (above)
 
 'x:j':
-- aggregate(dimensions=['i'], ...)
+- sum(dimensions=['i'], weights=None, ...)
 - 'x:i-j' (above)
 
 'z:':
-- data_for_quantity('z', 'var', 'lvl', ...)
+- data_for_quantity('var', 'z', 'lvl', ...)
 - 'scenario' (above)
 
 'all':

--- a/tests/data/report-input.csv
+++ b/tests/data/report-input.csv
@@ -1,0 +1,7 @@
+i,j,value
+seattle,new-york,2.5
+seattle,chicago,1.7
+seattle,topeka,1.8
+san-diego,new-york,2.5
+san-diego,chicago,1.8
+san-diego,topeka,1.4

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -73,9 +73,12 @@ def test_reporter_from_dantzig(test_mp):
     # Units pass through disaggregation
     assert b_jp.attrs['unit'] == 'cases'
 
-    # 'all' key retrieves all variables at their defined dimensionality
-    names = 'a b d f demand demand-margin z x'.split()
-    assert all(a == b.name for a, b in zip(names, rep.get('all')))
+    # Set elements are available
+    assert rep.get('j') == ['new-york', 'chicago', 'topeka']
+
+    # 'all' key retrieves all quantities
+    names = set('a b d f demand demand-margin z x'.split())
+    assert names == {da.name for da in rep.get('all')}
 
 
 def test_reporter_disaggregate():

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -21,7 +21,7 @@ TS_DF['unit'] = '???'
 @pytest.fixture
 def scenario(test_mp):
     # from test_feature_timeseries.test_new_timeseries_as_year_value
-    scen = ixmp.Scenario(test_mp, *test_args, version='new', annotation='fo')
+    scen = ixmp.Scenario(test_mp, *test_args, version='new', annotation='foo')
     scen.add_timeseries(TS_DF)
     scen.commit('importing a testing timeseries')
     return scen
@@ -134,3 +134,12 @@ def test_reporting_files(tmp_path):
     assert p2.read_text() == 'Hello, world!'
 
     # TODO test reading CSV data to xarray
+
+
+def test_reporter_visualize(test_mp):
+    scen = dantzig_transport(test_mp)
+    r = Reporter.from_scenario(scen)
+
+    r.visualize('visualize.png')
+
+    # TODO compare to a specimen; place in a temporary directory

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -381,7 +381,11 @@ def test_report_size(test_mp):
     keys = [rep.full_key(name) for name in names]
     rep.add('bigmem', tuple([computations.product] + keys))
 
-    # Trigger MemoryError
+    # One quantity fits in memory
+    rep.get(keys[0])
+    # assert False
+
+    # All quantities together trigger MemoryError
     rep.get('bigmem')
 
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -13,7 +13,7 @@ from xarray.testing import (
     assert_equal as assert_xr_equal,
 )
 
-from ixmp.testing import dantzig_transport
+from ixmp.testing import make_dantzig
 from ixmp.reporting import Key, Reporter, computations
 from ixmp.reporting.utils import ureg
 
@@ -61,7 +61,7 @@ def test_reporter(scenario):
 
 
 def test_reporter_from_dantzig(test_mp, test_data_path):
-    scen = dantzig_transport(test_mp, solve=test_data_path)
+    scen = make_dantzig(test_mp, solve=test_data_path)
 
     # Reporter.from_scenario can handle the Dantzig problem
     rep = Reporter.from_scenario(scen)
@@ -113,7 +113,7 @@ def test_reporter_from_dantzig(test_mp, test_data_path):
 
 
 def test_reporter_read_config(test_mp, test_data_path):
-    scen = dantzig_transport(test_mp)
+    scen = make_dantzig(test_mp)
 
     rep = Reporter.from_scenario(scen)
     with pytest.warns(UserWarning,
@@ -261,7 +261,7 @@ def test_reporting_units():
 
 
 def test_reporter_describe(test_mp, test_data_path):
-    scen = dantzig_transport(test_mp)
+    scen = make_dantzig(test_mp)
     r = Reporter.from_scenario(scen)
 
     # hexadecimal ID of *scen*
@@ -285,7 +285,7 @@ def test_reporter_describe(test_mp, test_data_path):
 
 
 def test_reporter_visualize(test_mp):
-    scen = dantzig_transport(test_mp)
+    scen = make_dantzig(test_mp)
     r = Reporter.from_scenario(scen)
 
     r.visualize('visualize.png')
@@ -296,7 +296,7 @@ def test_reporter_visualize(test_mp):
 def test_reporting_cli(test_mp_props, test_data_path):
     # Put something in the database
     mp = ixmp.Platform(dbprops=test_mp_props)
-    dantzig_transport(mp)
+    make_dantzig(mp)
     mp.close_db()
     del mp
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -7,8 +7,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from testing_utils import dantzig, test_data_path
-
+from ixmp.testing import dantzig_transport
 
 test_args = ('Douglas Adams', 'Hitchhiker')
 
@@ -52,8 +51,8 @@ def test_reporter(scenario):
     # TODO add some assertions
 
 
-def test_reporter_from_dantzig(test_mp):
-    scen = dantzig(test_mp, solve=True)
+def test_reporter_from_dantzig(test_mp, test_data_path):
+    scen = dantzig_transport(test_mp, solve=test_data_path)
 
     # Reporter.from_scenario can handle the Dantzig problem
     rep = Reporter.from_scenario(scen)
@@ -81,8 +80,8 @@ def test_reporter_from_dantzig(test_mp):
     assert names == {da.name for da in rep.get('all')}
 
 
-def test_reporter_read_config(test_mp):
-    scen = dantzig(test_mp)
+def test_reporter_read_config(test_mp, test_data_path):
+    scen = dantzig_transport(test_mp)
 
     rep = Reporter.from_scenario(scen)
     with pytest.warns(UserWarning,

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -107,6 +107,9 @@ def test_reporter_from_dantzig(test_mp, test_data_path):
     names = set('a b d f demand demand-margin z x'.split())
     assert names == {da.name for da in rep.get('all')}
 
+    # Shorthand for retrieving a full key name
+    assert rep.full_key('d') == 'd:i-j' and isinstance(rep.full_key('d'), Key)
+
 
 def test_reporter_read_config(test_mp, test_data_path):
     scen = dantzig_transport(test_mp)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -266,7 +266,7 @@ def test_reporter_describe(test_mp, test_data_path):
 
     # hexadecimal ID of *scen*
     id_ = hex(id(scen)) if os.name != 'nt' else \
-        '{:#018X}'.format(id(scen)).upper()
+        '{:#018X}'.format(id(scen)).replace('X', 'x')
 
     # Describe one key
     expected = """'d:i':

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -181,6 +181,21 @@ def test_reporting_files(tmp_path):
     # TODO test reading CSV data to xarray
 
 
+def test_reporter_describe(test_mp, test_data_path):
+    scen = dantzig_transport(test_mp)
+    r = Reporter.from_scenario(scen)
+
+    expected = """'d:i':
+- aggregate(d=i, ...)
+- 'd:i-j':
+  - <xarray.DataArray 'd' (i: 2, j: 3)>
+"""
+    assert r.describe('d:i') == expected
+
+    print(r.describe())
+    assert r.describe() == (test_data_path / 'report-describe.txt').read_text()
+
+
 def test_reporter_visualize(test_mp):
     scen = dantzig_transport(test_mp)
     r = Reporter.from_scenario(scen)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -85,7 +85,7 @@ def test_reporter_from_dantzig(test_mp, test_data_path):
     assert_xr_equal(
         rep.get(new_key),
         (rep.get('d:i-j') * weights).sum(dim=['j']) / weights.sum(dim=['j'])
-        )
+    )
 
     # Disaggregation with explicit data
     # (cases of canned food 'p'acked in oil or water)
@@ -228,8 +228,8 @@ def test_reporting_file_formats(test_data_path, tmp_path):
     r.write(k, p2)
 
     # Output is identical to input file, except for order
-    assert (sorted(p1.read_text().split('\n')) ==
-            sorted(p2.read_text().split('\n')))
+    assert (sorted(p1.read_text().split('\n'))
+            == sorted(p2.read_text().split('\n')))
 
     # Write to Excel
     p3 = tmp_path / 'report-output.xlsx'
@@ -418,5 +418,4 @@ def test_reporting_aggregate(test_mp):
 
     with pytest.raises(NotImplementedError):
         # Not yet supported; requires two separate operations
-        key3 = rep.aggregate('x:t-y', 'agg3',
-                             {'t': t_groups, 'y': [2000, 2010]})
+        rep.aggregate('x:t-y', 'agg3', {'t': t_groups, 'y': [2000, 2010]})

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -127,8 +127,8 @@ def test_reporter_read_config(test_mp, test_data_path):
 def test_reporter_apply():
     # Reporter with two scalar values
     r = Reporter()
-    r.add('foo', 42)
-    r.add('bar', 11)
+    r.add('foo', (lambda x: x, 42))
+    r.add('bar', (lambda x: x, 11))
 
     # A computation
     def _product(a, b):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,4 +1,5 @@
 """Tests for ixmp.reporting."""
+import os
 import subprocess
 
 import ixmp
@@ -264,7 +265,7 @@ def test_reporter_describe(test_mp, test_data_path):
     r = Reporter.from_scenario(scen)
 
     # hexadecimal ID of *scen*
-    id_ = hex(id(scen))
+    id_ = hex(id(scen)) if os.name != 'nt' else '{:#018X}'.format(id(scen))
 
     # Describe one key
     expected = """'d:i':

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -186,13 +186,12 @@ def test_reporter_describe(test_mp, test_data_path):
     r = Reporter.from_scenario(scen)
 
     expected = """'d:i':
-- aggregate(d=i, ...)
+- aggregate(dimensions=['j'], ...)
 - 'd:i-j':
   - <xarray.DataArray 'd' (i: 2, j: 3)>
 """
     assert r.describe('d:i') == expected
 
-    print(r.describe())
     assert r.describe() == (test_data_path / 'report-describe.txt').read_text()
 
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -7,7 +7,7 @@ import pandas as pd
 import pytest
 import xarray as xr
 
-from testing_utils import dantzig
+from testing_utils import dantzig, test_data_path
 
 
 test_args = ('Douglas Adams', 'Hitchhiker')
@@ -79,6 +79,18 @@ def test_reporter_from_dantzig(test_mp):
     # 'all' key retrieves all quantities
     names = set('a b d f demand demand-margin z x'.split())
     assert names == {da.name for da in rep.get('all')}
+
+
+def test_reporter_read_config(test_mp):
+    scen = dantzig(test_mp)
+
+    rep = Reporter.from_scenario(scen)
+    with pytest.warns(UserWarning,
+                      match=r"Unrecognized sections {'notarealsection'}"):
+        rep.read_config(test_data_path / 'report-config-0.yaml')
+
+    # Data from configured file is available
+    assert rep.get('d_check').loc['seattle', 'chicago'] == 1.7
 
 
 def test_reporter_disaggregate():

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -283,10 +283,11 @@ def test_reporting_cli(test_mp_props, test_data_path):
     mp.close_db()
     del mp
 
-    cmd = ['ixmp', 'report',
+    cmd = ['ixmp',
            '--dbprops', str(test_mp_props),
            '--model', 'canning problem',
            '--scenario', 'standard',
+           'report',
            '--config', str(test_data_path / 'report-config-0.yaml'),
            '--default', 'd_check',
            ]

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -53,7 +53,7 @@ def test_reporter(scenario):
 
     r.finalize(scenario)
 
-    # TODO add some assertions
+    assert 'scenario' in r.graph
 
 
 def test_reporter_from_dantzig(test_mp, test_data_path):
@@ -66,7 +66,7 @@ def test_reporter_from_dantzig(test_mp, test_data_path):
     d_i = rep.get('d:i')
 
     # Units pass through summation
-    assert d_i.attrs['unit'] == 'km'
+    assert d_i.attrs['_unit'] == ureg.parse_units('km')
 
     # Aggregation with weights
     weights = xr.DataArray([1, 2, 3],
@@ -213,8 +213,22 @@ def test_reporting_file_formats(test_data_path, tmp_path):
                     index_col=['i', 'j'])['value'])
 
     # CSV file is automatically parsed to xr.DataArray
-    k = r.add_file(test_data_path / 'report-input.csv')
+    p1 = test_data_path / 'report-input.csv'
+    k = r.add_file(p1)
     assert_xr_equal(r.get(k), expected)
+
+    # Write to CSV
+    p2 = tmp_path / 'report-output.csv'
+    r.write(k, p2)
+
+    # Output is identical to input file, except for order
+    assert (sorted(p1.read_text().split('\n')) ==
+            sorted(p2.read_text().split('\n')))
+
+    # Write to Excel
+    p3 = tmp_path / 'report-output.xlsx'
+    r.write(k, p3)
+    # TODO check the contents of the Excel file
 
 
 def test_reporting_units():

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -201,7 +201,7 @@ def test_reporting_cli(test_mp_props, test_data_path):
            '--dbprops', test_mp_props,
            '--model', 'canning problem',
            '--scenario', 'standard',
-           '--config', test_data_path / 'report-config-0.yaml',
+           '--config', str(test_data_path / 'report-config-0.yaml'),
            '--default', 'd_check',
            ]
     out = subprocess.check_output(cmd, encoding='utf-8')

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -52,6 +52,12 @@ def test_reporting_key():
     assert sum(1 for a in k1.iter_sums()) == 7
 
 
+def test_reporting_configure():
+    # TODO test: All supported configuration keys can be handled
+    # TODO test: Unsupported keys raise warnings or errors
+    pass
+
+
 def test_reporter(scenario):
     r = Reporter.from_scenario(scenario)
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -198,7 +198,7 @@ def test_reporting_cli(test_mp_props, test_data_path):
     del mp
 
     cmd = ['ixmp', 'report',
-           '--dbprops', test_mp_props,
+           '--dbprops', str(test_mp_props),
            '--model', 'canning problem',
            '--scenario', 'standard',
            '--config', str(test_data_path / 'report-config-0.yaml'),

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -265,7 +265,8 @@ def test_reporter_describe(test_mp, test_data_path):
     r = Reporter.from_scenario(scen)
 
     # hexadecimal ID of *scen*
-    id_ = hex(id(scen)) if os.name != 'nt' else '{:#018X}'.format(id(scen))
+    id_ = hex(id(scen)) if os.name != 'nt' else \
+        '{:#018X}'.format(id(scen)).upper()
 
     # Describe one key
     expected = """'d:i':

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -284,13 +284,13 @@ def test_reporter_describe(test_mp, test_data_path):
     assert r.describe() == expected
 
 
-def test_reporter_visualize(test_mp):
+def test_reporter_visualize(test_mp, tmp_path):
     scen = make_dantzig(test_mp)
     r = Reporter.from_scenario(scen)
 
-    r.visualize('visualize.png')
+    r.visualize(str(tmp_path / 'visualize.png'))
 
-    # TODO compare to a specimen; place in a temporary directory
+    # TODO compare to a specimen
 
 
 def test_reporting_cli(test_mp_props, test_data_path):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -53,7 +53,7 @@ def test_reporter(scenario):
 
 
 def test_reporter_from_dantzig(test_mp):
-    scen = dantzig(test_mp)
+    scen = dantzig(test_mp, solve=True)
 
     # Reporter.from_scenario can handle the Dantzig problem
     rep = Reporter.from_scenario(scen)
@@ -74,7 +74,8 @@ def test_reporter_from_dantzig(test_mp):
     assert b_jp.attrs['unit'] == 'cases'
 
     # 'all' key retrieves all variables at their defined dimensionality
-    assert all(a == b.name for a, b in zip('a b d f'.split(), rep.get('all')))
+    names = 'a b d f demand demand-margin z x'.split()
+    assert all(a == b.name for a, b in zip(names, rep.get('all')))
 
 
 def test_reporter_disaggregate():


### PR DESCRIPTION
This will implement the second phase of the [reporting update](https://github.com/iiasa/message_ix/wiki/Reporting#phase-2).

**See also:**

- iiasa/message_ix#176 for corresponding changes to `message_ix`.
- iiasa/message_data#41 for corresponding changes to the MESSAGE global model.
- iiasa/message_ix#142 for phase 1.
- iiasa/message_ix#149 master issue for both phases.

**Progress**
Address requirements from wiki:
- [x] A1. Provide equal support for any type of model that can be built on the ixmp.
- [x] A2. Support use of exogenous data.
- [ ] A3. Support basic operations:
  - [x] A3i. Weighted sums using model or exogenous weights.
  - [x] A3ii. Disaggregation using model or exogenous shares.
  - [ ] A3iii. Interpolation: linear, exponential, etc.
- [x] A4. Support operations using quantities at different levels of aggregation.
- [x] A5. Support user-defined operations.
- [x] A6. Duplicate or clone existing operations for multiple other sets of inputs or outputs.
- [ ] A7. Support renaming of quantities using multiple name mappings:
  - [x] A7i. …given programmatically.
  - [ ] A7ii. …loaded from file.
- [x] A8. Compute only a subset of quantities from a larger/complete report.
  - [x] A8i. …for testing/development use-cases.
  - [x] A8ii. …for high-performance use-cases.
  - [x] A8iii. …using command-line arguments or other straightforward inputs to specify the subset.
- [x] A9. Handle units for quantities.
  - [x] Both quantities with provided units, and quantities without units.
  - [x] Derive units for operations such as division and multiplication.
- [x] A10. Provide automated description of how quantities are computed, as text (console output) or image.
- [ ] A11. Callable through `retixmp` (tests require #135)

PR checklist:
* [x] Tests added (ongoing)
* [x] Documentation added — **preview [here](https://ixmp-khaeru.readthedocs.io/en/feature-reporting2/api/python_reporting.html)**.
* [x] Description in RELEASE_NOTES.md added

Miscellaneous:
- [x] Choose target release: 0.3 or 1.0?
- [ ] Decide: this adds dependencies on `dask[array]` (thus `toolz`), `graphviz` (for dask.visualize), `pint`, and `xarray`. Should these be non-optional requirements, or extras (`ixmp[reporting]`)?
- [ ] Per @gidden [comment below](https://github.com/iiasa/ixmp/pull/126#issuecomment-499445625), provide user-friendly exception handling when bad units are encountered.