### PR TITLE
hotfixing for pytest/pathlib2 instabilities

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,6 +68,11 @@ def test_mp(tmp_path_factory, test_data_path):
     *test_mp* is used across the entire test session, so the contents of the
     database may reflect other tests already run.
     """
+    # casting to Path(str()) is a hotfix due to errors upstream in pytest on
+    # Python 3.5 (at least, perhaps others), there is an implicit cast to
+    # python2's pathlib which is incompatible with python3's pathlib Path
+    # objects.  This can be taken out once it is resolved upstream and CI is
+    # setup on multiple Python3.x distros.
     db_path = Path(str(tmp_path_factory.mktemp('test_mp')))
     test_props = create_local_testdb(db_path, test_data_path / 'testdb')
 
@@ -81,6 +86,11 @@ def test_mp(tmp_path_factory, test_data_path):
 @pytest.fixture(scope="session")
 def test_mp_props(tmp_path_factory, test_data_path):
     """Path to a database properties file referring to a test database."""
+    # casting to Path(str()) is a hotfix due to errors upstream in pytest on
+    # Python 3.5 (at least, perhaps others), there is an implicit cast to
+    # python2's pathlib which is incompatible with python3's pathlib Path
+    # objects.  This can be taken out once it is resolved upstream and CI is
+    # setup on multiple Python3.x distros.
     db_path = Path(str(tmp_path_factory.mktemp('test_mp_props')))
     test_props = create_local_testdb(db_path, test_data_path / 'testdb')
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -68,7 +68,7 @@ def test_mp(tmp_path_factory, test_data_path):
     *test_mp* is used across the entire test session, so the contents of the
     database may reflect other tests already run.
     """
-    db_path = tmp_path_factory.mktemp('test_mp')
+    db_path = Path(str(tmp_path_factory.mktemp('test_mp')))
     test_props = create_local_testdb(db_path, test_data_path / 'testdb')
 
     # launch Platform and connect to testdb (reconnect if closed)
@@ -81,7 +81,8 @@ def test_mp(tmp_path_factory, test_data_path):
 @pytest.fixture(scope="session")
 def test_mp_props(tmp_path_factory, test_data_path):
     """Path to a database properties file referring to a test database."""
-    db_path = tmp_path_factory.mktemp('test_mp_props')
+    db_path = Path(str(tmp_path_factory.mktemp('test_mp_props')))
     test_props = create_local_testdb(db_path, test_data_path / 'testdb')
 
+    print(type(db_path))
     yield test_props

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -84,5 +84,4 @@ def test_mp_props(tmp_path_factory, test_data_path):
     db_path = Path(str(tmp_path_factory.mktemp('test_mp_props')))
     test_props = create_local_testdb(db_path, test_data_path / 'testdb')
 
-    print(type(db_path))
     yield test_props


### PR DESCRIPTION
This is a hotfix for pytest issues on Python3.[<7]. On Python3.5, I get the following error with `master`:

```
test_cli.py F

==================================================================================== FAILURES ====================================================================================

_____________________________________________________________________________ test_import_timeseries _____________________________________________________________________________

test_mp_props = PosixPath('/tmp/pytest-of-gidden/pytest-4/test_mp_props0/testdb/test.properties'), test_data_path = PosixPath('/home/gidden/work/iiasa/message/ixmp/tests/data')

    def test_import_timeseries(test_mp_props, test_data_path):

        fname = test_data_path / 'timeseries_canning.csv'

    

        cmd = ('import-timeseries --dbprops="{}" --data="{}" --model="{}" '

               '--scenario="{}" --version="{}" --firstyear="{}"').format(

            test_mp_props, fname, 'canning problem', 'standard', 1, 2020)

    

        win = os.name == 'nt'

        subprocess.check_call(cmd, shell=not win)

    

>       mp = ix.Platform(test_mp_props)

test_cli.py:22: 

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

/home/gidden/.local/lib/python3.5/site-packages/ixmp-0.1.3.post0.dev17-py3.5.egg/ixmp/core.py:100: in __init__

    dbprops = _config.find_dbprops(dbprops)

/home/gidden/.local/lib/python3.5/site-packages/ixmp-0.1.3.post0.dev17-py3.5.egg/ixmp/config.py:203: in find_dbprops

    dirs=[Path.cwd(), self.get('DB_CONFIG_PATH')])

/home/gidden/.local/lib/python3.5/site-packages/ixmp-0.1.3.post0.dev17-py3.5.egg/ixmp/config.py:97: in _locate

    if (directory / filename).exists():

/usr/lib/python3.5/pathlib.py:889: in __truediv__

    return self._make_child((key,))

/usr/lib/python3.5/pathlib.py:681: in _make_child

    drv, root, parts = self._parse_args(args)

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

cls = <class 'pathlib.PosixPath'>, args = (PosixPath('/tmp/pytest-of-gidden/pytest-4/test_mp_props0/testdb/test.properties'),)

    @classmethod

    def _parse_args(cls, args):

        # This is useful when you don't want to create an instance, just

        # canonicalize some constructor arguments.

        parts = []

        for a in args:

            if isinstance(a, PurePath):

                parts += a._parts

            elif isinstance(a, str):

                # Force-cast str subclasses to str (issue #21127)

                parts.append(str(a))

            else:

                raise TypeError(

                    "argument should be a path or str object, not %r"

>                   % type(a))

E               TypeError: argument should be a path or str object, not <class 'pathlib2.PosixPath'>

/usr/lib/python3.5/pathlib.py:643: TypeError

------------------------------------------------------------------------------ Captured stdout call ------------------------------------------------------------------------------

2019-04-01 11:08:41,952  INFO at.ac.iiasa.ixmp.Platform:117 - Welcome to the IX modeling platform!

2019-04-01 11:08:41,954  INFO at.ac.iiasa.ixmp.Platform:118 -  connected to database 'jdbc:hsqldb:file:/tmp/pytest-of-gidden/pytest-4/test_mp_props0/testdb/ixmptest' (user: ixmp)...

2019-04-01 11:08:41,981  INFO at.ac.iiasa.ixmp.objects.Scenario:211 - loading Scenario 'canning problem|standard' by version id (version: 1, runid: 1)...

2019-04-01 11:08:41,983  INFO at.ac.iiasa.ixmp.objects.Scenario:234 - done loading Scenario from the database!

2019-04-01 11:08:42,081  INFO at.ac.iiasa.ixmp.objects.Scenario:1945 - committing changes of Scenario 'canning problem|standard' to the database (runid: 1)...

2019-04-01 11:08:42,086  INFO at.ac.iiasa.ixmp.objects.TimeSeries:813 - done updating Scenario 'canning problem|standard' to the database (runid: 1, version: 1)!

2019-04-01 11:08:42,228  INFO at.ac.iiasa.ixmp.Platform:148 - closed the connection to database 'jdbc:hsqldb:file:/tmp/pytest-of-gidden/pytest-4/test_mp_props0/testdb/ixmptest'

------------------------------------------------------------------------------ Captured stderr call ------------------------------------------------------------------------------

INFO:root:launching ixmp.Platform using config file at '/tmp/pytest-of-gidden/pytest-4/test_mp_props0/testdb/test.properties'

------------------------------------------------------------------------------- Captured log call --------------------------------------------------------------------------------

core.py                    116 INFO     Could not launch the JVM for the ixmp.Platform.Make sure that all dependencies of ixmp.jarare included in the 'ixmp/lib' folder.

============================================================================ 1 failed in 2.58 seconds ===========================================================================
```

This fix explicitly casts fixture paths to the installed `Path` library instance