### PR TITLE
Hotfix RTD build by adding pytest to doc/requirements.txt

### DIFF
--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -3,4 +3,5 @@ sphinx_rtd_theme
 sphinxcontrib-bibtex
 numpydoc
 nbformat
+pytest
 jupyter


### PR DESCRIPTION
Hotfix to docs build on RTD; was failing (eg. [here](https://readthedocs.com/projects/iiasa-energy-program-ixmp/builds/211100/)) because extra requirement `pytest` was not installed.
