### PR TITLE
DO NOT MERGE: commit to remove unit checking

### DIFF
--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -183,6 +183,10 @@ def keys_for_quantity(ix_type, name, scenario):
 def _parse_units(units_series):
     unit = pd.unique(units_series)
 
+    # TODO remove these two lines, it completely overrides all unit knowledge
+    import numpy as np
+    unit = np.array(['-'] * len(unit))
+
     if len(unit) > 1:
         log.info(f'Mixed units {unit} discarded')
         unit = ['']


### PR DESCRIPTION
new reporting requires better unit support, which will require model cleanups and pint unit registry, for now this commit changes all units to `'-'` (for reporting testing). FYI @khaeru 