### PR TITLE
Feature/reporting2 qty testing

### DIFF
--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -211,7 +211,7 @@ class AttrSeries(pd.Series):
     _metadata = ['attrs']
 
     def __init__(self, *args, **kwargs):
-        if isinstance(args[0], xr.DataArray):
+        if hasattr(args[0], 'attrs'):
             # Use attrs from an xarray object
             attrs = args[0].attrs.copy()
 

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -274,19 +274,6 @@ class AttrSeries(pd.Series):
         return AttrSeries
 
 
-# commented: see description in reporting/__init__.py
-# Quantity = xr.DataArray
-Quantity = AttrSeries
-
-
-def concat(*args, **kwargs):
-    if Quantity is AttrSeries:
-        kwargs.pop('dim')
-        return pd.concat(*args, **kwargs)
-    elif Quantity is xr.DataArray:
-        return xr.concat(*args, **kwargs)
-
-
 def data_for_quantity(ix_type, name, column, scenario):
     """Retrieve data from *scenario*.
 
@@ -357,3 +344,15 @@ def data_for_quantity(ix_type, name, column, scenario):
         pass
 
     return ds
+
+
+# Quantity = xr.DataArray
+Quantity = AttrSeries
+
+
+def concat(*args, **kwargs):
+    if Quantity is AttrSeries:
+        kwargs.pop('dim')
+        return pd.concat(*args, **kwargs)
+    elif Quantity is xr.DataArray:
+        return xr.concat(*args, **kwargs)

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -211,7 +211,10 @@ class AttrSeries(pd.Series):
     _metadata = ['attrs']
 
     def __init__(self, *args, **kwargs):
-        if hasattr(args[0], 'attrs'):
+        if 'attrs' in kwargs:
+            # Use provided attrs
+            attrs = kwargs.pop('attrs')
+        elif hasattr(args[0], 'attrs'):
             # Use attrs from an xarray object
             attrs = args[0].attrs.copy()
 
@@ -219,8 +222,8 @@ class AttrSeries(pd.Series):
             args = list(args)
             args[0] = args[0].to_series()
         else:
-            # Use provided attrs
-            attrs = kwargs.pop('attrs', collections.OrderedDict())
+            # default empty
+            attrs = collections.OrderedDict()
 
         super().__init__(*args, **kwargs)
 

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -299,11 +299,14 @@ def get_cell_output(nb, name_or_index):
 
 
 def assert_qty_equal(a, b, **kwargs):
-    print(Quantity)
     a = Quantity(a)
     b = Quantity(b)
 
+    # check type-specific equal
     if Quantity is AttrSeries:
         assert_series_equal(a, b, **kwargs)
     elif Quantity is xr.DataArray:
         assert_xr_equal(a, b, **kwargs)
+
+    # check attributes are equal
+    assert a.attrs == b.attrs

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -26,6 +26,7 @@ import xarray as xr
 from pandas.testing import assert_series_equal
 from xarray.testing import (
     assert_equal as assert_xr_equal,
+    assert_allclose as assert_xr_allclose,
 )
 
 from .config import _config as ixmp_config
@@ -307,6 +308,21 @@ def assert_qty_equal(a, b, **kwargs):
         assert_series_equal(a, b, **kwargs)
     elif Quantity is xr.DataArray:
         assert_xr_equal(a, b, **kwargs)
+
+    # check attributes are equal
+    assert a.attrs == b.attrs
+
+
+def assert_qty_allclose(a, b, **kwargs):
+    a = Quantity(a)
+    b = Quantity(b)
+
+    # check type-specific allclose
+    if Quantity is AttrSeries:
+        # we may
+        assert_series_equal(a, b, **kwargs)
+    elif Quantity is xr.DataArray:
+        assert_xr_allclose(a, b, **kwargs)
 
     # check attributes are equal
     assert a.attrs == b.attrs

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -15,18 +15,25 @@ try:
     from pathlib import Path
 except ImportError:
     from pathlib2 import Path
+import pytest
 import shutil
 import sys
 import subprocess
 
 import pandas as pd
-import pytest
+import xarray as xr
+
+from pandas.testing import assert_series_equal
+from xarray.testing import (
+    assert_equal as assert_xr_equal,
+)
 
 from .config import _config as ixmp_config
 from .core import Platform, Scenario
-
+from .reporting.utils import Quantity, AttrSeries
 
 # pytest hooks and fixtures
+
 
 def pytest_sessionstart(session):
     """Unset any configuration read from the user's directory."""
@@ -286,3 +293,17 @@ def get_cell_output(nb, name_or_index):
         return eval(cell['outputs'][0]['data']['text/plain'])
     except NameError:
         raise ValueError('no cell named {!r}'.format(name_or_index))
+
+
+# special ixmp-based assertions
+
+
+def assert_qty_equal(a, b, **kwargs):
+    print(Quantity)
+    a = Quantity(a)
+    b = Quantity(b)
+
+    if Quantity is AttrSeries:
+        assert_series_equal(a, b, **kwargs)
+    elif Quantity is xr.DataArray:
+        assert_xr_equal(a, b, **kwargs)

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -299,7 +299,7 @@ def get_cell_output(nb, name_or_index):
 # special ixmp-based assertions
 
 
-def assert_qty_equal(a, b, **kwargs):
+def assert_qty_equal(a, b, check_attrs=True, **kwargs):
     a = Quantity(a)
     b = Quantity(b)
 
@@ -310,10 +310,11 @@ def assert_qty_equal(a, b, **kwargs):
         assert_xr_equal(a, b, **kwargs)
 
     # check attributes are equal
-    assert a.attrs == b.attrs
+    if check_attrs:
+        assert a.attrs == b.attrs
 
 
-def assert_qty_allclose(a, b, **kwargs):
+def assert_qty_allclose(a, b, check_attrs=True, **kwargs):
     a = Quantity(a)
     b = Quantity(b)
 
@@ -325,4 +326,5 @@ def assert_qty_allclose(a, b, **kwargs):
         assert_xr_allclose(a, b, **kwargs)
 
     # check attributes are equal
-    assert a.attrs == b.attrs
+    if check_attrs:
+        assert a.attrs == b.attrs

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -42,21 +42,24 @@ def scenario(test_mp):
 # the backend for testing both xr and pd.
 # I have done this by hand (swapping the Quantity class and running tests) on
 # commit df1ec6f of #147.
-def test_assert_qty_equal():
+def test_assert_qty():
     # tests without `attr` property, in which case direct pd.Series and
     # xr.DataArray comparisons are possible
     a = xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
     b = a.to_series()
-
     assert_qty_equal(a, b)
     assert_qty_equal(b, a)
+    assert_qty_allclose(a, b)
+    assert_qty_allclose(b, a)
 
     c = Quantity(a)
     assert_qty_equal(a, c)
     assert_qty_equal(c, a)
+    assert_qty_allclose(a, c)
+    assert_qty_allclose(c, a)
 
 
-def test_assert_qty_equal_attrs():
+def test_assert_qty_attrs():
     # tests *with* `attr` property, in which case direct pd.Series and
     # xr.DataArray comparisons *not* are possible
     a = xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
@@ -67,10 +70,11 @@ def test_assert_qty_equal_attrs():
     # make sure it has the correct property
     assert a.attrs == attrs
     assert b.attrs == attrs
-    assert a.attrs == b.attrs
 
     assert_qty_equal(a, b)
     assert_qty_equal(b, a)
+    assert_qty_allclose(a, b)
+    assert_qty_allclose(b, a)
 
 
 def test_reporting_key():

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -76,6 +76,9 @@ def test_assert_qty_attrs():
     assert_qty_allclose(a, b)
     assert_qty_allclose(b, a)
 
+    a.attrs = {'bar': 'foo'}
+    assert_qty_equal(a, b, check_attrs=False)
+
 
 def test_reporting_key():
     k1 = Key('foo', ['a', 'b', 'c'])

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -37,8 +37,42 @@ def scenario(test_mp):
     return scen
 
 
-# TODO: we would need to revamp the quantity interface to be able to custom set
-# the backend for testing both xr and pd
+# TODO:
+# we would need to revamp the quantity interface to be able to custom set
+# the backend for testing both xr and pd.
+# I have done this by hand (swapping the Quantity class and running tests) on
+# commit df1ec6f of #147.
+def test_assert_qty_equal():
+    # tests without `attr` property, in which case direct pd.Series and
+    # xr.DataArray comparisons are possible
+    a = xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
+    b = a.to_series()
+
+    assert_qty_equal(a, b)
+    assert_qty_equal(b, a)
+
+    c = Quantity(a)
+    assert_qty_equal(a, c)
+    assert_qty_equal(c, a)
+
+
+def test_assert_qty_equal_attrs():
+    # tests *with* `attr` property, in which case direct pd.Series and
+    # xr.DataArray comparisons *not* are possible
+    a = xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
+    attrs = {'foo': 'bar'}
+    a.attrs = attrs
+    b = Quantity(a)
+
+    # make sure it has the correct property
+    assert a.attrs == attrs
+    assert b.attrs == attrs
+    assert a.attrs == b.attrs
+
+    assert_qty_equal(a, b)
+    assert_qty_equal(b, a)
+
+
 def test_assert_qty_equal():
     a = xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
     b = a.to_series()

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -13,9 +13,9 @@ from xarray.testing import (
     assert_equal as assert_xr_equal,
 )
 
-from ixmp.testing import make_dantzig
+from ixmp.testing import make_dantzig, assert_qty_equal
 from ixmp.reporting import Key, Reporter, computations
-from ixmp.reporting.utils import ureg, Quantity
+from ixmp.reporting.utils import ureg, Quantity, AttrSeries
 
 from pandas.testing import assert_series_equal
 
@@ -35,6 +35,16 @@ def scenario(test_mp):
     scen.add_timeseries(TS_DF)
     scen.commit('importing a testing timeseries')
     return scen
+
+
+# TODO: we would need to revamp the quantity interface to be able to custom set
+# the backend for testing both xr and pd
+def test_assert_qty_equal():
+    a = xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
+    b = a.to_series()
+
+    assert_qty_equal(a, b)
+    assert_qty_equal(b, a)
 
 
 def test_reporting_key():

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -16,7 +16,7 @@ from xarray.testing import (
 
 from ixmp.testing import make_dantzig, assert_qty_equal, assert_qty_allclose
 from ixmp.reporting import Key, Reporter, computations
-from ixmp.reporting.utils import ureg, Quantity, AttrSeries
+from ixmp.reporting.utils import ureg, Quantity
 
 
 test_args = ('Douglas Adams', 'Hitchhiker')
@@ -481,8 +481,8 @@ def test_reporting_aggregate(test_mp):
     assert set(agg1.coords['t'].values) == set(t) | set(t_groups.keys())
 
     # Sums are as expected
-    # TODO: the check_dtype arg assumes Quantity backend is a AttrSeries, should
-    # that be made default in assert_qty_allclose?
+    # TODO: the check_dtype arg assumes Quantity backend is a AttrSeries,
+    # should that be made default in assert_qty_allclose?
     assert_qty_allclose(agg1.sel(t='foo', drop=True), x.sel(t=t_foo).sum('t'),
                         check_dtype=False)
     assert_qty_allclose(agg1.sel(t='bar', drop=True), x.sel(t=t_bar).sum('t'),

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -73,14 +73,6 @@ def test_assert_qty_equal_attrs():
     assert_qty_equal(b, a)
 
 
-def test_assert_qty_equal():
-    a = xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
-    b = a.to_series()
-
-    assert_qty_equal(a, b)
-    assert_qty_equal(b, a)
-
-
 def test_reporting_key():
     k1 = Key('foo', ['a', 'b', 'c'])
 


### PR DESCRIPTION
@khaeru this extends `ixmp.testing`  to include `assert_qty_equal` and `assert_qty_allclose`. some outstanding questions in TODOs. Shim removed, tests pass.