### PR TITLE
Drop Python 2 CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -3,8 +3,6 @@
 
 environment:
   matrix:
-  - PYTHON_VERSION: "2.7"
-    PYTHON_ARCH: "64"
   - PYTHON_VERSION: "3.6"
     PYTHON_ARCH: "64"
   - PYTHON_VERSION: "3.7"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,12 +8,8 @@ matrix:
   include:
   - os: linux
     env: PYENV=py37
-  - os: linux
-    env: PYENV=py27
   - os: osx
     env: PYENV=py37
-  - os: osx
-    env: PYENV=py27
 # turn these on once travis support gets a little better, see pyam for example
 #  - os: windows
 #    env: PYENV=py37

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,6 @@ matrix:
 # turn these on once travis support gets a little better, see pyam for example
 #  - os: windows
 #    env: PYENV=py37
-#  - os: windows
-#    env: PYENV=py27
 
 r_packages:
 - IRkernel

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,6 +1,7 @@
 
 # Next Release
 
+- [#175](https://github.com/iiasa/ixmp/pull/175): Drop support for Python 2.
 - [#173](https://github.com/iiasa/ixmp/pull/173): Make AppVeyor CI more robust; support pandas 0.25.0.
 
 # v0.2.0

--- a/ci/appveyor-install.R
+++ b/ci/appveyor-install.R
@@ -1,24 +1,18 @@
 step <- commandArgs(TRUE)[1]
 
-options(repos=c('https://cloud.r-project.org'))
+# Install only binary packages on AppVeyor/Windows. This prevents build
+# failures when the source package version is ahead of the binary version and
+# the AppVeyor worker lacks the necessary libraries etc. to compile the
+# source.
+options(repos=c('https://cloud.r-project.org'), pkgType='win.binary')
 
 if ( step == '1' ) {
-  # Install only binary packages on AppVeyor/Windows. This prevents build
-  # failures when the source package version is ahead of the binary version and
-  # the AppVeyor worker lacks the necessary libraries etc. to compile the
-  # source.
-  options(pkgType='win.binary')
-
   install.packages(c('devtools', 'IRkernel'), quiet = TRUE)
 
   # Install the IR kernel specification so that Jupyter can handle R notebooks
   IRkernel::installspec()
 } else if ( step == '2' ) {
-
-  # upgrade = FALSE is to keep mime (above) at 0.6
   devtools::install(file.path('.', 'rixmp'),
                     args = '--no-multiarch',
-                    dependencies = TRUE,
-                    upgrade = FALSE)
-
+                    dependencies = TRUE)
 }

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -42,9 +42,6 @@ case "${TRAVIS_OS_NAME}" in
 esac
 
 case "${PYENV}" in
-    py27)
-        export PYVERSION=2
-    ;;
     py37)
         export PYVERSION=3
     ;;

--- a/ixmp/config.py
+++ b/ixmp/config.py
@@ -11,7 +11,7 @@ except ImportError:
 from ixmp.utils import logger
 
 
-class Config(object):
+class Config:
     """Configuration for ixmp.
 
     When imported, :mod:`ixmp` reads a configuration file `config.json` in the
@@ -164,8 +164,7 @@ class Config(object):
 
         # Write the file
         logger().info('Updating configuration file: {}'.format(path))
-        # str() here is for py2 compatibility
-        with open(str(path), 'w') as f:
+        with open(path, 'w') as f:
             json.dump({k: str(self.values[k]) for k in self._keys if
                        self.values[k] is not None}, f)
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -47,7 +47,7 @@ def start_jvm(jvmargs=None):
     java.LinkedHashMap = java("java.util").LinkedHashMap
 
 
-class Platform(object):
+class Platform:
     """Database-backed instance of the ixmp.
 
     Each Platform connects three components:
@@ -325,7 +325,7 @@ def _logger_region_exists(_regions, r):
 # %% class TimeSeries
 
 
-class TimeSeries(object):
+class TimeSeries:
     """Generic collection of data in time series format.
 
     TimeSeries is the parent/super-class of :class:`Scenario`.

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -44,7 +44,7 @@ from .describe import describe_recursive
 log = logging.getLogger(__name__)
 
 
-class Reporter(object):
+class Reporter:
     """Class for generating reports on :class:`ixmp.Scenario` objects."""
     # TODO meet the requirements:
     # A3iii. Interpolation.
@@ -306,7 +306,7 @@ class Reporter(object):
                 self.graph['filters'].pop(key, None)
 
     # ixmp data model manipulations
-    def add_product(self, name, quantities, sums=True):
+    def add_product(self, name, *quantities, sums=True):
         """Add a computation that takes the product of *quantities*.
 
         Parameters
@@ -322,9 +322,6 @@ class Reporter(object):
         Key
             The full key of the new quantity.
         """
-        # TODO when py2 support is dropped, convert 'quantities' to
-        #      '*quantities' in the signature.
-
         # Fetch the full key for each quantity
         try:
             base_keys = [self.full_key(q) for q in quantities]

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -49,10 +49,7 @@ class Key:
             dims = value._dims.copy()
             _tag = value._tag
         else:
-            # TODO after py2.7 compatibility is dropped, use:
-            # name, *dims = value.split(':')
-            dims = value.split(':')
-            name = dims.pop(0)
+            name, *dims = value.split(':')
             _tag = dims[1] if len(dims) == 2 else None
             dims = dims[0].split('-')
         if drop:
@@ -185,10 +182,7 @@ def keys_for_quantity(ix_type, name, scenario):
                 'scenario', 'filters'))
 
     # Partial sums
-    # py2 compat: would prefer to do:
-    # yield from key.iter_sums()
-    for k in key.iter_sums():
-        yield k
+    yield from key.iter_sums()
 
 
 def _parse_units(units_series):
@@ -196,7 +190,7 @@ def _parse_units(units_series):
     unit = pd.unique(units_series)
 
     if len(unit) > 1:
-        # py2 compat: could use an f-string here
+        # py3.5 compat: could use an f-string here
         log.info('Mixed units {} discarded'.format(unit))
         unit = ['']
 
@@ -222,7 +216,7 @@ def _parse_units(units_series):
                 # Unit already defined
                 continue
 
-            # py2 compat: could use f-strings here
+            # py3.5 compat: could use f-strings here
             definition = '{0} = [{0}]'.format(u)
             log.info('Add unit definition: {}'.format(definition))
 
@@ -234,8 +228,7 @@ def _parse_units(units_series):
             unit = ureg.parse_units(unit)
         except pint.UndefinedUnitError:
             # Handle the silent failure of define(), above
-            # py2 compat: would prefer to raise 'from None'
-            raise invalid(unit)
+            raise invalid(unit) from None
     except AttributeError:
         # Unit contains a character like '-' that throws off pint
         # NB this 'except' clause must be *after* UndefinedUnitError, since

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -22,9 +22,12 @@ import subprocess
 
 import pandas as pd
 from pandas.testing import assert_series_equal
+from xarray import DataArray
+from xarray.testing import assert_equal as assert_xr_equal
 
 from .config import _config as ixmp_config
 from .core import Platform, Scenario, IAMC_IDX
+from .reporting.utils import Quantity, AttrSeries
 
 
 models = {
@@ -123,8 +126,7 @@ def create_local_testdb(db_path, data_path, db='ixmptest'):
     """
     # Copy test database
     dst = Path(db_path) / 'testdb'
-    # str() here is for py2 compatibility
-    shutil.copytree(str(data_path), str(dst))
+    shutil.copytree(data_path, str(dst))
 
     # Create properties file
     props = (Path(data_path) / 'test.properties_template').read_text()
@@ -313,12 +315,6 @@ def get_cell_output(nb, name_or_index):
 
 
 def assert_qty_equal(a, b, check_attrs=True, **kwargs):
-    # py2 compat: import here instead of top of file
-    from xarray import DataArray
-    from xarray.testing import assert_equal as assert_xr_equal
-
-    from .reporting.utils import Quantity, AttrSeries
-
     a = Quantity(a)
     b = Quantity(b)
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -485,7 +485,7 @@ def test_report_size(test_mp):
     # Names like f_0000 ... f_1596 along each dimension
     coords = []
     for d, N in zip(dims, sizes):
-        # py2 compat: could use an f-string here
+        # py3.5 compat: could use an f-string here
         coords.append(['{}_{:04d}'.format(d, i) for i in range(N)])
         # Add to Scenario
         scen.init_set(d)
@@ -493,8 +493,7 @@ def test_report_size(test_mp):
 
     def _make_values():
         """Make a DataFrame containing each label in *coords* at least once."""
-        # py2 compat: *( + [ ])
-        values = list(zip_longest(*(coords + [np.random.rand(max(sizes))])))
+        values = list(zip_longest(*coords, np.random.rand(max(sizes))))
         result = pd.DataFrame(values, columns=list(dims) + ['value']) \
                    .ffill()
         result['unit'] = 'kg'
@@ -504,7 +503,7 @@ def test_report_size(test_mp):
     N = 10
     names = []
     for i in range(10):
-        # py2 compat: could use an f-string here
+        # py3.5 compat: could use an f-string here
         name = 'q_{:02d}'.format(i)
         scen.init_par(name, list(dims))
         scen.add_par(name, _make_values())


### PR DESCRIPTION
To partially address #158, CI for Python 2 is disabled on Travis & Appveyor.

**PR checklist:**

- [x] ~Tests added.~ N/A
- [x] ~Documentation added.~ N/A; will be written into the release notes for 1.0
- [x] Release notes updated.