### PR TITLE
Sum across all dimensions; check missing keys

### DIFF
--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -205,16 +205,26 @@ class Reporter:
                computations.
             4. A list containing one or more of #1, #2, and/or #3.
         strict : bool, optional
-            If True (default), *key* must not already exist in the Reporter.
+            If True, *key* must not already exist in the Reporter, and
+            any keys referred to by *computation* must exist.
 
         Raises
         ------
         KeyError
-            If `key` is already in the Reporter.
+            If `key` is already in the Reporter, or any key referred to by
+            `computation` does not exist.
         """
-        if strict and key in self.graph:
-            raise KeyError(key)
+        if strict:
+            # Key already exists in graph
+            if key in self.graph:
+                raise KeyError(key)
+
+            # Check that keys used in *computation* are in the graph
+            keylike = filter(lambda e: isinstance(e, (str, Key)), computation)
+            self.check_keys(*keylike)
+
         self.graph[key] = computation
+
         return key
 
     def apply(self, generator, *keys):

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -294,8 +294,14 @@ class AttrSeries(pd.Series):
         try:
             dim = kwargs.pop('dim')
             if isinstance(self.index, pd.MultiIndex):
-                obj = self.unstack(dim)
-                kwargs['axis'] = 1
+                if len(dim) == len(self.index.names):
+                    # assume dimensions = full multi index, do simple sum
+                    obj = self
+                    kwargs = {}
+                else:
+                    # pivot and sum across columns
+                    obj = self.unstack(dim)
+                    kwargs['axis'] = 1
             else:
                 if dim != [self.index.name]:
                     raise ValueError(dim, self.index.name, self)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -62,9 +62,15 @@ def test_missing_keys():
         r.apply(gen, 'd', 'e', 'f')
 
     # add(..., strict=True) checks str or Key arguments
+    g = Key('g', 'hi')
     with pytest.raises(KeyError, match=r"\['b', g:h-i\]"):
-        r.add('foo', (computations.product, 'a', 'b', Key('g', 'hi')),
-              strict=True)
+        r.add('foo', (computations.product, 'a', 'b', g), strict=True)
+
+    # aggregate() and disaggregate() call add(), which raises the exception
+    with pytest.raises(KeyError, match=r"\[g:h-i\]"):
+        r.aggregate(g, 'tag', 'i')
+    with pytest.raises(KeyError, match=r"\[g:h-i\]"):
+        r.disaggregate(g, 'j')
 
 
 def test_reporter_from_scenario(scenario):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -61,6 +61,11 @@ def test_missing_keys():
     with pytest.raises(KeyError, match=r"\['e', 'f'\]"):
         r.apply(gen, 'd', 'e', 'f')
 
+    # add(..., strict=True) checks str or Key arguments
+    with pytest.raises(KeyError, match=r"\['b', g:h-i\]"):
+        r.add('foo', (computations.product, 'a', 'b', Key('g', 'hi')),
+              strict=True)
+
 
 def test_reporter_from_scenario(scenario):
     r = Reporter.from_scenario(scenario)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -40,13 +40,26 @@ def test_reporting_configure():
 
 
 def test_missing_keys():
-    """Adding computations that refer to missing keys raises ValueError."""
+    """Adding computations that refer to missing keys raises KeyError."""
     r = Reporter()
     r.add('a', 3)
+    r.add('d', 4)
 
-    with pytest.raises(ValueError):
-        # Refers to non-existent 'b'
+    def gen(other):
+        """A generator for apply()."""
+        return (lambda a, b: a * b, 'a', other)
+
+    # One missing key
+    with pytest.raises(KeyError, match="['b']"):
         r.add_product('ab', 'a', 'b')
+
+    # Two missing keys
+    with pytest.raises(KeyError, match="['c', 'b']"):
+        r.add_product('abc', 'c', 'a', 'b')
+
+    # Using apply() targeted at non-existent keys also raises an Exception
+    with pytest.raises(KeyError, match="['e', 'f']"):
+        r.apply(gen, 'b', 'd', 'e', 'f')
 
 
 def test_reporter_from_scenario(scenario):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -39,7 +39,17 @@ def test_reporting_configure():
     pass
 
 
-def test_reporter(scenario):
+def test_missing_keys():
+    """Adding computations that refer to missing keys raises ValueError."""
+    r = Reporter()
+    r.add('a', 3)
+
+    with pytest.raises(ValueError):
+        # Refers to non-existent 'b'
+        r.add_product('ab', 'a', 'b')
+
+
+def test_reporter_from_scenario(scenario):
     r = Reporter.from_scenario(scenario)
 
     r.finalize(scenario)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -50,16 +50,16 @@ def test_missing_keys():
         return (lambda a, b: a * b, 'a', other)
 
     # One missing key
-    with pytest.raises(KeyError, match="['b']"):
+    with pytest.raises(KeyError, match=r"\['b'\]"):
         r.add_product('ab', 'a', 'b')
 
     # Two missing keys
-    with pytest.raises(KeyError, match="['c', 'b']"):
+    with pytest.raises(KeyError, match=r"\['c', 'b'\]"):
         r.add_product('abc', 'c', 'a', 'b')
 
     # Using apply() targeted at non-existent keys also raises an Exception
-    with pytest.raises(KeyError, match="['e', 'f']"):
-        r.apply(gen, 'b', 'd', 'e', 'f')
+    with pytest.raises(KeyError, match=r"\['e', 'f'\]"):
+        r.apply(gen, 'd', 'e', 'f')
 
 
 def test_reporter_from_scenario(scenario):

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -133,6 +133,10 @@ def test_reporter_from_dantzig(test_mp, test_data_path):
     # Units pass through summation
     assert d_i.attrs['_unit'] == ureg.parse_units('km')
 
+    d = rep.get('d:')
+    assert len(d) == 1
+    assert np.isclose(d.iloc[0], 11.7)
+
     # Weighted sum
     weights = Quantity(xr.DataArray(
         [1, 2, 3],

--- a/tests/test_reporting_utils.py
+++ b/tests/test_reporting_utils.py
@@ -1,0 +1,96 @@
+"""Tests for ixmp.reporting.utils."""
+import pandas as pd
+import pytest
+import xarray as xr
+
+from ixmp.reporting import Key
+from ixmp.reporting.utils import AttrSeries, Quantity
+from ixmp.testing import assert_qty_allclose, assert_qty_equal
+
+
+def test_reporting_key():
+    k1 = Key('foo', ['a', 'b', 'c'])
+
+    # Representation
+    assert repr(k1) == 'foo:a-b-c'
+
+    # Key hashes the same as its string representation
+    assert hash(k1) == hash('foo:a-b-c')
+
+    # Key compares equal to its string representation
+    assert k1 == 'foo:a-b-c'
+
+    # Number of partial sums for a 3-dimensional quantity
+    assert sum(1 for a in k1.iter_sums()) == 7
+
+
+class TestQuantity:
+    """Tests of Quantity.
+
+    NB. these tests should pass whether Quantity is set to AttrSeries or
+    xr.DataArray in ixmp.reporting.utils. As written, they only test the
+    current form of Quantity. @gidden tested both by hand-swapping the Quantity
+    class and running tests as of commit df1ec6f of PR #147.
+    """
+    @pytest.fixture()
+    def a(self):
+        yield xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
+
+    def test_assert(self, a):
+        """Test assertions about Quantity.
+
+        These are tests without `attr` property, in which case direct pd.Series
+        and xr.DataArray comparisons are possible.
+        """
+        # Convert to pd.Series
+        b = a.to_series()
+
+        assert_qty_equal(a, b)
+        assert_qty_equal(b, a)
+        assert_qty_allclose(a, b)
+        assert_qty_allclose(b, a)
+
+        c = Quantity(a)
+
+        assert_qty_equal(a, c)
+        assert_qty_equal(c, a)
+        assert_qty_allclose(a, c)
+        assert_qty_allclose(c, a)
+
+    def test_assert_with_attrs(self, a):
+        """Test assertions about Quantity with attrs.
+
+        Here direct pd.Series and xr.DataArray comparisons are *not* possible.
+        """
+        attrs = {'foo': 'bar'}
+        a.attrs = attrs
+
+        b = Quantity(a)
+
+        # make sure it has the correct property
+        assert a.attrs == attrs
+        assert b.attrs == attrs
+
+        assert_qty_equal(a, b)
+        assert_qty_equal(b, a)
+        assert_qty_allclose(a, b)
+        assert_qty_allclose(b, a)
+
+        # check_attrs=False allows a successful equals assertion even when the
+        # attrs are different
+        a.attrs = {'bar': 'foo'}
+        assert_qty_equal(a, b, check_attrs=False)
+
+
+class TestAttrSeries:
+    """Tests of AttrSeries in particular."""
+    def test_sum(self):
+        idx = pd.MultiIndex.from_product([['a1', 'a2'], ['b1', 'b2']],
+                                         names=['a', 'b'])
+        foo = AttrSeries([0, 1, 2, 3], index=idx)
+
+        # AttrSeries can be summed across all dimensions
+        result = foo.sum(dim=['a', 'b'])
+        assert isinstance(result, AttrSeries)  # returns an AttrSeries
+        assert len(result) == 1                # with one element
+        assert result[0] == 6                  # that has the correct value


### PR DESCRIPTION

Previously, reporting would fail if provided a complete summation (e.g., `d:i` to `d:`). This now allows us to support summing over all indicies.

**PR checklist:**

- [x] Tests added.
- [x] Documentation added.
- [ ] Release notes updated. 