### PR TITLE
Fix typo in method name for `add-region-synonym`

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -319,8 +319,8 @@ class Platform:
         else:
             _logger_region_exists(_regions, region)
 
-    def add_region_synomym(self, region, mapped_to):
-        """Define a synomym for a `region`.
+    def add_region_synonym(self, region, mapped_to):
+        """Define a synonym for a `region`.
 
         When adding timeseries data using the synonym in the region column, it
         will be converted to `mapped_to`.
@@ -368,7 +368,7 @@ def _logger_region_exists(_regions, r):
     region = _regions.set_index('region').loc[r]
     msg = 'region `{}` is already defined in the platform instance'
     if region['mapped_to'] is not None:
-        msg += ' as synomym for region `{}`'.format(region.mapped_to)
+        msg += ' as synonym for region `{}`'.format(region.mapped_to)
     if region['parent'] is not None:
         msg += ', as subregion of `{}`'.format(region.parent)
     logger().info(msg.format(r))

--- a/tests/test_feature_timeseries.py
+++ b/tests/test_feature_timeseries.py
@@ -151,7 +151,7 @@ def test_timeseries_edit_iamc(test_mp):
 def test_timeseries_edit_with_region_synonyms(test_mp):
     args_all = ('Douglas Adams 1', 'test_remove_all')
     test_mp.set_log_level('DEBUG')
-    test_mp.add_region_synomym('Hell', 'World')
+    test_mp.add_region_synonym('Hell', 'World')
     scen = ixmp.TimeSeries(test_mp, *args_all, version='new', annotation='nk')
 
     df = pd.DataFrame.from_dict({'region': ['World'],

--- a/tests/test_regions.py
+++ b/tests/test_regions.py
@@ -19,7 +19,7 @@ def test_add_region(test_mp):
 
 def test_add_region_synonym(test_mp):
     test_mp.add_region('foo', 'bar', 'World')
-    test_mp.add_region_synomym('foo2', 'foo')
+    test_mp.add_region_synonym('foo2', 'foo')
     regions = test_mp.regions()
     obs = regions[regions.region.isin(['foo', 'foo2'])].reset_index(drop=True)
 


### PR DESCRIPTION
Just a type in method name