### PR TITLE
Disable Travis caching of Miniconda to resolve CI errors

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,7 @@ cache:
   directories:
   - $HOME/.conda/pkgs
   - $HOME/.cache/ixmp
-  - $HOME/miniconda/pkgs
+#  - $HOME/miniconda/pkgs
   - $HOME/R/Library
 
 addons:

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,6 @@ cache:
   directories:
   - $HOME/.conda/pkgs
   - $HOME/.cache/ixmp
-#  - $HOME/miniconda/pkgs
   - $HOME/R/Library
 
 addons:

--- a/ci/env.sh
+++ b/ci/env.sh
@@ -50,3 +50,6 @@ esac
 export CONDAFNAME=Miniconda$PYVERSION-latest-$OSNAME-x86_64.$EXT
 export CONDAURL=https://repo.anaconda.com/miniconda/$CONDAFNAME
 export PATH=$HOME/miniconda/bin:$PATH
+
+# Echo all environment variables for debugging
+env | sort

--- a/ci/travis-before_install.sh
+++ b/ci/travis-before_install.sh
@@ -13,7 +13,7 @@ maybe_download $CONDAURL $CONDAFNAME
 
 
 # Install graphiz on OS X (requires updating homebrew)
-if [ `uname` -eq "Darwin" ];
+if [ `uname` = "Darwin" ];
 then
   brew update
   brew install graphviz

--- a/ci/travis-install.sh
+++ b/ci/travis-install.sh
@@ -6,6 +6,9 @@ which gams
 
 
 # Install and update conda
+# -b: run in batch mode with no user input
+# -u: update existing installation
+# -p: install prefix
 $CACHE/$CONDAFNAME -b -u -p $HOME/miniconda
 conda update --yes conda
 


### PR DESCRIPTION
Travis builds (e.g. [#547](https://travis-ci.org/iiasa/ixmp/builds/574821631)) are erroring with messages like:
```
Downloading and Extracting Packages

python-libarchive-c- | 23 KB     |            |   0% 
conda-package-handli | 255 KB    |            |   0% 
bzip2-1.0.8          | 75 KB     |            |   0% 
sqlite-3.29.0        | 1.2 MB    |            |   0% 

RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/osx-64/python-libarchive-c-2.8-py37_11.conda\nThis command is using a remote connection in offline mode.\n',)
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/osx-64/conda-package-handling-1.3.11-py37_0.conda\nThis command is using a remote connection in offline mode.\n',)
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/osx-64/bzip2-1.0.8-h1de35cc_0.conda\nThis command is using a remote connection in offline mode.\n',)
RuntimeError('EnforceUnusedAdapter called with url https://repo.anaconda.com/pkgs/main/osx-64/sqlite-3.29.0-ha441bb4_0.conda\nThis command is using a remote connection in offline mode.\n',)

ci/travis-install.sh: line 10: conda: command not found
```
… etc.

This PR is to debug/resolve.

**PR checklist:**

- [x] ~Tests added.~ Not applicable; this is not a user-facing/API change.
- [x] ~Documentation added.~
- [x] ~Release notes updated.~