### PR TITLE
Handle type coversion of equ_list, var_list in JDBCBackend.read_gdx

### DIFF
--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -623,8 +623,8 @@ class JDBCBackend(Backend):
             Variables to be imported.
         """
         self.jindex[s].readSolutionFromGDX(
-            str(path.parent), path.name, comment, var_list, equ_list,
-            check_solution)
+            str(path.parent), path.name, comment, to_jlist2(var_list),
+            to_jlist2(equ_list), check_solution)
 
     def _get_item(self, s, ix_type, name, load=True):
         """Return the Java object for item *name* of *ix_type*.

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -138,7 +138,7 @@ class GAMSModel(Model):
         # Read model solution
         scenario._backend('read_gdx', self.out_file,
                           self.check_solution,
-                          self.comment,
-                          as_str_list(self.equ_list),
-                          as_str_list(self.var_list),
+                          self.comment or '',
+                          as_str_list(self.equ_list) or [],
+                          as_str_list(self.var_list) or [],
                           )

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -225,9 +225,11 @@ def make_dantzig(mp, solve=False):
     scen.init_scalar('f', 90.0, 'USD_per_km')
 
     # initialize the decision variables and equations
-    scen.init_var('z', None, None)
     scen.init_var('x', idx_sets=['i', 'j'])
+    scen.init_var('z', None, None)
+    scen.init_equ('cost')
     scen.init_equ('demand', idx_sets=['j'])
+    scen.init_equ('supply', idx_sets=['i'])
 
     # commit the scenario
     scen.commit("Import Dantzig's transport problem for testing.")

--- a/tests/data/report-describe.txt
+++ b/tests/data/report-describe.txt
@@ -14,6 +14,16 @@
   - 'scenario' (above)
   - 'filters' (above)
 
+'cost-margin:':
+- data_for_quantity('equ', 'cost', 'mrg', ...)
+- 'scenario' (above)
+- 'filters' (above)
+
+'cost:':
+- data_for_quantity('equ', 'cost', 'lvl', ...)
+- 'scenario' (above)
+- 'filters' (above)
+
 'd:':
 - sum(dimensions=['i', 'j'], weights=None, ...)
 - 'd:i-j':
@@ -52,6 +62,18 @@
 'j':
 - ['new-york', 'chicago', 'topeka']
 
+'supply-margin:i':
+- data_for_quantity('equ', 'supply', 'mrg', ...)
+- 'scenario' (above)
+- 'filters' (above)
+
+'supply:':
+- sum(dimensions=['i'], weights=None, ...)
+- 'supply:i':
+  - data_for_quantity('equ', 'supply', 'lvl', ...)
+  - 'scenario' (above)
+  - 'filters' (above)
+
 'x:':
 - sum(dimensions=['i', 'j'], weights=None, ...)
 - 'x:i-j':
@@ -76,9 +98,13 @@
 - list of:
   - 'a:i' (above)
   - 'b:j' (above)
+  - 'cost-margin:' (above)
+  - 'cost:' (above)
   - 'd:i-j' (above)
   - 'demand-margin:j' (above)
   - 'demand:j' (above)
   - 'f:' (above)
+  - 'supply-margin:i' (above)
+  - 'supply:i' (above)
   - 'x:i-j' (above)
   - 'z:' (above)

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,0 +1,12 @@
+from ixmp.testing import make_dantzig
+import pytest
+
+
+@pytest.mark.parametrize('kwargs', [
+    dict(comment=None),
+    dict(equ_list=None, var_list=['x']),
+    dict(equ_list=['demand', 'supply'], var_list=[]),
+], ids=['null-comment', 'null-list', 'empty-list'])
+def test_GAMSModel(test_mp, test_data_path, kwargs):
+    s = make_dantzig(test_mp)
+    s.solve(test_data_path / 'transport_ixmp', **kwargs)

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -173,7 +173,8 @@ def test_reporter_from_dantzig(test_mp, test_data_path):
 
     # 'all' key retrieves all quantities
     obs = {da.name for da in rep.get('all')}
-    exp = set('a b d f demand demand-margin z x'.split())
+    exp = set(('a b d f x z cost cost-margin demand demand-margin supply '
+               'supply-margin').split())
     assert obs == exp
 
     # Shorthand for retrieving a full key name


### PR DESCRIPTION
iiasa/message_ix#223 test failures reveal that the equ_list and var_list args need to be converted to Java types when reading model solutions from GDX files. This PR makes that change.

It also:
1. Adds test_model.py and test_GAMSModel().
2. Improves testing.make_dantzig(). Previously, init_equ() was only called for the equation 'demand', and not for 'cost' or 'supply'.
3. Adjusts the reporting tests per item 2 above.

## How to review

- Confirm that CI passes.
- Confirm that tests of iiasa/message_ix#223 pass with these changes.

## PR checklist

- [x] Tests added.
- [x] ~Documentation added.~ N/A
- [ ] Release notes updated.