### PR TITLE
Add CachingBackend, address performance of JDBCBackend.item_get_elements

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -20,7 +20,8 @@ Configuration for ixmp and its storage backends has been streamlined.
 
 - [#189](https://github.com/iiasa/ixmp/pull/189): Identify and load Scenarios using URLs.
 - [#182](https://github.com/iiasa/ixmp/pull/182),
-  [#200](https://github.com/iiasa/ixmp/pull/200): Add new Backend, Model APIs and JDBCBackend, GAMSModel classes.
+  [#200](https://github.com/iiasa/ixmp/pull/200),
+  [#213](https://github.com/iiasa/ixmp/pull/213): Add new Backend, Model APIs and CachingBackend, JDBCBackend, GAMSModel classes.
 - [#188](https://github.com/iiasa/ixmp/pull/188),
   [#195](https://github.com/iiasa/ixmp/pull/195): Enhance reporting.
 - [#177](https://github.com/iiasa/ixmp/pull/177): add ability to pass `gams_args` through `Scenario.solve()`

--- a/doc/source/api-backend.rst
+++ b/doc/source/api-backend.rst
@@ -22,13 +22,8 @@ Provided backends
 
    JDBCBackend supports:
 
-   - ``dbtype='HSQLDB'``: HyperSQL databases in local files.
-   - Remote databases. This is accomplished by creating a :class:`ixmp.Platform` with the ``dbprops`` argument pointing a file that specifies JDBC information. For instance::
-
-       jdbc.driver = oracle.jdbc.driver.OracleDriver
-       jdbc.url = jdbc:oracle:thin:@database-server.example.com:1234:SCHEMA
-       jdbc.user = USER
-       jdbc.pwd = PASSWORD
+   - Databases in local files (HyperSQL) using ``driver='hsqldb'`` and the *path* argument.
+   - Remote, Oracle databases using ``driver='oracle'`` and the *url*, *username* and *password* arguments.
 
    It has the following methods that are not part of the overall :class:`Backend` API:
 
@@ -38,10 +33,29 @@ Provided backends
       read_gdx
       write_gdx
 
+   JDBCBackend caches values in memory to improve performance when repeatedly reading data from the same items with :meth:`.par`, :meth:`.equ`, or :meth:`.var`.
+
+   .. tip:: If repeatedly accessing the same item with different *filters*:
+
+      1. First, access the item by calling e.g. :meth:`.par` *without* any filters.
+         This causes the full contents of the item to be loaded into cache.
+      2. Then, access by making multiple :meth:`.par` calls with different *filters* arguments.
+         The cache value is filtered and returned without further access to the database.
+
+   .. tip:: Modifying an item by adding or deleting elements invalidates its cache.
+
 .. automethod:: ixmp.backend.jdbc.start_jvm
 
 Backend API
 -----------
+
+.. currentmodule:: ixmp.backend.base
+
+.. autosummary::
+
+   ixmp.backend.FIELDS
+   ixmp.backend.base.Backend
+   ixmp.backend.base.CachingBackend
 
 - :class:`ixmp.Platform` implements a *user-friendly* API for scientific programming.
   This means its methods can take many types of arguments, check, and transform them—in a way that provides modeler-users with easy, intuitive workflows.
@@ -56,8 +70,6 @@ Backend API
 
 
 .. autodata:: ixmp.backend.FIELDS
-
-.. currentmodule:: ixmp.backend.base
 
 .. autoclass:: ixmp.backend.base.Backend
    :members:

--- a/doc/source/api-backend.rst
+++ b/doc/source/api-backend.rst
@@ -51,6 +51,10 @@ Backend API
   - :class:`Platform <ixmp.Platform>` code is not affected by where and how data is stored; it merely handles user arguments and then makes, usually, a single :class:`Backend` call.
   - :class:`Backend` code does not need to perform argument checking; merely store and retrieve data reliably.
 
+- Additional Backends may inherit from :class:`Backend` or
+  :class:`CachingBackend`.
+
+
 .. autodata:: ixmp.backend.FIELDS
 
 .. currentmodule:: ixmp.backend.base
@@ -143,3 +147,12 @@ Backend API
       cat_get_elements
       cat_list
       cat_set_elements
+
+
+.. autoclass:: ixmp.backend.base.CachingBackend
+   :members:
+   :private-members:
+
+   CachingBackend stores cache values for multiple :class:`.TimeSeries`/:class:`Scenario` objects, and for multiple values of a *filters* argument.
+
+   Subclasses **must** call :meth:`cache`, :meth:`cache_get`, and :meth:`cache_invalidate` as appropriate to manage the cache; CachingBackend does not enforce any such logic.

--- a/doc/source/api-python.rst
+++ b/doc/source/api-python.rst
@@ -124,7 +124,6 @@ Scenario
       add_par
       add_set
       change_scalar
-      clear_cache
       clone
       equ
       equ_list

--- a/doc/source/reporting.rst
+++ b/doc/source/reporting.rst
@@ -136,24 +136,22 @@ Others:
      >>> k1.drop('a', 'c') == k2.drop('a') == 'foo:b'
      True
 
-   Notes
-   -----
-   A Key has the same hash, and compares equal to its ``str()``. ``repr(key)``
-   prints the Key in angle brackets ('<>') to signify it is a Key object.
+   Some notes:
 
-   >>> repr(k1)
-   <foo:a-b-c>
+   - A Key has the same hash, and compares equal to its ``str()``.
+     ``repr(key)`` prints the Key in angle brackets ('<>') to signify it is a Key object.
 
-   Keys are *immutable*: the properties :attr:`name`, :attr:`dims`, and
-   :attr:`tag` are read-only, and the methods :meth:`append`, :meth:`drop`, and
-   :meth:`add_tag` return *new* Key objects.
+     >>> repr(k1)
+     <foo:a-b-c>
 
-   Keys may be generated concisely by defining a convenience method:
+   - Keys are *immutable*: the properties :attr:`name`, :attr:`dims`, and :attr:`tag` are read-only, and the methods :meth:`append`, :meth:`drop`, and :meth:`add_tag` return *new* Key objects.
 
-   >>> def foo(dims):
-   >>>     return Key('foo', dims.split())
-   >>> foo('a b c')
-   foo:a-b-c
+   - Keys may be generated concisely by defining a convenience method:
+
+     >>> def foo(dims):
+     >>>     return Key('foo', dims.split())
+     >>> foo('a b c')
+     foo:a-b-c
 
 
 Computations

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -764,12 +764,20 @@ class Backend(ABC):
 
 
 class CachingBackend(Backend):
-    """Backend with additional features for caching values."""
+    """Backend with additional features for caching data."""
+
+    #: Cache of values. Keys are given by :meth:`_cache_key`; values depend on
+    #: the subclass' usage of the cache.
     _cache = {}
+
+    #: Count of number of times a value was retrieved from cache successfully
+    #: using :meth:`cache_get`.
     _cache_hit = {}
 
     def __init__(self):
-        """Initialize the cache."""
+        super().__init__()
+
+        # Empty the cache
         self._cache = {}
         self._cache_hit = {}
 
@@ -777,12 +785,21 @@ class CachingBackend(Backend):
     def _cache_key(self, ts, ix_type, name, filters=None):
         """Return a hashable cache key.
 
+        ixmp *filters* (a :class:`dict` of :class:`list`) are converted to a
+        unique id that is hashable.
+
         Parameters
         ----------
         ts : .TimeSeries
         ix_type : str
         name : str
         filters : dict
+
+        Returns
+        -------
+        tuple
+            A hashable key with 4 elements for *ts*, *ix_type*, *name*, and
+            *filters*.
         """
         ts = id(ts)
         if filters is None or len(filters) == 0:
@@ -793,7 +810,17 @@ class CachingBackend(Backend):
             return (ts, ix_type, name, filters)
 
     def cache_get(self, ts, ix_type, name, filters):
-        """Retrieve value from cache."""
+        """Retrieve value from cache.
+
+        The value in :attr:`_cache` is copied to avoid cached values being
+        modified by user code. :attr:`_cache_hit` is incremented.
+
+        Raises
+        ------
+        KeyError
+            If the key for *ts*, *ix_type*, *name* and *filters* is not in the
+            cache.
+        """
         key = self._cache_key(ts, ix_type, name, filters)
 
         if key in self._cache:
@@ -803,7 +830,14 @@ class CachingBackend(Backend):
             raise KeyError(ts, ix_type, name, filters)
 
     def cache(self, ts, ix_type, name, filters, value):
-        """Store value in cache."""
+        """Store *value* in cache.
+
+        Returns
+        -------
+        bool
+            :obj:`True` if the key was already in the cache and its value was
+            overwritten.
+        """
         key = self._cache_key(ts, ix_type, name, filters)
 
         refreshed = key in self._cache
@@ -812,10 +846,15 @@ class CachingBackend(Backend):
         return refreshed
 
     def cache_invalidate(self, ts, ix_type=None, name=None, filters=None):
-        """Invalidate all cached values for *ix_type* and *name*.
+        """Invalidate cached values.
 
-        If *filters* is :obj:`None` (the default), all filtered values are
-        also invalidated. If all argument are none, all
+        With all arguments given, single key/value is removed from the cache.
+        Otherwise, multiple keys/values are removed:
+
+        - *ts* only: all cached values associated with the :class:`.TimeSeries`
+          or :class:`.Scenario` object.
+        - *ts*, *ix_type*, and *name*: all cached values associated with the
+          ixmp item, whether filtered or unfiltered.
         """
         key = self._cache_key(ts, ix_type, name, filters)
 

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -1,4 +1,6 @@
 from abc import ABC, abstractmethod
+from copy import copy
+import json
 
 from ixmp.core import TimeSeries, Scenario
 
@@ -759,3 +761,69 @@ class Backend(ABC):
         -------
         None
         """
+
+
+class CachingBackend(Backend):
+    """Backend with additional features for caching values."""
+    _cache = {}
+    _cache_hit = {}
+
+    def __init__(self):
+        """Initialize the cache."""
+        self._cache = {}
+        self._cache_hit = {}
+
+    @classmethod
+    def _cache_key(self, ts, ix_type, name, filters=None):
+        """Return a hashable cache key.
+
+        Parameters
+        ----------
+        ts : .TimeSeries
+        ix_type : str
+        name : str
+        filters : dict
+        """
+        ts = id(ts)
+        if filters is None or len(filters) == 0:
+            return (ts, ix_type, name)
+        else:
+            # Convert filters into a hashable object
+            filters = hash(json.dumps(sorted(filters.items())))
+            return (ts, ix_type, name, filters)
+
+    def cache_get(self, ts, ix_type, name, filters):
+        """Retrieve value from cache."""
+        key = self._cache_key(ts, ix_type, name, filters)
+
+        if key in self._cache:
+            self._cache_hit[key] = self._cache_hit.setdefault(key, 0) + 1
+            return copy(self._cache[key])
+        else:
+            raise KeyError(ts, ix_type, name, filters)
+
+    def cache(self, ts, ix_type, name, filters, value):
+        """Store value in cache."""
+        key = self._cache_key(ts, ix_type, name, filters)
+
+        refreshed = key in self._cache
+        self._cache[key] = value
+
+        return refreshed
+
+    def cache_invalidate(self, ts, ix_type=None, name=None, filters=None):
+        """Invalidate all cached values for *ix_type* and *name*.
+
+        If *filters* is :obj:`None` (the default), all filtered values are
+        also invalidated. If all argument are none, all
+        """
+        key = self._cache_key(ts, ix_type, name, filters)
+
+        if filters is None:
+            i = slice(1) if (ix_type is name is None) else slice(3)
+            to_remove = filter(lambda k: k[i] == key[i], self._cache.keys())
+        else:
+            to_remove = [key]
+
+        for key in list(to_remove):
+            self._cache.pop(key)

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -551,14 +551,16 @@ class JDBCBackend(CachingBackend):
                                   columns=columns) \
                        .astype(dtypes)
 
+            # Copy vectors from Java into DataFrame columns
+            # NB [:] causes JPype to use a faster code path
             for i in range(len(idx_sets)):
-                result.iloc[:, i] = item.getCol(i, jList)
+                result.iloc[:, i] = item.getCol(i, jList)[:]
             if type == 'par':
-                result.loc[:, 'value'] = item.getValues(jList)
-                result.loc[:, 'unit'] = item.getUnits(jList)
+                result.loc[:, 'value'] = item.getValues(jList)[:]
+                result.loc[:, 'unit'] = item.getUnits(jList)[:]
             elif type in ('equ', 'var'):
-                result.loc[:, 'lvl'] = item.getLevels(jList)
-                result.loc[:, 'mrg'] = item.getMarginals(jList)
+                result.loc[:, 'lvl'] = item.getLevels(jList)[:]
+                result.loc[:, 'mrg'] = item.getMarginals(jList)[:]
         elif type == 'set':
             # Index sets
             result = pd.Series(item.getCol(0, jList))

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -531,11 +531,8 @@ class JDBCBackend(CachingBackend):
             # Prepare dtypes for index columns
             dtypes = {}
             for idx_name, idx_set in zip(columns, idx_sets):
-                if idx_set == 'year':
-                    dtypes[idx_name] = int
-                else:
-                    dtypes[idx_name] = CategoricalDtype(
-                        self.item_get_elements(s, 'set', idx_set))
+                dtypes[idx_name] = CategoricalDtype(
+                    self.item_get_elements(s, 'set', idx_set))
 
             # Prepare dtypes for additional columns
             if type == 'par':

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -11,7 +11,6 @@ from .model import get_model
 from .utils import (
     as_str_list,
     check_year,
-    filtered,
     logger,
     parse_url
 )
@@ -617,9 +616,9 @@ class Scenario(TimeSeries):
             warn('Using `ixmp.Scenario` for MESSAGE-scheme scenarios is '
                  'deprecated, please use `message_ix.Scenario`')
 
-        # Initialize cache
-        self._cache = cache
-        self._pycache = {}
+    @property
+    def _cache(self):
+        return hasattr(self.platform._backend, '_cache')
 
     @classmethod
     def from_url(cls, url, errors='warn'):
@@ -678,37 +677,11 @@ class Scenario(TimeSeries):
         if not self._cache:
             raise ValueError('Cache must be enabled to load scenario data')
 
-        funcs = {
-            'set': (self.set_list, self.set),
-            'par': (self.par_list, self.par),
-            'var': (self.var_list, self.var),
-            'equ': (self.equ_list, self.equ),
-        }
-        for ix_type, (list_func, get_func) in funcs.items():
+        for ix_type in 'equ', 'par', 'set', 'var':
             logger().info('Caching {} data'.format(ix_type))
-            for item in list_func():
-                get_func(item)
-
-    def _element(self, ix_type, name, filters=None, cache=None):
-        """Return a pd.DataFrame of item elements."""
-        cache_key = (ix_type, name)
-
-        # if dataframe in python cache, retrieve from there
-        if cache_key in self._pycache:
-            return filtered(self._pycache[cache_key], filters)
-
-        # if no cache, retrieve from Backend with filters
-        if filters is not None and not self._cache:
-            return self._backend('item_get_elements', ix_type, name, filters)
-
-        # otherwise, retrieve from Java and keep in python cache
-        df = self._backend('item_get_elements', ix_type, name, None)
-
-        # save if using memcache
-        if self._cache:
-            self._pycache[cache_key] = df
-
-        return filtered(df, filters)
+            get_func = getattr(self, ix_type)
+            for name in getattr(self, '{}_list'.format(ix_type))():
+                get_func(name)
 
     def idx_sets(self, name):
         """Return the list of index sets for an item (set, par, var, equ)
@@ -799,7 +772,7 @@ class Scenario(TimeSeries):
         -------
         pandas.DataFrame
         """
-        return self._element('set', name, filters, **kwargs)
+        return self._backend('item_get_elements', 'set', name, filters)
 
     def add_set(self, name, key, comment=None):
         """Add elements to an existing set.
@@ -825,7 +798,6 @@ class Scenario(TimeSeries):
         """
         # TODO expand docstring (here or in doc/source/api.rst) with examples,
         #      per test_core.test_add_set.
-        self.clear_cache(name=name, ix_type='set')
 
         # Get index names for set *name*, may raise KeyError
         idx_names = self.idx_names(name)
@@ -915,8 +887,6 @@ class Scenario(TimeSeries):
         key : dataframe or key list or concatenated string
             elements to be removed
         """
-        self.clear_cache(name=name, ix_type='set')
-
         if key is None:
             self._backend('delete_item', 'set', name)
         else:
@@ -955,7 +925,7 @@ class Scenario(TimeSeries):
         filters : dict
             index names mapped list of index set elements
         """
-        return self._element('par', name, filters, **kwargs)
+        return self._backend('item_get_elements', 'par', name, filters)
 
     def add_par(self, name, key_or_data=None, value=None, unit=None,
                 comment=None, key=None, val=None):
@@ -1060,9 +1030,6 @@ class Scenario(TimeSeries):
         # Store
         self._backend('item_set_elements', 'par', name, elements)
 
-        # Clear cache
-        self.clear_cache(name=name, ix_type='par')
-
     def init_scalar(self, name, val, unit, comment=None):
         """Initialize a new scalar.
 
@@ -1108,7 +1075,6 @@ class Scenario(TimeSeries):
         comment : str, optional
             Description of the change.
         """
-        self.clear_cache(name=name, ix_type='par')
         self._backend('item_set_elements', 'par', name,
                       [(None, float(val), unit, comment)])
 
@@ -1122,8 +1088,6 @@ class Scenario(TimeSeries):
         key : dataframe or key list or concatenated string, optional
             elements to be removed
         """
-        self.clear_cache(name=name, ix_type='par')
-
         if key is None:
             self._backend('delete_item', 'par', name)
         else:
@@ -1162,7 +1126,7 @@ class Scenario(TimeSeries):
         filters : dict
             index names mapped list of index set elements
         """
-        return self._element('var', name, filters, **kwargs)
+        return self._backend('item_get_elements', 'var', name, filters)
 
     def equ_list(self):
         """List all defined equations."""
@@ -1196,7 +1160,7 @@ class Scenario(TimeSeries):
         filters : dict
             index names mapped list of index set elements
         """
-        return self._element('equ', name, filters, **kwargs)
+        return self._backend('item_get_elements', 'equ', name, filters)
 
     def clone(self, model=None, scenario=None, annotation=None,
               keep_solution=True, shift_first_model_year=None, platform=None,
@@ -1295,7 +1259,6 @@ class Scenario(TimeSeries):
             If Scenario has no solution or if `first_model_year` is not `int`.
         """
         if self.has_solution():
-            self.clear_cache()  # reset Python data cache
             check_year(first_model_year, 'first_model_year')
             self._backend('clear_solution', first_model_year)
         else:
@@ -1389,35 +1352,6 @@ class Scenario(TimeSeries):
             if cb_result:
                 # Callback indicates convergence is reached
                 break
-
-    def clear_cache(self, name=None, ix_type=None):
-        """clear the Python cache of item elements
-
-        Parameters
-        ----------
-        name : str, optional
-            item name (`None` clears entire Python cache)
-        ix_type : str, optional
-            type of item (if provided, cache clearing is faster)
-        """
-        # if no name is given, clean the entire cache
-        if name is None:
-            self._pycache = {}
-            return  # exit early
-
-        # remove this element from the cache if it exists
-        key = None
-        keys = self._pycache.keys()
-        if ix_type is not None:
-            key = (ix_type, name) if (ix_type, name) in keys else None
-        else:  # look for it
-            hits = [k for k in keys if k[1] == name]  # 0 is ix_type, 1 is name
-            if len(hits) > 1:
-                raise ValueError('Multiple values named {}'.format(name))
-            if len(hits) == 1:
-                key = hits[0]
-        if key is not None:
-            self._pycache.pop(key)
 
     def get_meta(self, name=None):
         """get scenario metadata

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -925,7 +925,16 @@ class Scenario(TimeSeries):
         filters : dict
             index names mapped list of index set elements
         """
-        return self._backend('item_get_elements', 'par', name, filters)
+        result = self._backend('item_get_elements', 'par', name, filters)
+
+        # FIXME message_ix requires 'year' columns to be returned as integers
+        #       This code should be in a message_ix override of this method.
+        dtypes = {}
+        for idx_set, col_name in zip(self.idx_sets(), self.idx_names()):
+            if idx_set == 'year':
+                dtypes[col_name] = int
+
+        return result.astype(dtypes)
 
     def add_par(self, name, key_or_data=None, value=None, unit=None,
                 comment=None, key=None, val=None):

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -930,11 +930,12 @@ class Scenario(TimeSeries):
         # FIXME message_ix requires 'year' columns to be returned as integers
         #       This code should be in a message_ix override of this method.
         dtypes = {}
-        for idx_set, col_name in zip(self.idx_sets(), self.idx_names()):
+        for idx_set, col_name in zip(self.idx_sets(name),
+                                     self.idx_names(name)):
             if idx_set == 'year':
                 dtypes[col_name] = int
 
-        return result.astype(dtypes)
+        return result.astype(dtypes) if len(dtypes) else result
 
     def add_par(self, name, key_or_data=None, value=None, unit=None,
                 comment=None, key=None, val=None):

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -132,9 +132,6 @@ class GAMSModel(Model):
         # Invoke GAMS
         check_call(command, shell=os.name == 'nt', cwd=model_file.parent)
 
-        # Reset Python data cache
-        scenario.clear_cache()
-
         # Read model solution
         scenario._backend('read_gdx', self.out_file,
                           self.check_solution,

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -224,7 +224,7 @@ def data_for_quantity(ix_type, name, column, scenario, filters=None):
         filters = filters_to_use
 
     # Retrieve quantity data
-    data = scenario._element(ix_type, name, filters)
+    data = getattr(scenario, ix_type)(name, filters)
 
     # ixmp/GAMS scalar is not returned as pd.DataFrame
     if isinstance(data, dict):

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -208,9 +208,10 @@ def data_for_quantity(ix_type, name, column, scenario, filters=None):
     log.debug('Retrieving data for {}'.format(name))
 
     # Only use the relevant filters
+    idx_names = scenario.idx_names(name)
     if filters:
         # Dimensions of the object
-        dims = dims_for_qty(scenario.idx_names(name))
+        dims = dims_for_qty(idx_names)
 
         # Mapping from renamed dimensions to Scenario dimension names
         MAP = get_reversed_rename_dims()
@@ -237,6 +238,9 @@ def data_for_quantity(ix_type, name, column, scenario, filters=None):
         log.warning(f'0 values for {ix_type} {name!r} using filters:'
                     f'\n  {filters!r}\n  Subsequent computations may fail.')
 
+    # Convert categorical dtype to str
+    data = data.astype({col: str for col in idx_names})
+
     # List of the dimensions
     dims = dims_for_qty(data)
 
@@ -258,8 +262,8 @@ def data_for_quantity(ix_type, name, column, scenario, filters=None):
     # Set index if 1 or more dimensions
     if len(dims):
         # First rename, then set index
-        data.rename(columns=RENAME_DIMS, inplace=True)
-        data.set_index(dims, inplace=True)
+        data = data.rename(columns=RENAME_DIMS) \
+                   .set_index(dims)
 
     # Check sparseness
     # try:
@@ -272,20 +276,18 @@ def data_for_quantity(ix_type, name, column, scenario, filters=None):
     # info = (name, shape, filled, size, need_to_chunk)
     # log.debug(' '.join(map(str, info)))
 
-    # Convert to a Dataset, assign attrbutes and name
-    # ds = xr.Dataset.from_dataframe(data)[column]
-    # or to a new "Attribute Series"
-    ds = as_quantity(data[column]) \
+    # Convert to a Quantity, assign attrbutes and name
+    qty = as_quantity(data[column]) \
         .assign_attrs(attrs) \
         .rename(name + ('-margin' if column == 'mrg' else ''))
 
     try:
         # Remove length-1 dimensions for scalars
-        ds = ds.squeeze('index', drop=True)
+        qty = qty.squeeze('index', drop=True)
     except KeyError:
         pass
 
-    return ds
+    return qty
 
 
 def as_attrseries(obj):

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -164,7 +164,7 @@ def filtered(df, filters):
 
     mask = pd.Series(True, index=df.index)
     for k, v in filters.items():
-        isin = df[k].isin(v)
+        isin = df[k].isin(as_str_list(v))
         mask = mask & isin
     return df[mask]
 

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -1,7 +1,6 @@
 """Tests for ixmp.reporting."""
 import os
 
-from click.testing import CliRunner
 import ixmp
 import numpy as np
 import pandas as pd

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -537,9 +537,10 @@ def test_report_size(test_mp):
     # test_mp.add_unit('kg')
     scen = ixmp.Scenario(test_mp, 'size test', 'base', version='new')
 
-    # Dimensions and their lengths
-    dims = 'abcdef'
-    sizes = [1, 5, 21, 21, 89, 377]  # Fibonacci #s; next 1597, 6765
+    # Dimensions and their lengths (Fibonacci numbers)
+    N_dims = 6
+    dims = 'abcdefgh'[:N_dims + 1]
+    sizes = [1, 5, 21, 21, 89, 377, 1597, 6765][:N_dims + 1]
 
     # commented: "377 / 73984365 elements = 0.00051% full"
     # from functools import reduce


### PR DESCRIPTION
This PR:
- **Refactors JDBCBackend.item_get_elements() to *not* use pd.DataFrame.from_dict(),** which can be slow. Instead, an empty pd.DataFrame is allocated and values from the Java side are copied into it.
- **Re-adds `[:]` slice syntax when accessing arrays via JPype.** This was added in 2017 (554c9be) but removed in #182. It is significantly faster than accessing the object without the slice; see jpype-project/jpype#71. Although that issue is closed, this workaround still seems necessary. It is not discussed in the JPype documentation. This PR also adds a comment clearly stating this is necessary. Incorporates #214.
-  **Moves caching out of ixmp.core and into a CachingBackend class.** Other backends can inherit from this class and use its caching features; or just inherit from the base Backend.

In the longer run, we will need to add performance tests (e.g. using [pytest-benchmark](https://pytest-benchmark.readthedocs.io)) to ensure that the ixmp test suite *directly* tests that ixmp has satisfactory performance for data on the scale of MESSAGE-GLOBIOM (~10 dimensions, ~10⁶ rows). That will be a separate issue.

## How to review

- Read the code!
- Try to load large parameters and ensure that performance is better when the cache is hit.
  - Import the code and use a custom script to load some large MESSAGE-GLOBIOM parameters.
  - Change N_dim in `test_report_size` to 8 and run only that test with `pytest -k report_size`.

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.