### PR TITLE
Remove special handling for dimensions indexed by a 'year' set

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -925,17 +925,7 @@ class Scenario(TimeSeries):
         filters : dict
             index names mapped list of index set elements
         """
-        result = self._backend('item_get_elements', 'par', name, filters)
-
-        # FIXME message_ix requires 'year' columns to be returned as integers
-        #       This code should be in a message_ix override of this method.
-        dtypes = {}
-        for idx_set, col_name in zip(self.idx_sets(name),
-                                     self.idx_names(name)):
-            if idx_set == 'year':
-                dtypes[col_name] = int
-
-        return result.astype(dtypes) if len(dtypes) else result
+        return self._backend('item_get_elements', 'par', name, filters)
 
     def add_par(self, name, key_or_data=None, value=None, unit=None,
                 comment=None, key=None, val=None):


### PR DESCRIPTION
#213 mistakenly added code in `ixmp.Scenario.par()` with special treatment for dimensions indexed by a set named 'year'. Per iiasa/message_ix#268 / #218, this is the **wrong place** for such code. It belongs in message_ix. 

*Mea culpa*! The change was too hurried.

See iiasa/message_ix#269, which adds this special handling in the correct place.

## How to review

Check that tests pass.

## PR checklist

<!-- The following items are all **required* if the PR results in changes to
the user behaviour, e.g. new features or fixes to existing behaviour. They are
**optional** if the changes are solely to documentation, CI configuration, etc.

In ambiguous cases, strike them out and add a short explanation, e.g.

- [x] ~Tests added.~ No change in behaviour, simply refactoring.
-->

- ~[ ] Tests added.~ N/A
- ~[ ] Documentation added.~ N/A
- ~[ ] Release notes updated.~ N/A; adjustment to a previous PR.