### PR TITLE
Improving ixmp reporting documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,6 @@ rixmp/source/.Rhistory
 coverage.xml
 htmlcov/
 
-# idea
-.idea/
+# JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio and WebStorm
+/**/.idea
 *.iml

--- a/doc/source/reporting.rst
+++ b/doc/source/reporting.rst
@@ -126,6 +126,8 @@ Others:
      >>> k1 == 'foo:a-b-c'
      True
 
+     Notice that a Key has the same hash, and compares equal (`==`) to its ``str()``.
+
    - in a partial sum over one dimension, e.g. summed along c with dimensions
      a and b:
 
@@ -138,22 +140,22 @@ Others:
      >>> k1.drop('a', 'c') == k2.drop('a') == 'foo:b'
      True
 
-   Some notes:
+   .. note::
+        Some remarks:
 
-   - A Key has the same hash, and compares equal (NOT CLEAR THIS SENTENCE) to its ``str()``.
-     ``repr(key)`` prints the Key in angle brackets ('<>') to signify it is a Key object.
+        - ``repr(key)`` prints the Key in angle brackets ('<>') to signify it is a Key object.
 
-     >>> repr(k1)
-     <foo:a-b-c>
+          >>> repr(k1)
+          <foo:a-b-c>
 
-   - Keys are *immutable*: the properties :attr:`name`, :attr:`dims`, and :attr:`tag` are read-only, and the methods :meth:`append`, :meth:`drop`, and :meth:`add_tag` return *new* Key objects.
+        - Keys are *immutable*: the properties :attr:`name`, :attr:`dims`, and :attr:`tag` are read-only, and the methods :meth:`append`, :meth:`drop`, and :meth:`add_tag` return *new* Key objects.
 
-   - Keys may be generated concisely by defining a convenience method:
+        - Keys may be generated concisely by defining a convenience method:
 
-     >>> def foo(dims):
-     >>>     return Key('foo', dims.split())
-     >>> foo('a b c')
-     foo:a-b-c
+          >>> def foo(dims):
+          >>>     return Key('foo', dims.split())
+          >>> foo('a b c')
+          foo:a-b-c
 
 
 Computations

--- a/doc/source/reporting.rst
+++ b/doc/source/reporting.rst
@@ -98,9 +98,9 @@ Others:
         foo
 
       .. note::
-         Use care when adding literal :class:`str` values (2); these may
-         conflict with keys that identify the results of other
-         computations.
+         Use care when adding literal ``str()`` values as a *computation*
+         argument for :meth:`add`; these may conflict with keys that
+         identify the results of other computations.
 
 
 .. autoclass:: ixmp.reporting.Key

--- a/doc/source/reporting.rst
+++ b/doc/source/reporting.rst
@@ -82,7 +82,9 @@ Others:
 
       - Provide an alias from one *key* to another:
 
-        >>> r.add('aliased name', 'original name')
+        >>> from message_ix.reporting import Reporter
+        >>> rep = Reporter()  # Create a new Reporter object
+        >>> rep.add('aliased name', 'original name')
 
       - Define an arbitrarily complex computation in a Python function that
         operates directly on the :class:`ixmp.Scenario`:
@@ -90,9 +92,9 @@ Others:
         >>> def my_report(scenario):
         >>>     # many lines of code
         >>>     return 'foo'
-        >>> r.add('my report', (my_report, 'scenario'))
-        >>> r.finalize(scenario)
-        >>> r.get('my report')
+        >>> rep.add('my report', (my_report, 'scenario'))
+        >>> rep.finalize(scenario)
+        >>> rep.get('my report')
         foo
 
       .. note::
@@ -138,7 +140,7 @@ Others:
 
    Some notes:
 
-   - A Key has the same hash, and compares equal to its ``str()``.
+   - A Key has the same hash, and compares equal (NOT CLEAR THIS SENTENCE) to its ``str()``.
      ``repr(key)`` prints the Key in angle brackets ('<>') to signify it is a Key object.
 
      >>> repr(k1)

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -90,7 +90,7 @@ class Reporter:
         Returns
         -------
         :class:`Reporter <ixmp.reporting.Reporter>`
-            A Reporter instance containing:
+        A Reporter instance containing:
 
             - A 'scenario' key referring to the *scenario* object.
             - Each parameter, equation, and variable in the *scenario*.
@@ -415,7 +415,7 @@ class Reporter:
 
         Returns
         -------
-        Key
+        :class:`Key`
             The full key of the new quantity.
         """
         # Fetch the full key for each quantity
@@ -442,13 +442,13 @@ class Reporter:
         Parameters
         ----------
         qty: :class:`Key` or str
-            Key of the quantity to be disaggregated.
+            Key of the quantity to be aggregated.
         tag: str
             Additional string to add to the end the key for the aggregated
             quantity.
         dims_or_groups: str or iterable of str or dict
             Name(s) of the dimension(s) to sum over, or nested dict.
-        weights : xr.DataArray, optional
+        weights : :class:`xarray.DataArray`, optional
             Weights for weighted aggregation.
         keep : bool, optional
             Passed to :meth:`computations.aggregate
@@ -480,12 +480,12 @@ class Reporter:
         return self.add(key, comp, strict=True, index=True, sums=sums)
 
     def disaggregate(self, qty, new_dim, method='shares', args=[]):
-        """Add a computation that disaggregates *var* using *method*.
+        """Add a computation that disaggregates *qty* using *method*.
 
         Parameters
         ----------
-        var: hashable
-            Key of the variable to be disaggregated.
+        qty: hashable
+            Key of the quantity to be disaggregated.
         new_dim: str
             Name of the new dimension of the disaggregated variable.
         method: callable or str
@@ -498,7 +498,7 @@ class Reporter:
 
         Returns
         -------
-        Key
+        :class:`Key`
             The key of the newly-added node.
         """
         # Compute the new key

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -90,7 +90,7 @@ class Reporter:
         Returns
         -------
         :class:`Reporter <ixmp.reporting.Reporter>`
-        A Reporter instance containing:
+            A Reporter instance containing:
 
             - A 'scenario' key referring to the *scenario* object.
             - Each parameter, equation, and variable in the *scenario*.

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -20,6 +20,7 @@ __all__ = [
     'disaggregate_shares',
     'load_file',
     'product',
+    'ratio',
     'sum',
     'write_report',
 ]

--- a/ixmp/reporting/key.py
+++ b/ixmp/reporting/key.py
@@ -27,7 +27,7 @@ class Key:
 
         Returns
         -------
-        Key
+        :class:`Key`
         """
         # Determine the base Key
         if isinstance(value, cls):

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -296,7 +296,8 @@ def as_attrseries(obj):
 
 
 def as_sparse_xarray(obj):  # pragma: no cover
-    """Convert *obj* to an :class:`xarray.DataArray` with sparse.COO storage."""
+    """Convert *obj* to an :class:`xarray.DataArray` with sparse.COO
+    storage."""
     import sparse
     from xarray.core.dtypes import maybe_promote
 

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -30,7 +30,7 @@ REPLACE_UNITS = {
 RENAME_DIMS = {}
 
 #: :doc:`pint <pint:index>` unit registry for processing quantity units.
-#: All units handled by :mod:`imxp.reporting` must be either standard SI units,
+#: All units handled by :mod:`ixmp.reporting` must be either standard SI units,
 #: or added to this registry.
 UNITS = pint.UnitRegistry()
 
@@ -296,7 +296,7 @@ def as_attrseries(obj):
 
 
 def as_sparse_xarray(obj):  # pragma: no cover
-    """Convert *obj* to an xr.DataArray with sparse.COO storage."""
+    """Convert *obj* to an :class:`xarray.DataArray` with sparse.COO storage."""
     import sparse
     from xarray.core.dtypes import maybe_promote
 


### PR DESCRIPTION
Corrected typos and performed some formatting to the `ixmp` reporting documentation files in `/reporting`.

This has been done by also editing the _docstrings_ of different methods of the `Reporter` class as well as other main classes.

Please @khaeru go through this small modification when you'll have time so this PR can be either extended or merged as soon as possible.