### PR TITLE
Strip Python 2 compatibility code

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -4,6 +4,11 @@
 
 ## Migration notes
 
+Support for Python 2.7 is dropped as it has reached end-of-life, meaning no further releases will be made even to fix bugs.
+See [PEP-0373](https://legacy.python.org/dev/peps/pep-0373/) and https://python3statement.org.
+``ixmp`` users must upgrade to Python 3.
+
+
 Configuration for ixmp and its storage backends has been streamlined.
 
 - Instead of ``DB_CONFIG_PATH``:
@@ -27,7 +32,8 @@ Configuration for ixmp and its storage backends has been streamlined.
 - [#188](https://github.com/iiasa/ixmp/pull/188),
   [#195](https://github.com/iiasa/ixmp/pull/195): Enhance reporting.
 - [#177](https://github.com/iiasa/ixmp/pull/177): add ability to pass `gams_args` through `Scenario.solve()`
-- [#175](https://github.com/iiasa/ixmp/pull/175): Drop support for Python 2.
+- [#175](https://github.com/iiasa/ixmp/pull/175),
+  [#239](https://github.com/iiasa/ixmp/pull/239): Drop support for Python 2.7.
 - [#174](https://github.com/iiasa/ixmp/pull/174): Set `convertStrings=True` for JPype >= 0.7; see the [JPype changelog](https://jpype.readthedocs.io/en/latest/CHANGELOG.html).
 - [#173](https://github.com/iiasa/ixmp/pull/173): Make AppVeyor CI more robust; support pandas 0.25.0.
 - [#165](https://github.com/iiasa/ixmp/pull/165): Add support for handling geodata.

--- a/ci/appveyor-install.ps1
+++ b/ci/appveyor-install.ps1
@@ -38,11 +38,7 @@ Exec { gams }
 Progress 'Set conda version/path'
 # These correspond to folder naming of miniconda installs on appveyor
 # See https://www.appveyor.com/docs/windows-images-software/#miniconda
-if ( $env:PYTHON_VERSION -eq '2.7' ) {
-  $MC_PYTHON_VERSION = ''
-} else {
-  $MC_PYTHON_VERSION = $env:PYTHON_VERSION.Replace('.', '')
-}
+$MC_PYTHON_VERSION = $env:PYTHON_VERSION.Replace('.', '')
 if ( $env:PYTHON_ARCH -eq '64' ) { $ARCH_LABEL = '-x64' }
 
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -165,7 +165,6 @@ Users developing models using existing *ixmp* functionality **should not** need 
 - (Windows) **C++ compiler.**
 
    - For Python 3: http://landinghub.visualstudio.com/visual-cpp-build-tools
-   - For Python 2: https://www.microsoft.com/en-us/download/details.aspx?id=44266
 
 - **Git.** Use one of:
 

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -282,8 +282,7 @@ def run_notebook(nb_path, tmp_path, env=os.environ, kernel=None):
     """
     major_version = sys.version_info[0]
     kernel = kernel or 'python{}'.format(major_version)
-    # str() here is for python2 compatibility
-    os.chdir(str(nb_path.parent))
+    os.chdir(nb_path.parent)
     fname = tmp_path / 'test.ipynb'
     args = [
         "jupyter", "nbconvert", "--to", "notebook", "--execute",
@@ -292,8 +291,7 @@ def run_notebook(nb_path, tmp_path, env=os.environ, kernel=None):
         "--output", str(fname), str(nb_path)]
     subprocess.check_call(args, env=env)
 
-    # str() here is for python2 compatibility
-    nb = nbformat.read(io.open(str(fname), encoding='utf-8'),
+    nb = nbformat.read(io.open(fname, encoding='utf-8'),
                        nbformat.current_nbformat)
 
     errors = [

--- a/rixmp/tests/testthat/test_core.R
+++ b/rixmp/tests/testthat/test_core.R
@@ -53,9 +53,6 @@ test_that('set, mapping sets and par values can be set on a Scenario', {
   a = scen$par('a')
   attributes(a)$pandas.index = NULL
 
-  # Python 2.7: ensure consistent column order in the returned data.frame
-  a <- a[, c('i', 'value', 'unit')]
-
   expect_equal(a, a.df)
 })
 

--- a/rixmp/tests/testthat/test_reporting.R
+++ b/rixmp/tests/testthat/test_reporting.R
@@ -1,8 +1,4 @@
 test_that('the canning problem can be reported', {
-  sys <- import('sys')
-  skip_if(sys$version_info$major == 2,
-          'Experimental reporting does not support Python 2.7.')
-
   # Create the Scenario
   mp <- test_mp()
   scen <- ixmp$testing$make_dantzig(mp)

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,4 @@
 #!/usr/bin/env python
-from __future__ import print_function
-
 import glob
 
 from setuptools import find_packages, setup

--- a/tests/test_access.py
+++ b/tests/test_access.py
@@ -38,8 +38,7 @@ def create_local_testdb(db_path, data_path, db='ixmptest',
     """
     # Copy test database
     dst = Path(db_path) / 'testdb'
-    # str() here is for py2 compatibility
-    shutil.copytree(str(data_path), str(dst))
+    shutil.copytree(data_path, dst)
 
     # Create properties file
     props = (Path(data_path) / 'test_auth.properties_template').read_text()

--- a/tests/test_r.py
+++ b/tests/test_r.py
@@ -45,8 +45,7 @@ def test_r_build_and_check(r_args):
         # - Do not cross-build/-check e.g. i386 on x64 Appveyor workers
         # - Do not build manual (avoids overhead of LaTeX install)
         cmd.extend(['--no-multiarch', '--no-manual'])
-    # Path() here is required because of str() in r_args for Python 2.7 compat
-    cmd.extend(map(str, Path(r_args['cwd']).glob('*.tar.gz')))
+    cmd.extend(map(str, r_args['cwd'].glob('*.tar.gz')))
     info = run(cmd, **r_args)
 
     try:
@@ -55,11 +54,6 @@ def test_r_build_and_check(r_args):
         # Copy the log to stdout
         sys.stdout.write(info.stdout)
         raise
-    except AttributeError:
-        # Python 2.7
-        if info.returncode != 0:
-            sys.stdout.write(info.stdout)
-            raise
 
 
 @pytest.mark.rixmp

--- a/tests/test_r.py
+++ b/tests/test_r.py
@@ -1,19 +1,7 @@
-try:
-    from pathlib import Path
-except ImportError:
-    from pathlib2 import Path
+from pathlib import Path
 import re
 import subprocess
-try:
-    from subprocess import run
-except ImportError:
-    # Python 2.7 compatibility
-    def run(*args, **kwargs):
-        popen = subprocess.Popen(*args, **kwargs)
-        stdout, _ = popen.communicate()
-        # Convert stream to sequence
-        popen.stdout = str(stdout)
-        return popen
+from subprocess import run
 import sys
 
 import pytest
@@ -37,8 +25,7 @@ def r_args(request, tmp_env, test_data_path, tmp_path_factory):
     # Show all lines on tests failure
     tmp_env['_R_CHECK_TESTS_NLINES_'] = '0'
 
-    # str() here is for Python 2.7 compatibility on Windows
-    args = dict(cwd=str(rixmp_path), env=tmp_env, stdout=subprocess.PIPE,
+    args = dict(cwd=rixmp_path, env=tmp_env, stdout=subprocess.PIPE,
                 stderr=subprocess.STDOUT)
 
     arg = 'text' if sys.version_info[:2] >= (3, 7) else 'universal_newlines'


### PR DESCRIPTION
Closes #158 by removing remaining Python 2 compatibility code.

See also iiasa/message_ix#285.

## How to review

- View changes.
- Note that the CI checks all pass.

## PR checklist

- [x] ~Tests added.~ N/A
- [x] Documentation added.
- [x] Release notes updated.