### PR TITLE
Add 'ixmp list' CLI command

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -18,6 +18,7 @@ Configuration for ixmp and its storage backends has been streamlined.
 
 ## All changes
 
+- [#240](https://github.com/iiasa/ixmp/pull/240): Add ``ixmp list`` command-line tool.
 - [#225](https://github.com/iiasa/ixmp/pull/225): Ensure filters are always converted to string.
 - [#189](https://github.com/iiasa/ixmp/pull/189): Identify and load Scenarios using URLs.
 - [#182](https://github.com/iiasa/ixmp/pull/182),

--- a/doc/source/api-python.rst
+++ b/doc/source/api-python.rst
@@ -203,6 +203,8 @@ Utilities
 
 .. automethod:: ixmp.utils.parse_url
 
+.. automethod:: ixmp.utils.format_scenario_list
+
 
 Testing utilities
 -----------------

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -142,5 +142,4 @@ def list_command(context, **kwargs):
             model=context.get('model name', None),
             scenario=context.get('scenario name', None),
             **kwargs)
-        )
-    )
+    ))

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -112,3 +112,49 @@ def platform(action, name, values):
     elif action == 'list':
         for key, info in ixmp.config.values['platform'].items():
             print(key, info)
+
+
+@main.command('list')
+@click.option('--default-only', is_flag=True,
+              help='Only display scenarios with a default version.')
+@click.pass_obj
+def list_command(context, default_only):
+    """List scenarios on the --platform."""
+    scenarios = context['mp'].scenario_list(default=default_only)
+
+    N_model = 0
+
+    for model, group_m in scenarios.groupby('model'):
+        N_model += 1
+        print('\n', model, sep='')
+
+        for scenario_name, group_s in group_m.groupby('scenario'):
+            max = group_s.version.max()
+
+            try:
+                mask = group_s.is_default.astype(bool)
+                default = group_s.loc[mask, 'version'].iat[0]
+            except IndexError:
+                default = max
+
+            line = '  {}#{}'.format(scenario_name, default)
+
+            count = len(group_s)
+            if count > 1:
+                line += '\t'
+                min = group_s.version.min()
+
+                if default != max:
+                    line += '{}–{}'.format(min, max)
+
+                line += '({} versions)'.format(count)
+
+            print(line)
+
+    print(
+        '',
+        '{} model name(s)'.format(N_model),
+        '{} scenario name(s)'.format(len(scenarios['scenario'].unique())),
+        '{} (model, scenario) combination(s)'
+        .format(len(scenarios.groupby(['model', 'scenario']))),
+        sep='\n')

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import ixmp
+from ixmp.testing import make_dantzig
 import pandas as pd
 import pandas.testing as pdt
 
@@ -57,6 +58,17 @@ def test_config(ixmp_cli):
     # get() with a value is an invalid call
     result = ixmp_cli.invoke(['config', 'get', 'test key', 'BADVALUE'])
     assert result.exit_code != 0
+
+
+def test_list(ixmp_cli, test_mp):
+    # CLI works; nothing returned with a --match option that matches nothing
+    r = ixmp_cli.invoke(['--platform', test_mp.name, 'list', '--match', 'foo'])
+    assert r.output == """
+0 model name(s)
+0 scenario name(s)
+0 (model, scenario) combination(s)
+0 total scenarios
+"""
 
 
 def test_platform(ixmp_cli, tmp_path):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 
 import ixmp
-from ixmp.testing import make_dantzig
 import pandas as pd
 import pandas.testing as pdt
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -7,6 +7,7 @@ import pytest
 from pytest import mark, param
 
 from ixmp import utils
+from ixmp.testing import make_dantzig
 
 
 def make_obs(fname, exp, **kwargs):
@@ -113,3 +114,31 @@ def test_parse_url(url, p, s):
     # Expected platform and scenario information is returned
     assert platform_info == p
     assert scenario_info == s
+
+
+def test_format_scenario_list(test_mp):
+    make_dantzig(test_mp)
+
+    exp = [
+        '',
+        'Douglas Adams/',
+        '  Hitchhiker#1',
+        '',
+        'canning problem/',
+        '  standard#3  1–3',
+        '',
+        '2 model name(s)',
+        '2 scenario name(s)',
+        '2 (model, scenario) combination(s)',
+        '4 total scenarios',
+    ]
+
+    # Expected results
+    assert exp == utils.format_scenario_list(test_mp)
+
+    # With as_url=True
+    exp = list(map(lambda s: s.format(test_mp.name), [
+        'ixmp://{}/Douglas Adams/Hitchhiker#1',
+        'ixmp://{}/canning problem/standard#3',
+    ]))
+    assert exp == utils.format_scenario_list(test_mp, as_url=True)


### PR DESCRIPTION
Closes #202.

## How to review

- Run the command against a platform/backend with many Scenarios, e.g. `$ ixmp --platform GP3 list`.
- Run `$ ixmp list --help`, view and try the different options.
- Is there any other functionality that would be useful?

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.