### PR TITLE
added --editable to install docu

### DIFF
--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -100,7 +100,7 @@ Install *ixmp* from source
 6. (Optional) Run the built-in test suite to check that *ixmp* functions
    correctly on your system::
 
-    $ pip install .[tests]
+    $ pip install --editable .[tests]
     $ py.test
 
 


### PR DESCRIPTION
Closely related with PR iiasa/message_ix#291

Added `--editable` also in the point `6.` of the installation step from source. Users who'd run that command after installing ixmp using `--editable` in step `5.` would deprecate that flag and therefore not being able to run the tests.


- [x] Documentation added.