### PR TITLE
Adjust for pint 0.10

### DIFF
--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -630,7 +630,7 @@ class JDBCBackend(CachingBackend):
                 jobj.addElement(*args)
         except java.IxException as e:
             msg = e.message()
-            if 'does not have an element' in msg:
+            if ('does not have an element' in msg) or ('The unit' in msg):
                 # Re-raise as Python ValueError
                 raise ValueError(msg) from e
             else:  # pragma: no cover

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -413,9 +413,12 @@ def test_reporting_platform_units(test_mp, caplog):
     bad_units = [
         ('-', '-', '-'),
         ('???', r'\?\?\?', r'\?'),
-        ('G$', r'G\$', r'\$')
+        ('E$', r'E\$', r'\$')
     ]
     for unit, expr, chars in bad_units:
+        # Add the unit
+        test_mp.add_unit(unit)
+
         # Overwrite the parameter
         x['unit'] = unit
         scen.add_par('x', x)


### PR DESCRIPTION
The release of pint 0.10 caused `test_reporting_platform_units` to fail; see e.g. [Travis job #841.1](https://travis-ci.org/iiasa/ixmp/jobs/634186339#L2053).
This PR adjusts the tests.

## PR checklist

- [x] Tests added.
- [x] ~Documentation added.~ N/A
- [x] ~Release notes updated.~ N/A