### PR TITLE
Copy input dataframe in add_par() to avoid changing its contents in the calling scope

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -28,7 +28,8 @@ Configuration for ixmp and its storage backends has been streamlined.
 - [#182](https://github.com/iiasa/ixmp/pull/182),
   [#200](https://github.com/iiasa/ixmp/pull/200),
   [#213](https://github.com/iiasa/ixmp/pull/213),
-  [#217](https://github.com/iiasa/ixmp/pull/217): Add new Backend, Model APIs and CachingBackend, JDBCBackend, GAMSModel classes.
+  [#217](https://github.com/iiasa/ixmp/pull/217),
+  [#245](https://github.com/iiasa/ixmp/pull/245): Add new Backend, Model APIs and CachingBackend, JDBCBackend, GAMSModel classes.
 - [#188](https://github.com/iiasa/ixmp/pull/188),
   [#195](https://github.com/iiasa/ixmp/pull/195): Enhance reporting.
 - [#177](https://github.com/iiasa/ixmp/pull/177): add ability to pass `gams_args` through `Scenario.solve()`

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -967,7 +967,7 @@ class Scenario(TimeSeries):
             # dict containing data
             data = pd.DataFrame.from_dict(key_or_data, orient='columns')
         elif isinstance(key_or_data, pd.DataFrame):
-            data = key_or_data
+            data = key_or_data.copy()
             if 'value' in data.columns and value is not None:
                 raise ValueError('both key_or_data.value and value supplied')
         else:

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -90,7 +90,7 @@ def test_gh_210(test_mp):
 
     # foo_data is not modified by add_par()
     scen.add_par('foo', foo_data)
-    assert foo_data.columns == columns
+    assert all(foo_data.columns == columns)
 
 
 def test_get_scalar(test_mp):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -77,6 +77,22 @@ def test_range(test_mp):
     scen.add_par('new_par', ii, [1.2] * len(ii))
 
 
+def test_gh_210(test_mp):
+    scen = ixmp.Scenario(test_mp, *can_args, version='new')
+    i = ['i0', 'i1', 'i2']
+
+    scen.init_set('i')
+    scen.add_set('i', i)
+    scen.init_par('foo', idx_sets='i')
+
+    columns = ['i', 'value']
+    foo_data = pd.DataFrame(zip(i, [10, 20, 30]), columns=columns)
+
+    # foo_data is not modified by add_par()
+    scen.add_par('foo', foo_data)
+    assert foo_data.columns == columns
+
+
 def test_get_scalar(test_mp):
     scen = ixmp.Scenario(test_mp, *can_args)
     obs = scen.scalar('f')


### PR DESCRIPTION
Closes #210; FYI @Jihoon.

## How to review

`pytest -k gh_210` or run any user code that calls `Scenario.add_par()` with a pd.DataFrame as the second argument.

## PR checklist

- [x] Tests added.
- [x] ~Documentation added.~ N/A, fixes code to expected behaviour.
- [x] Release notes updated.