### PR TITLE
Ensure TimeSeries/Scenario.version is set when cloning

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -30,7 +30,8 @@ Configuration for ixmp and its storage backends has been streamlined.
   [#213](https://github.com/iiasa/ixmp/pull/213),
   [#217](https://github.com/iiasa/ixmp/pull/217),
   [#230](https://github.com/iiasa/ixmp/pull/230),
-  [#245](https://github.com/iiasa/ixmp/pull/245): Add new Backend, Model APIs and CachingBackend, JDBCBackend, GAMSModel classes.
+  [#245](https://github.com/iiasa/ixmp/pull/245),
+  [#246](https://github.com/iiasa/ixmp/pull/246): Add new Backend, Model APIs and CachingBackend, JDBCBackend, GAMSModel classes.
 - [#188](https://github.com/iiasa/ixmp/pull/188),
   [#195](https://github.com/iiasa/ixmp/pull/195): Enhance reporting.
 - [#177](https://github.com/iiasa/ixmp/pull/177): add ability to pass `gams_args` through `Scenario.solve()`

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -317,11 +317,14 @@ class JDBCBackend(CachingBackend):
         # Add to index
         self.jindex[ts] = jobj
 
+        # Retrieve or check the version
         if version is None:
-            # Update the version attribute
-            ts.version = jobj.getVersion()
+            version = jobj.getVersion()
         else:
             assert version == jobj.getVersion()
+
+        # Update the version attribute
+        ts.version = version
 
         if isinstance(ts, Scenario):
             # Also retrieve the scheme

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,6 +27,9 @@ def test_run_clone(test_mp, test_data_path, caplog):
     assert np.isclose(scen2.var('z')['lvl'], 153.675)
     pdt.assert_frame_equal(scen2.timeseries(iamc=True), TS_DF)
 
+    # version attribute of the clone matches the original (GitHub #211)
+    assert scen2.version == scen.version
+
     # cloning with `keep_solution=True` and `first_model_year` raises a warning
     scen.clone(keep_solution=True, shift_first_model_year=2005)
     assert ('Overriding keep_solution=True for shift_first_model_year'

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -27,8 +27,8 @@ def test_run_clone(test_mp, test_data_path, caplog):
     assert np.isclose(scen2.var('z')['lvl'], 153.675)
     pdt.assert_frame_equal(scen2.timeseries(iamc=True), TS_DF)
 
-    # version attribute of the clone matches the original (GitHub #211)
-    assert scen2.version == scen.version
+    # version attribute of the clone increments the original (GitHub #211)
+    assert scen2.version == scen.version + 1
 
     # cloning with `keep_solution=True` and `first_model_year` raises a warning
     scen.clone(keep_solution=True, shift_first_model_year=2005)


### PR DESCRIPTION
Closes #211; FYI @Jihoon.

## How to review

- `pytest -k run_clone`.
- Note that the CI checks all pass.

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.