### PR TITLE
update jdbc.py to allow using .remove_set()

### DIFF
--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -503,7 +503,7 @@ class JDBCBackend(CachingBackend):
                 raise
 
     def delete_item(self, s, type, name):
-        getattr(self.jindex[s], f'remove{type.title()}')()
+        getattr(self.jindex[s], f'remove{type.title()}')(name)
         self.cache_invalidate(s, type, name)
 
     def item_index(self, s, name, sets_or_names):

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -219,6 +219,16 @@ def test_set(test_mp):
     foo = {'i1', 'i2', 'i3', 'i6', 'i7', 'i8'} - {'i2'} - {'i7', 'i8'}
     assert foo == set(scen.set('foo')['dim_i'])
 
+    # Remove a set completely.
+    scen2 = ixmp.Scenario(test_mp, *can_args, version=2)
+    scen2.check_out()
+    scen2.init_set('h')
+    scen2.add_set('h', 'test')
+    scen2.remove_set('h')
+    obs = {}
+    exp = set(scen2.set('h'))
+    assert obs == exp
+
 
 # make sure that changes to a scenario are copied over during clone
 def test_add_clone(test_mp):
@@ -226,7 +236,7 @@ def test_add_clone(test_mp):
     scen.check_out()
     scen.init_set('h')
     scen.add_set('h', 'test')
-    scen.commit("adding an index set 'h', wiht element 'test'")
+    scen.commit("adding an index set 'h', with element 'test'")
 
     scen2 = scen.clone(keep_solution=False)
     obs = scen2.set('h')

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -219,15 +219,14 @@ def test_set(test_mp):
     foo = {'i1', 'i2', 'i3', 'i6', 'i7', 'i8'} - {'i2'} - {'i7', 'i8'}
     assert foo == set(scen.set('foo')['dim_i'])
 
-    # Remove a set completely.
-    scen2 = ixmp.Scenario(test_mp, *can_args, version=2)
-    scen2.check_out()
-    scen2.init_set('h')
-    scen2.add_set('h', 'test')
-    scen2.remove_set('h')
-    obs = {}
-    exp = set(scen2.set('h'))
-    assert obs == exp
+    # Remove a set completely
+    assert 'h' not in scen.set_list()
+
+    scen.init_set('h')
+    assert 'h' in scen.set_list()
+
+    scen.remove_set('h')
+    assert 'h' not in scen.set_list()
 
 
 # make sure that changes to a scenario are copied over during clone


### PR DESCRIPTION
This PR closes #250. 

According to @zikolach, the error that does not allow remove_set() to function is found in the jdbc.py file.

After doing this modification `remove_set()` is working in my PC.

Are any other modifications to be done related to this method?

- [x] A test should be added to test this method.
- [x] Confirmation that `remove_set()` is working by other users. 
