### PR TITLE
Give more helpful messages on "ixmp list" user error

### DIFF
--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -36,13 +36,9 @@ def main(ctx, url, platform, dbprops, model, scenario, version):
 
     # Store the model and scenario name from arguments
     if model:
-        if platform is None:
-            raise click.UsageError('--model was given without --platform')
         ctx.obj['model name'] = model
 
     if scenario:
-        if platform is None:
-            raise click.UsageError('--scenario was given without --platform')
         ctx.obj['scenario name'] = scenario
 
     try:

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -28,17 +28,27 @@ def main(ctx, url, platform, dbprops, model, scenario, version):
         mp = ixmp.Platform(name=platform)
     elif dbprops:
         mp = ixmp.Platform(backend='jdbc', dbprops=dbprops)
+    else:
+        raise click.BadOptionUsage('either --url, --platform, or --dbprops '
+                                   'are  needed')
 
+    ctx.obj = dict()
     try:
-        ctx.obj = dict(mp=mp)
+        ctx.obj['mp'] = mp
     except NameError:
-        return
+        pass
 
     # Store the model and scenario name from arguments
     if model:
+        if platform is None:
+            raise click.BadOptionUsage('--model or --scenario without '
+                                       '--platform')
         ctx.obj['model name'] = model
 
     if scenario:
+        if platform is None:
+            raise click.BadOptionUsage('--model or --scenario without '
+                                       '--platform')
         ctx.obj['scenario name'] = scenario
 
     try:
@@ -140,6 +150,9 @@ def list_command(context, **kwargs):
     if not context:
         raise click.UsageError('give either --url, --platform or --dbprops '
                                'before command list')
+    platform = context.get('mp', None)
+    if platform is None:
+        raise click.BadOptionUsage('ixmp list requires a --platform to list')
 
     print('\n'.join(
         format_scenario_list(

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -36,13 +36,9 @@ def main(ctx, url, platform, dbprops, model, scenario, version):
 
     # Store the model and scenario name from arguments
     if model:
-        if platform is None:
-            raise click.UsageError('--model was given without --platform')
         ctx.obj['model name'] = model
 
     if scenario:
-        if platform is None:
-            raise click.UsageError('--scenario was given without --platform')
         ctx.obj['scenario name'] = scenario
 
     try:
@@ -63,6 +59,9 @@ def report(context, config, key):
     # Import here to avoid importing reporting dependencies when running
     # other commands
     from ixmp.reporting import Reporter
+    if not context:
+        raise click.UsageError('give either --url, --platform or --dbprops '
+                               'before command report')
 
     # Instantiate the Reporter with the Scenario loaded by main()
     r = Reporter.from_scenario(context['scen'])

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -28,27 +28,21 @@ def main(ctx, url, platform, dbprops, model, scenario, version):
         mp = ixmp.Platform(name=platform)
     elif dbprops:
         mp = ixmp.Platform(backend='jdbc', dbprops=dbprops)
-    else:
-        raise click.BadOptionUsage('either --url, --platform, or --dbprops '
-                                   'are  needed')
 
-    ctx.obj = dict()
     try:
-        ctx.obj['mp'] = mp
+        ctx.obj = dict(mp=mp)
     except NameError:
-        pass
+        return
 
     # Store the model and scenario name from arguments
     if model:
         if platform is None:
-            raise click.BadOptionUsage('--model or --scenario without '
-                                       '--platform')
+            raise click.UsageError('--model was given without --platform')
         ctx.obj['model name'] = model
 
     if scenario:
         if platform is None:
-            raise click.BadOptionUsage('--model or --scenario without '
-                                       '--platform')
+            raise click.UsageError('--scenario was given without --platform')
         ctx.obj['scenario name'] = scenario
 
     try:
@@ -150,9 +144,6 @@ def list_command(context, **kwargs):
     if not context:
         raise click.UsageError('give either --url, --platform or --dbprops '
                                'before command list')
-    platform = context.get('mp', None)
-    if platform is None:
-        raise click.BadOptionUsage('ixmp list requires a --platform to list')
 
     print('\n'.join(
         format_scenario_list(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+click
 codecov
 dask[array]
 graphviz

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,8 +1,8 @@
 from pathlib import Path
+from pandas.testing import assert_frame_equal
 
 import ixmp
 import pandas as pd
-import pandas.testing as pdt
 
 
 def test_main(ixmp_cli, test_mp, tmp_path):
@@ -147,4 +147,4 @@ def test_import(ixmp_cli, test_mp, test_data_path):
         'model': ['canning problem'],
         'scenario': ['standard'],
     })
-    pdt.assert_frame_equal(exp, scen.timeseries())
+    assert_frame_equal(exp, scen.timeseries())

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 from pandas.testing import assert_frame_equal
+from click.exceptions import UsageError
 
 import ixmp
 import pandas as pd
@@ -15,30 +16,31 @@ def test_main(ixmp_cli, test_mp, tmp_path):
         '--dbprops', str(tmp_path),
         'platform', 'list',  # Doesn't get executed; fails in cli.main()
     ]
-    r = ixmp_cli.invoke(cmd)
-    assert r.exit_code == 2  # click retcode for bad option usage
+    result = ixmp_cli.invoke(cmd)
+    assert result.exit_code == UsageError.exit_code  # click retcode for bad
+    # option usage
 
     # Create the file
     tmp_path.write_text('')
 
     # Giving both --platform and --dbprops is bad option usage
-    r = ixmp_cli.invoke(cmd)
-    assert r.exit_code == 1
+    result = ixmp_cli.invoke(cmd)
+    assert result.exit_code == UsageError.exit_code
 
     # --dbprops alone causes backend='jdbc' to be inferred (but an error
     # because temp.properties is empty)
-    r = ixmp_cli.invoke(cmd[2:])
-    assert 'Config file contains no database URL' in r.exception.args[0]
+    result = ixmp_cli.invoke(cmd[2:])
+    assert 'Config file contains no database URL' in result.exception.args[0]
 
     # --url argument can be given
     cmd = ['--url', 'ixmp://{}/Douglas Adams/Hitchhiker'.format(test_mp.name),
            'platform', 'list']
-    r = ixmp_cli.invoke(cmd)
-    assert r.exit_code == 0
+    result = ixmp_cli.invoke(cmd)
+    assert result.exit_code == 0
 
     # --url and other Platform/Scenario specifiers are bad option usage
-    r = ixmp_cli.invoke(cmd + ['--version', '1'])
-    assert r.exit_code == 2
+    result = ixmp_cli.invoke(cmd + ['--version', '1'])
+    assert result.exit_code == 2
 
 
 def test_config(ixmp_cli):


### PR DESCRIPTION
This PR helps `ixmp` **CLI** to create more intuitive error messages when user fails to insert the _commands_ or _options_ as it is required for it work. 