### PR TITLE
Support pandas 1.0

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -13,7 +13,7 @@ cache:
   - C:\Miniconda37-x64\pkgs
   - C:\Users\appveyor\.conda\pkgs
   - C:\Users\appveyor\AppData\Local\conda\conda\pkgs
-  - C:\RLibrary
+  - C:\RLibrary -> .appveyor.yml
 
 init:
   # Download and install the R Appveyor tool from

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,9 @@ Next release
 All changes
 -----------
 
+- `#261 <https://github.com/iiasa/ixmp/pull/261>`_: Increase minimum pandas
+  version to 1.0; adjust for `API changes and deprecations <https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html#backwards-incompatible-api-changes>`_.
+
 
 v2.0.0 (2020-01-14)
 ===================

--- a/ci/appveyor-install.R
+++ b/ci/appveyor-install.R
@@ -13,6 +13,8 @@ step <- commandArgs(TRUE)[1]
 # compile the source.
 options(repos=c('https://cloud.r-project.org'), pkgType='win.binary')
 
+print(.libPaths())
+
 if ( step == '1' ) {
   # Step 1: Install packages needed for testing
   install.packages(c('devtools', 'IRkernel'), quiet = TRUE)

--- a/ixmp/reporting/attrseries.py
+++ b/ixmp/reporting/attrseries.py
@@ -32,7 +32,10 @@ class AttrSeries(pd.Series):
 
             # pre-convert an pd.Series to preserve names and labels
             args = list(args)
-            args[0] = args[0].to_series()
+            try:
+                args[0] = args[0].to_series()
+            except AttributeError:
+                pass
         else:
             # default empty
             attrs = OrderedDict()

--- a/ixmp/reporting/attrseries.py
+++ b/ixmp/reporting/attrseries.py
@@ -30,12 +30,12 @@ class AttrSeries(pd.Series):
             # Use attrs from an xarray object
             attrs = args[0].attrs.copy()
 
-            # pre-convert an pd.Series to preserve names and labels
+            # pre-convert to a pd.Series to preserve names and labels
             args = list(args)
             try:
                 args[0] = args[0].to_series()
             except AttributeError:
-                pass
+                pass  # args[0] was already pd.Series
         else:
             # default empty
             attrs = OrderedDict()

--- a/setup.py
+++ b/setup.py
@@ -13,7 +13,7 @@ INSTALL_REQUIRES = [
     'click',
     'dask[array]',
     'graphviz',
-    'pandas',
+    'pandas>=1.0',
     'pint',
     'PyYAML',
     'xarray',

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,7 +1,7 @@
-import pytest
+from numpy.testing import assert_array_equal
+from pandas.testing import assert_frame_equal
 import numpy as np
-from numpy import testing as npt
-import pandas.util.testing as pdt
+import pytest
 
 import ixmp
 from ixmp.testing import make_dantzig, models, TS_DF, HIST_DF
@@ -20,12 +20,12 @@ def test_run_clone(test_mp, test_data_path, caplog):
     mp = test_mp
     scen = make_dantzig(mp, solve=test_data_path)
     assert np.isclose(scen.var('z')['lvl'], 153.675)
-    pdt.assert_frame_equal(scen.timeseries(iamc=True), TS_DF)
+    assert_frame_equal(scen.timeseries(iamc=True), TS_DF)
 
     # cloning with `keep_solution=True` keeps all timeseries and the solution
     scen2 = scen.clone(keep_solution=True)
     assert np.isclose(scen2.var('z')['lvl'], 153.675)
-    pdt.assert_frame_equal(scen2.timeseries(iamc=True), TS_DF)
+    assert_frame_equal(scen2.timeseries(iamc=True), TS_DF)
 
     # version attribute of the clone increments the original (GitHub #211)
     assert scen2.version == scen.version + 1
@@ -39,7 +39,7 @@ def test_run_clone(test_mp, test_data_path, caplog):
     # timeseries set as `meta=True`
     scen3 = scen.clone(keep_solution=False)
     assert np.isnan(scen3.var('z')['lvl'])
-    pdt.assert_frame_equal(scen3.timeseries(iamc=True), HIST_DF)
+    assert_frame_equal(scen3.timeseries(iamc=True), HIST_DF)
 
     # cloning with `keep_solution=False` and `first_model_year`
     # drops the solution and removes all timeseries not marked `meta=True`
@@ -48,7 +48,7 @@ def test_run_clone(test_mp, test_data_path, caplog):
                       match='first_model_year` is deprecated'):
         scen4 = scen.clone(keep_solution=False, first_model_year=2005)
     assert np.isnan(scen4.var('z')['lvl'])
-    pdt.assert_frame_equal(scen4.timeseries(iamc=True), TS_DF_CLEARED)
+    assert_frame_equal(scen4.timeseries(iamc=True), TS_DF_CLEARED)
 
 
 def test_run_remove_solution(test_mp, test_data_path):
@@ -67,7 +67,7 @@ def test_run_remove_solution(test_mp, test_data_path):
     scen2.remove_solution()
     assert not scen2.has_solution()
     assert np.isnan(scen2.var('z')['lvl'])
-    pdt.assert_frame_equal(scen2.timeseries(iamc=True), HIST_DF)
+    assert_frame_equal(scen2.timeseries(iamc=True), HIST_DF)
 
     # remove the solution with a specific year as first model year, check that
     # variables are empty and timeseries not marked `meta=True` are removed
@@ -75,7 +75,7 @@ def test_run_remove_solution(test_mp, test_data_path):
     scen3.remove_solution(first_model_year=2005)
     assert not scen3.has_solution()
     assert np.isnan(scen3.var('z')['lvl'])
-    pdt.assert_frame_equal(scen3.timeseries(iamc=True), TS_DF_CLEARED)
+    assert_frame_equal(scen3.timeseries(iamc=True), TS_DF_CLEARED)
 
 
 def scenario_list(mp):
@@ -83,7 +83,7 @@ def scenario_list(mp):
 
 
 def assert_multi_db(mp1, mp2):
-    pdt.assert_frame_equal(scenario_list(mp1), scenario_list(mp2))
+    assert_frame_equal(scenario_list(mp1), scenario_list(mp2))
 
 
 def get_distance(scen):
@@ -123,15 +123,15 @@ def test_multi_db_run(tmpdir, test_data_path):
     scen2 = ixmp.Scenario(_mp2, **models['dantzig'])
 
     # check that sets, variables and parameter were copied correctly
-    npt.assert_array_equal(scen1.set('i'), scen2.set('i'))
-    pdt.assert_frame_equal(scen1.par('d'), scen2.par('d'))
+    assert_array_equal(scen1.set('i'), scen2.set('i'))
+    assert_frame_equal(scen1.par('d'), scen2.par('d'))
     assert np.isclose(scen2.var('z')['lvl'], 153.675)
-    pdt.assert_frame_equal(scen1.var('x'), scen2.var('x'))
+    assert_frame_equal(scen1.var('x'), scen2.var('x'))
 
     # check that custom unit, region and timeseries are migrated correctly
     assert scen2.par('f')['value'] == 90.0
     assert scen2.par('f')['unit'] == 'USD_per_km'
-    pdt.assert_frame_equal(scen2.timeseries(iamc=True), TS_DF)
+    assert_frame_equal(scen2.timeseries(iamc=True), TS_DF)
 
 
 def test_multi_db_edit_source(tmpdir):
@@ -142,7 +142,7 @@ def test_multi_db_edit_source(tmpdir):
     mp2 = ixmp.Platform(backend='jdbc', driver='hsqldb', path=tmpdir / 'mp2')
     scen2 = scen1.clone(platform=mp2)
 
-    pdt.assert_frame_equal(scen1.par('d'), scen2.par('d'))
+    assert_frame_equal(scen1.par('d'), scen2.par('d'))
 
     scen1.check_out()
     scen1.add_par('d', ['san-diego', 'topeka'], 1.5, 'km')
@@ -167,7 +167,7 @@ def test_multi_db_edit_target(tmpdir):
     mp2 = ixmp.Platform(backend='jdbc', driver='hsqldb', path=tmpdir / 'mp2')
     scen2 = scen1.clone(platform=mp2)
 
-    pdt.assert_frame_equal(scen1.par('d'), scen2.par('d'))
+    assert_frame_equal(scen1.par('d'), scen2.par('d'))
 
     scen2.check_out()
     scen2.add_par('d', ['san-diego', 'topeka'], 1.5, 'km')

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -124,8 +124,6 @@ def test_reporter_add_product(test_mp):
     # Product has the expected value
     exp = as_quantity(x * x)
     exp.attrs['_unit'] = UNITS('kilogram ** 2').units
-
-    pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
     assert_qty_equal(exp, rep.get(key))
 
 
@@ -143,7 +141,6 @@ def test_reporter_from_dantzig(test_mp, test_data_path):
     # Reporter.from_scenario can handle the Dantzig problem
     rep = Reporter.from_scenario(scen)
 
-    pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
     # Partial sums are available automatically (d is defined over i and j)
     d_i = rep.get('d:i')
 
@@ -380,8 +377,6 @@ def test_reporting_units():
 
     # Aggregation preserves units
     r.add('energy', (computations.sum, 'energy:x', None, ['x']))
-
-    pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
     assert r.get('energy').attrs['_unit'] == UNITS.parse_units('MJ')
 
     # Units are derived for a ratio of two quantities
@@ -438,8 +433,6 @@ def test_reporting_platform_units(test_mp, caplog):
 
     # Unrecognized units are added automatically, with log messages emitted
     caplog.clear()
-
-    pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
     rep.get(x_key)
     expected = [
         'Add unit definition: USD = [USD]',
@@ -592,7 +585,6 @@ def test_report_size(test_mp):
     keys = [rep.full_key(name) for name in names]
     rep.add('bigmem', tuple([computations.product] + keys))
 
-    pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
     # One quantity fits in memory
     rep.get(keys[0])
 
@@ -685,7 +677,6 @@ def test_reporting_filters(test_mp, tmp_path, caplog):
     x_key = rep.full_key('x')
 
     def assert_t_indices(labels):
-        pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
         assert set(rep.get(x_key).coords['t'].values) == set(labels)
 
     # 1. Set filters directly

--- a/tests/test_reporting.py
+++ b/tests/test_reporting.py
@@ -124,6 +124,8 @@ def test_reporter_add_product(test_mp):
     # Product has the expected value
     exp = as_quantity(x * x)
     exp.attrs['_unit'] = UNITS('kilogram ** 2').units
+
+    pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
     assert_qty_equal(exp, rep.get(key))
 
 
@@ -141,6 +143,7 @@ def test_reporter_from_dantzig(test_mp, test_data_path):
     # Reporter.from_scenario can handle the Dantzig problem
     rep = Reporter.from_scenario(scen)
 
+    pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
     # Partial sums are available automatically (d is defined over i and j)
     d_i = rep.get('d:i')
 
@@ -377,6 +380,8 @@ def test_reporting_units():
 
     # Aggregation preserves units
     r.add('energy', (computations.sum, 'energy:x', None, ['x']))
+
+    pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
     assert r.get('energy').attrs['_unit'] == UNITS.parse_units('MJ')
 
     # Units are derived for a ratio of two quantities
@@ -433,6 +438,8 @@ def test_reporting_platform_units(test_mp, caplog):
 
     # Unrecognized units are added automatically, with log messages emitted
     caplog.clear()
+
+    pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
     rep.get(x_key)
     expected = [
         'Add unit definition: USD = [USD]',
@@ -585,9 +592,9 @@ def test_report_size(test_mp):
     keys = [rep.full_key(name) for name in names]
     rep.add('bigmem', tuple([computations.product] + keys))
 
+    pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
     # One quantity fits in memory
     rep.get(keys[0])
-    # assert False
 
     # All quantities together trigger MemoryError
     rep.get('bigmem')
@@ -678,6 +685,7 @@ def test_reporting_filters(test_mp, tmp_path, caplog):
     x_key = rep.full_key('x')
 
     def assert_t_indices(labels):
+        pytest.skip('Segmentation fault with pandas 1.0 on next line')  # FIXME
         assert set(rep.get(x_key).coords['t'].values) == set(labels)
 
     # 1. Set filters directly

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -1,6 +1,6 @@
 """Tests for ixmp.utils."""
 import pandas as pd
-import pandas.util.testing as pdt
+from pandas.testing import assert_frame_equal
 import pytest
 from pytest import mark, param
 
@@ -19,7 +19,7 @@ def test_pd_io_csv(tmp_path):
     fname = tmp_path / "test.csv"
     exp = pd.DataFrame({'a': [0, 1], 'b': [2, 3]})
     obs = make_obs(fname, exp)
-    pdt.assert_frame_equal(obs, exp)
+    assert_frame_equal(obs, exp)
 
 
 def test_pd_io_xlsx(tmp_path):
@@ -27,7 +27,7 @@ def test_pd_io_xlsx(tmp_path):
     fname = tmp_path / "test.xlsx"
     exp = pd.DataFrame({'a': [0, 1], 'b': [2, 3]})
     obs = make_obs(fname, exp)
-    pdt.assert_frame_equal(obs, exp)
+    assert_frame_equal(obs, exp)
 
 
 def test_pd_io_xlsx_multi(tmp_path):
@@ -40,7 +40,7 @@ def test_pd_io_xlsx_multi(tmp_path):
     obs = make_obs(fname, exp, sheet_name=None)
     for k, _exp in exp.items():
         _obs = obs[k]
-        pdt.assert_frame_equal(_obs, _exp)
+        assert_frame_equal(_obs, _exp)
 
 
 def test_pd_write(tmp_path):


### PR DESCRIPTION
[Pandas 1.0 is released](https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html). This PR makes one adjustment necessary to support pandas 1.0 in ixmp.

## Details

The following tests failed:
- test_reporting.test_reporting_aggregate
- test_reporting_utils.TestQuantity.test_assert

The following tests trigger a segfault with pandas 1.0:
- test_reporting.test_reporter_add_product
- test_reporting.test_reporter_from_dantzig
- test_reporting.test_reporting_units
- test_reporting.test_report_size
- test_reporting.test_reporting_filters

The common cause seems to be a call to `pd.Series.to_series()` in `reporting.utils.AttrSeries.__init__()`; the former was removed in pandas 1.0. When the resulting AttributeError occured inside some new, C- or other compiled code in pandas, it triggered the segfault.

Supersedes #261, fixing CI errors on AppVeyor.

## PR checklist

- [x] ~Tests added.~ N/A
- [x] ~Documentation added.~ N/A
- [x] Release notes updated.