### PR TITLE
Debug CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -14,6 +14,7 @@ cache:
   - C:\Users\appveyor\.conda\pkgs
   - C:\Users\appveyor\AppData\Local\conda\conda\pkgs
   - C:\RLibrary -> .appveyor.yml
+  - C:\R\Library -> .appveyor.yml
 
 init:
   # Download and install the R Appveyor tool from

--- a/ci/travis-before_install.sh
+++ b/ci/travis-before_install.sh
@@ -15,8 +15,11 @@ maybe_download $CONDAURL $CONDAFNAME
 
 
 # Install R packages needed for testing
-Rscript -e "install.packages(c('devtools', 'IRkernel'), lib = '$R_LIBS_USER')"
-Rscript -e "devtools::install_dev_deps('rixmp')"
+Rscript - <<EOF
+options(pkgType = 'source')
+install.packages(c('devtools', 'IRkernel'), lib = '$R_LIBS_USER')
+devtools::install_dev_deps('rixmp')
+EOF
 
 # Install graphiz on OS X (requires updating homebrew)
 if [ `uname` = "Darwin" ];

--- a/ci/travis-before_install.sh
+++ b/ci/travis-before_install.sh
@@ -15,11 +15,17 @@ maybe_download $CONDAURL $CONDAFNAME
 
 
 # Install R packages needed for testing
+#
+# Travis' R language support (https://docs.travis-ci.com/user/languages/r)
+# provides travis.yml keys for installing R packages. However, these are only
+# executed *after* the 'install' script from travis.yml—too late to set up
+# dependencies for the commands we use. Thus, we need to install packages here.
 Rscript - <<EOF
 options(pkgType = 'source')
 install.packages(c('devtools', 'IRkernel'), lib = '$R_LIBS_USER')
 devtools::install_dev_deps('rixmp')
 EOF
+
 
 # Install graphiz on OS X (requires updating homebrew)
 if [ `uname` = "Darwin" ];


### PR DESCRIPTION
CI is failing for:

- AppVeyor. This is the same issue described in #261/addressed in #263; it seems it was only temporarily fixed there by clearing caches.
- Travis / macOS only. The messages resembled:
  ```
  $ Rscript -e "devtools::install('rixmp')"
  jsonlite (1.6 -> 1.6.1) [CRAN]
  Installing 1 packages: jsonlite
  Installing package into ‘/Users/travis/R/Library’
  (as ‘lib’ is unspecified)
  Error: (converted from warning) unable to access index for repository https://cloud.r-project.org/bin/macosx/el-capitan/contrib/3.6:
    cannot open URL 'https://cloud.r-project.org/bin/macosx/el-capitan/contrib/3.6/PACKAGES'
  Execution halted
  The command "Rscript -e "devtools::install('rixmp')"" failed and exited with 1 during .
  ```

  I don't know why this happens, but the fix is to force installation of source packages only on Travis.

This is blocking #254, #260, #262.