### PR TITLE
Debug AppVeyor CI

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,11 +8,11 @@ environment:
   - PYTHON_VERSION: "3.7"
     PYTHON_ARCH: "64"
 
-cache:
-  - C:\Miniconda36-x64\pkgs
-  - C:\Miniconda37-x64\pkgs
-  - C:\Users\appveyor\.conda\pkgs
-  - C:\Users\appveyor\AppData\Local\conda\conda\pkgs
+# cache:
+#   - C:\Miniconda36-x64\pkgs
+#   - C:\Miniconda37-x64\pkgs
+#   - C:\Users\appveyor\.conda\pkgs
+#   - C:\Users\appveyor\AppData\Local\conda\conda\pkgs
 
 init:
   # Download and install the R Appveyor tool from

--- a/ci/appveyor-install.ps1
+++ b/ci/appveyor-install.ps1
@@ -59,7 +59,7 @@ Progress 'Update conda'
 # The installed conda on Appveyor workers is 4.5.x, while the latest is >4.7.
 # --quiet here and below suppresses progress bars, which show up as many lines
 # in the Appveyor build logs.
-Exec { conda update --quiet --yes conda }
+Exec { conda update --channel conda-forge --quiet --yes conda }
 
 # NB at the corresponding location, travis-install.sh creates a new conda
 #    environment, and later activates it. This was attempted for Windows/

--- a/ci/appveyor-install.ps1
+++ b/ci/appveyor-install.ps1
@@ -69,10 +69,7 @@ Exec { conda update --quiet --yes conda }
 
 Progress 'Install dependencies'
 Exec { conda install --channel conda-forge --quiet --yes `
-      ixmp[tests] `
-      codecov `
-      "pytest>=3.9" `
-      pytest-cov }
+       ixmp codecov "pytest>=3.9" pytest-cov }
 Exec { conda remove --force --yes ixmp }
 
 # This environment variable change would be performed by 'activate testing'; see


### PR DESCRIPTION
Per #267.

See for example [AppVeyor job 380](https://ci.appveyor.com/project/iiasa/ixmp/builds/31069476/job/q3je4mgdc2xdkdmi).
- Occurs only for Python 3.6; not Python 3.7.
- `conda update --quiet --yes conda` appears to downgrade some packages.
- Messages appear like:
  ```
  ERROR conda.core.link:_execute_actions(337): An error occurred while installing package 'conda-forge::tqdm-4.43.0-py_0'.
  CondaError: Cannot link a source that does not exist. C:\Miniconda36-x64\Scripts\conda.exe
  Attempting to roll back.

  CondaError: Cannot link a source that does not exist. C:\Miniconda36-x64\Scripts\conda.exe
  ```
- `conda install […]` then fails.