### PR TITLE
add docstrings related to the `timeslices` feature

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -284,6 +284,10 @@ class Platform:
         category (e.g., all months) from the pandas.DataFrame returned by this
         function or to aggregate subannual data to full-year results.
 
+        A timeslice is related to the index set 'time' in a message_ix.Scenario
+        to indicate a subannual temporal dimension. Alas, timeslices and set
+        elements of time have to be initialized/defined independently.
+
         See :meth:`add_timeslice` to initialize additional timeslices in the
         Platform instance.
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -271,7 +271,21 @@ class Platform:
         self._backend.set_node(region, synonym=mapped_to)
 
     def timeslices(self):
-        """Return all sub-annual time slices.
+        """Return all subannual time slices defined in this Platform instance.
+
+        Timeslices are a way to represent subannual temporal resolution in
+        timeseries data. A timeslice consists of a **name** (e.g., 'January',
+        'summer'), a **category** (e.g., 'months', 'seasons'), and a
+        **duration** given relative to a full year.
+
+        The category and duration do not have any functional relevance within
+        the ixmp framework, but they may be useful for pre- or post-processing.
+        For example, they can be used to filter all timeslices of a certain
+        category (e.g., all months) from the pandas.DataFrame returned by this
+        function or to aggregate subannual data to full-year results.
+
+        See :method:`add_timeslice` to initialize additional timeslices in the
+        Platform instance.
 
         Returns
         -------
@@ -281,14 +295,16 @@ class Platform:
                             columns=FIELDS['get_timeslices'])
 
     def add_timeslice(self, name, category, duration):
-        """Define a sub-annual time slice including a category and duration.
+        """Define a subannual time slice including a category and duration.
+
+        See :method:`timeslices` for a detailed description of timeslices.
 
         Parameters
         ----------
         name : str
             Unique name of the time slice.
         category : str
-            Time slice category (e.g. COMMON, MONTHS etc).
+            Time slice category (e.g. 'common', 'month', etc).
         duration : float
             Duration of time slice as fraction of year.
         """
@@ -448,6 +464,13 @@ class TimeSeries:
 
             - `year` and `value`—long, or 'tabular', format.
             - one or more specific years—wide, or 'IAMC' format.
+
+            To support subannual temporal resolution of timeseries data, a
+            column `subannual` is optional in `df`. The entries in this column
+            must have been defined in the Platform instance using
+            :method:`add_timeslice` beforehand. If no column `subannual` is
+            included in `df`, the data is assumed to contain yearly values.
+            See :method:`timeslices` for a detailed description of this feature.
 
         meta : bool, optional
             If :obj:`True`, store `df` as metadata. Metadata is treated

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -274,7 +274,7 @@ class Platform:
         """Return all subannual timeslices defined in this Platform instance.
 
         Timeslices are a way to represent subannual temporal resolution in
-        timeseries data. A timeslice consists of a **name** (e.g., 'January',
+        timeseries data. A timeslice consists of a **name** (e.g., 'january',
         'summer'), a **category** (e.g., 'months', 'seasons'), and a
         **duration** given relative to a full year.
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -271,7 +271,7 @@ class Platform:
         self._backend.set_node(region, synonym=mapped_to)
 
     def timeslices(self):
-        """Return all subannual time slices defined in this Platform instance.
+        """Return all subannual timeslices defined in this Platform instance.
 
         Timeslices are a way to represent subannual temporal resolution in
         timeseries data. A timeslice consists of a **name** (e.g., 'January',
@@ -295,18 +295,18 @@ class Platform:
                             columns=FIELDS['get_timeslices'])
 
     def add_timeslice(self, name, category, duration):
-        """Define a subannual time slice including a category and duration.
+        """Define a subannual timeslice including a category and duration.
 
         See :method:`timeslices` for a detailed description of timeslices.
 
         Parameters
         ----------
         name : str
-            Unique name of the time slice.
+            Unique name of the timeslice.
         category : str
-            Time slice category (e.g. 'common', 'month', etc).
+            Timeslice category (e.g. 'common', 'month', etc).
         duration : float
-            Duration of time slice as fraction of year.
+            Duration of timeslice as fraction of year.
         """
         self._backend.add_timeslice(name, category, duration)
 
@@ -470,7 +470,7 @@ class TimeSeries:
             must have been defined in the Platform instance using
             :method:`add_timeslice` beforehand. If no column `subannual` is
             included in `df`, the data is assumed to contain yearly values.
-            See :method:`timeslices` for a detailed description of this feature.
+            See :method:`timeslices` for a detailed description of the feature.
 
         meta : bool, optional
             If :obj:`True`, store `df` as metadata. Metadata is treated

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -284,12 +284,13 @@ class Platform:
         category (e.g., all months) from the pandas.DataFrame returned by this
         function or to aggregate subannual data to full-year results.
 
-        See :method:`add_timeslice` to initialize additional timeslices in the
+        See :meth:`add_timeslice` to initialize additional timeslices in the
         Platform instance.
 
         Returns
         -------
         pandas.DataFrame
+            DataFrame of timeslices, categories and duration
         """
         return pd.DataFrame(self._backend.get_timeslices(),
                             columns=FIELDS['get_timeslices'])
@@ -297,7 +298,7 @@ class Platform:
     def add_timeslice(self, name, category, duration):
         """Define a subannual timeslice including a category and duration.
 
-        See :method:`timeslices` for a detailed description of timeslices.
+        See :meth:`timeslices` for a detailed description of timeslices.
 
         Parameters
         ----------
@@ -468,9 +469,9 @@ class TimeSeries:
             To support subannual temporal resolution of timeseries data, a
             column `subannual` is optional in `df`. The entries in this column
             must have been defined in the Platform instance using
-            :method:`add_timeslice` beforehand. If no column `subannual` is
+            :meth:`add_timeslice` beforehand. If no column `subannual` is
             included in `df`, the data is assumed to contain yearly values.
-            See :method:`timeslices` for a detailed description of the feature.
+            See :meth:`timeslices` for a detailed description of the feature.
 
         meta : bool, optional
             If :obj:`True`, store `df` as metadata. Metadata is treated


### PR DESCRIPTION
## Description

This PR adds docstrings to the branch in #264 as requested by @zikolach [here](https://github.com/iiasa/ixmp/pull/264#issuecomment-583406552).

## How to review

Please read the added docstrings and comment whether they clarify the intention of this feature.
Also, I'm not sure whether there aren't "better" places to put this info (e.g., the backend?) or whether this should be duplicated somewhere...