### PR TITLE
Include dantzig.gms as package data

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,2 +1,3 @@
 include versioneer.py
 include ixmp/_version.py
+include ixmp/model/dantzig.gms

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ EXTRAS_REQUIRE = {
 }
 
 LIB_FILES = [x.split('ixmp/')[-1] for x in glob.glob('ixmp/lib/*')]
+MODEL_FILES = ['model/dantzig.gms']
 
 setup(
     name='ixmp',
@@ -44,7 +45,7 @@ setup(
     extras_require=EXTRAS_REQUIRE,
     packages=find_packages(),
     package_dir={'ixmp': 'ixmp'},
-    package_data={'ixmp': ['ixmp.jar'] + LIB_FILES},
+    package_data={'ixmp': ['ixmp.jar'] + LIB_FILES + MODEL_FILES},
     entry_points={
         'console_scripts': [
             'ixmp=ixmp.cli:main',


### PR DESCRIPTION
## How to review

- Check that this branch installs dantzig.gms on your system with `pip install` but *without* `--editable`.
- `python3 setup.py bdist_wheel sdist` and check that dantzig.gms is included in the packages produced in dist/.

## PR checklist

- [x] ~Tests added.~ N/A, packaging
- [x] ~Documentation added.~ N/A
- [x] ~Release notes updated.~ N/A