### PR TITLE
Exclude JPype 0.7.2 from CI; add python3-setuptools for TeamCity

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,11 +8,11 @@ environment:
   - PYTHON_VERSION: "3.6"
   - PYTHON_VERSION: "3.7"
 
-# cache:
-# - C:\Miniconda36-x64\pkgs
-# - C:\Miniconda37-x64\pkgs
-# - C:\Users\appveyor\.conda\pkgs
-# - C:\Users\appveyor\AppData\Local\conda\conda\pkgs
+cache:
+- C:\Miniconda36-x64\pkgs
+- C:\Miniconda37-x64\pkgs
+- C:\Users\appveyor\.conda\pkgs
+- C:\Users\appveyor\AppData\Local\conda\conda\pkgs
 
 init:
 # Download and install the R Appveyor tool from

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -8,11 +8,11 @@ environment:
   - PYTHON_VERSION: "3.6"
   - PYTHON_VERSION: "3.7"
 
-cache:
-- C:\Miniconda36-x64\pkgs
-- C:\Miniconda37-x64\pkgs
-- C:\Users\appveyor\.conda\pkgs
-- C:\Users\appveyor\AppData\Local\conda\conda\pkgs
+# cache:
+# - C:\Miniconda36-x64\pkgs
+# - C:\Miniconda37-x64\pkgs
+# - C:\Users\appveyor\.conda\pkgs
+# - C:\Users\appveyor\AppData\Local\conda\conda\pkgs
 
 init:
 # Download and install the R Appveyor tool from

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,7 +5,7 @@ ARG VIRTUAL_ENV=/opt/python3
 
 RUN apt-get update \
  && apt-get install -y --no-install-recommends \
-    curl graphviz python3 python3-pip python3-setuptools unzip \
+    curl graphviz python3 python3-distlib python3-pip python3-setuptools unzip \
  && pip3 install virtualenv \
  && virtualenv -p python3 $VIRTUAL_ENV
 
@@ -17,7 +17,7 @@ ARG GAMS_VERSION=27.3.0
 
 RUN curl -O https://d37drm4t2jghv5.cloudfront.net/distributions/$GAMS_VERSION/linux/linux_x64_64_sfx.exe \
  && echo '4fb888092c97053d787fb93566565401 *linux_x64_64_sfx.exe' | md5sum -c \
- && unzip linux_x64_64_sfx.exe \
+ && unzip -q linux_x64_64_sfx.exe \
  && rm linux_x64_64_sfx.exe
 
 ENV GAMS_PATH=/gams27.3_linux_x64_64_sfx

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -3,11 +3,11 @@ FROM openjdk:11-slim-buster
 # Install Python and other dependencies
 ARG VIRTUAL_ENV=/opt/python3
 
-RUN apt-get update \
- && apt-get install -y --no-install-recommends \
-    curl graphviz python3 python3-distlib python3-pip python3-setuptools unzip \
- && pip3 install virtualenv \
- && virtualenv -p python3 $VIRTUAL_ENV
+RUN apt-get update &&\
+    apt-get install -y --no-install-recommends curl graphviz python3 \
+      python3-distlib python3-pip python3-setuptools unzip &&\
+    pip3 install virtualenv &&\
+    virtualenv -p python3 $VIRTUAL_ENV
 
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
@@ -15,10 +15,10 @@ ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 # NB see also ci/env.sh and try to keep version in sync.
 ARG GAMS_VERSION=27.3.0
 
-RUN curl -O https://d37drm4t2jghv5.cloudfront.net/distributions/$GAMS_VERSION/linux/linux_x64_64_sfx.exe \
- && echo '4fb888092c97053d787fb93566565401 *linux_x64_64_sfx.exe' | md5sum -c \
- && unzip -q linux_x64_64_sfx.exe \
- && rm linux_x64_64_sfx.exe
+RUN curl -O https://d37drm4t2jghv5.cloudfront.net/distributions/$GAMS_VERSION/linux/linux_x64_64_sfx.exe &&\
+    echo '4fb888092c97053d787fb93566565401 *linux_x64_64_sfx.exe' | md5sum -c &&\
+    unzip -q linux_x64_64_sfx.exe &&\
+    rm linux_x64_64_sfx.exe
 
 ENV GAMS_PATH=/gams27.3_linux_x64_64_sfx
 ENV PATH="$PATH:$GAMS_PATH"

--- a/ci/conda-requirements.txt
+++ b/ci/conda-requirements.txt
@@ -2,7 +2,7 @@ click
 codecov
 dask
 graphviz
-JPype1
+JPype1!=0.7.2
 jupyter
 numpydoc
 pandas

--- a/ci/run.sh
+++ b/ci/run.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+. /opt/python3/bin/activate
+
+pip install --editable .[tests,tutorial]
+
+py.test --trace-config ixmp

--- a/ci/teamcity/Dockerfile
+++ b/ci/teamcity/Dockerfile
@@ -1,17 +1,24 @@
 FROM openjdk:11-slim-buster
 
-# installing python 3
+# Install Python and other dependencies
 ARG VIRTUAL_ENV=/opt/python3
-RUN apt-get update && apt-get install -y --no-install-recommends curl unzip graphviz python3 python3-pip && \
-    pip3 install virtualenv && \
-    virtualenv -p python3 $VIRTUAL_ENV
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+    curl graphviz python3 python3-pip python3-setuptools unzip \
+ && pip3 install virtualenv \
+ && virtualenv -p python3 $VIRTUAL_ENV
+
 ENV PATH="$VIRTUAL_ENV/bin:$PATH"
 
-# installing GAMS (see also ci/env.sh and try to keep version in sync)
+# Install GAMS
+# NB see also ci/env.sh and try to keep version in sync.
 ARG GAMS_VERSION=27.3.0
-RUN curl -O https://d37drm4t2jghv5.cloudfront.net/distributions/$GAMS_VERSION/linux/linux_x64_64_sfx.exe && \
-    echo '4fb888092c97053d787fb93566565401 *linux_x64_64_sfx.exe' | md5sum -c && \
-    unzip linux_x64_64_sfx.exe && \
-    rm linux_x64_64_sfx.exe
+
+RUN curl -O https://d37drm4t2jghv5.cloudfront.net/distributions/$GAMS_VERSION/linux/linux_x64_64_sfx.exe \
+ && echo '4fb888092c97053d787fb93566565401 *linux_x64_64_sfx.exe' | md5sum -c \
+ && unzip linux_x64_64_sfx.exe \
+ && rm linux_x64_64_sfx.exe
+
 ENV GAMS_PATH=/gams27.3_linux_x64_64_sfx
 ENV PATH="$PATH:$GAMS_PATH"

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,8 @@ with open('README.md', 'r') as f:
     LONG_DESCRIPTION = f.read()
 
 INSTALL_REQUIRES = [
-    'JPype1>=0.7',
+    # Temporary, to address segfaults with 0.7.2 on some systems
+    'JPype1>=0.7, !=0.7.2',
     'click',
     'dask[array]',
     'graphviz',

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ INSTALL_REQUIRES = [
 
 EXTRAS_REQUIRE = {
     'tests': ['codecov', 'jupyter', 'pretenders>=1.4.4', 'pytest-cov',
-              'pytest>=3.9'],
+              'pytest>=3.9', 'sparse'],
     'docs': ['numpydoc', 'sphinx', 'sphinx_rtd_theme', 'sphinxcontrib-bibtex'],
     'tutorial': ['jupyter'],
 }


### PR DESCRIPTION
Required to un-break builds failing with messages like [this](https://ene-builds.iiasa.ac.at/viewLog.html?buildTypeId=IxmpCore_IxmpPython&buildId=2332&tab=buildLog&logTab=tree&filter=debug&expand=all&_focus=853).

The Dockerfile is also formatted identically to message_data.

## How to review

Confirm the TeamCity CI check passes.

## PR checklist
- [x] ~Tests added.~ N/A; CI only.
- [x] ~Documentation added.~ N/A
- [x] ~Release notes updated.~ N/A