### PR TITLE
add warning if importing timeseries with unexpected columns

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -519,7 +519,7 @@ class TimeSeries:
         # TODO: and one remark: this should work on the column name,
         # TODO: not the datatype of the column values
         num_cols = [pd.api.types.is_numeric_dtype(dt) for dt in df.dtypes]
-        other_cols = [i if i not in ['model', 'scenario'] + num_cols
+        other_cols = [i if i not in ['model', 'scenario'] + num_cols \
                       for i in df.columns]
         if not other_cols.empty:
             logger().warning(f'dropping index columns {other_cols} from data')

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -513,8 +513,17 @@ class TimeSeries:
             # Wide format: set index columns
             df.set_index(index_cols, inplace=True)
 
-        # Discard non-numeric columns, e.g. 'model', 'scenario'
+        # Discard non-numeric columns, e.g. 'model', 'scenario',
+        # write warning about non-expected cols to log
+        # TODO: please use `utils.numcols` here to avoid duplication of code
+        # TODO: and one remark: this should work on the column name,
+        # TODO: not the datatype of the column values
         num_cols = [pd.api.types.is_numeric_dtype(dt) for dt in df.dtypes]
+        other_cols = [i if i not in ['model', 'scenario'] + num_cols
+                      for i in df.columns]
+        if not other_cols.empty:
+            logger().warning(f'dropping index columns {other_cols} from data')
+
         df = df.iloc[:, num_cols]
 
         # Columns (year) as integer

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -519,7 +519,7 @@ class TimeSeries:
         year_cols = year_list(df.columns)
         other_cols = [i for i in df.columns
                       if i not in ['model', 'scenario'] + year_cols]
-        if not other_cols.empty:
+        if len(other_cols) > 0:
             logger().warning(f'dropping index columns {other_cols} from data')
 
         df = df.iloc[:, year_cols]

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -571,7 +571,11 @@ class TimeSeries:
 
         if iamc:
             # Convert to wide format
-            df = df.pivot_table(index=IAMC_IDX, columns='year')['value'] \
+            if 'subannual' not in df.columns:
+                index = IAMC_IDX
+            else:
+                index = IAMC_IDX + ['subannual']
+            df = df.pivot_table(index=index, columns='year')['value'] \
                    .reset_index()
             df.columns.names = [None]
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -519,8 +519,8 @@ class TimeSeries:
         # TODO: and one remark: this should work on the column name,
         # TODO: not the datatype of the column values
         num_cols = [pd.api.types.is_numeric_dtype(dt) for dt in df.dtypes]
-        other_cols = [i if i not in ['model', 'scenario'] + num_cols \
-                      for i in df.columns]
+        other_cols = [i for i in df.columns
+                      if i not in ['model', 'scenario'] + num_cols]
         if not other_cols.empty:
             logger().warning(f'dropping index columns {other_cols} from data')
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -522,7 +522,7 @@ class TimeSeries:
         if len(other_cols) > 0:
             logger().warning(f'dropping index columns {other_cols} from data')
 
-        df = df.iloc[:, year_cols]
+        df = df.loc[:, year_cols]
 
         # Columns (year) as integer
         df.columns = df.columns.astype(int)

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -507,8 +507,8 @@ class TimeSeries:
         if 'value' in df.columns:
             # Long format; pivot to wide
             all_cols = [i for i in df.columns if i not in ['year', 'value']]
-            _df = pd.pivot_table(df, values='value', index=all_cols,
-                                 columns=['year']).reset_index()
+            df = pd.pivot_table(df, values='value', index=all_cols,
+                                columns=['year']).reset_index()
         df.set_index(index_cols, inplace=True)
 
         # Discard non-numeric columns, e.g. 'model', 'scenario',

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -513,9 +513,6 @@ class TimeSeries:
 
         # Discard non-numeric columns, e.g. 'model', 'scenario',
         # write warning about non-expected cols to log
-        # TODO: please use `utils.numcols` here to avoid duplication of code
-        # TODO: and one remark: this should work on the column name,
-        # TODO: not the datatype of the column values
         year_cols = year_list(df.columns)
         other_cols = [i for i in df.columns
                       if i not in ['model', 'scenario'] + year_cols]

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -127,11 +127,11 @@ def test_mp(request, tmp_env, test_data_path):
 MODEL = "canning problem"
 SCENARIO = "standard"
 HIST_DF = pd.DataFrame(
-    [[MODEL, SCENARIO, 'DantzigLand', 'GDP', 'USD', 'Year', 850., 900., 950.], ],
+    [[MODEL, SCENARIO, 'DantzigLand', 'GDP', 'USD', 'Year', 850., 900., 950.]],
     columns=IAMC_IDX + ['subannual'] + [2000, 2005, 2010],
 )
 INP_DF = pd.DataFrame(
-    [[MODEL, SCENARIO, 'DantzigLand', 'Demand', 'cases', 'Year', 850., 900.], ],
+    [[MODEL, SCENARIO, 'DantzigLand', 'Demand', 'cases', 'Year', 850., 900.]],
     columns=IAMC_IDX + ['subannual'] + [2000, 2005],
 )
 TS_DF = pd.concat([HIST_DF, INP_DF], sort=False)

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -127,12 +127,12 @@ def test_mp(request, tmp_env, test_data_path):
 MODEL = "canning problem"
 SCENARIO = "standard"
 HIST_DF = pd.DataFrame(
-    [[MODEL, SCENARIO, 'DantzigLand', 'GDP', 'USD', 850., 900., 950.], ],
-    columns=IAMC_IDX + [2000, 2005, 2010],
+    [[MODEL, SCENARIO, 'DantzigLand', 'GDP', 'USD', 'Year', 850., 900., 950.], ],
+    columns=IAMC_IDX + ['subannual'] + [2000, 2005, 2010],
 )
 INP_DF = pd.DataFrame(
-    [[MODEL, SCENARIO, 'DantzigLand', 'Demand', 'cases', 850., 900.], ],
-    columns=IAMC_IDX + [2000, 2005],
+    [[MODEL, SCENARIO, 'DantzigLand', 'Demand', 'cases', 'Year', 850., 900.], ],
+    columns=IAMC_IDX + ['subannual'] + [2000, 2005],
 )
 TS_DF = pd.concat([HIST_DF, INP_DF], sort=False)
 TS_DF.sort_values(by='variable', inplace=True)

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -175,6 +175,18 @@ def test_add_timeseries(ts, format):
 
 
 @pytest.mark.parametrize('format', ['long', 'wide'])
+def test_add_timeseries_with_extra_col(ts, format):
+    _data = DATA[0]
+    _data['climate_model'] = [0, 0]
+    data = DATA[0] if format == 'long' else wide(DATA[0])
+
+    # Data added
+    ts.add_timeseries(data)
+    # TODO: add check that warning message is displayed
+    ts.commit('')
+
+
+@pytest.mark.parametrize('format', ['long', 'wide'])
 def test_get(ts, format):
     data = DATA[0] if format == 'long' else wide(DATA[0])
 

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -182,6 +182,11 @@ def test_add_timeseries_with_extra_col(caplog, ts, format):
     _data = DATA[0].copy()
     _data['climate_model'] = [0, 1]
     data = _data if format == 'long' else wide(_data)
+
+    # check that extra column wasn't dropped by `wide(_data)
+    if format == 'wide' and 'climate_model' not in data.index.names:
+        raise ValueError('extra column not formatted correctly!')
+
     # Data added
     ts.add_timeseries(data)
     # TODO: add check that warning message is displayed

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -184,7 +184,7 @@ def test_add_timeseries_with_extra_col(caplog, ts, format):
     data = _data if format == 'long' else wide(_data)
 
     # check that extra column wasn't dropped by `wide(_data)
-    if format == 'wide' and 'climate_model' not in data.index.names:
+    if format == 'wide' and 'climate_model' not in data.columns:
         raise ValueError('extra column not formatted correctly!')
 
     # Data added

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -176,9 +176,9 @@ def test_add_timeseries(ts, format):
 
 @pytest.mark.parametrize('format', ['long', 'wide'])
 def test_add_timeseries_with_extra_col(ts, format):
-    _data = DATA[0]
-    _data['climate_model'] = [0, 0]
-    data = DATA[0] if format == 'long' else wide(DATA[0])
+    _data = DATA[0].copy()
+    _data['climate_model'] = [0, 1]
+    data = _data if format == 'long' else wide(_data)
 
     # Data added
     ts.add_timeseries(data)

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -184,8 +184,7 @@ def test_add_timeseries_with_extra_col(caplog, ts, format):
     data = _data if format == 'long' else wide(_data)
 
     # check that extra column wasn't dropped by `wide(_data)
-    if format == 'wide' and 'climate_model' not in data.columns:
-        raise ValueError('extra column not formatted correctly!')
+    assert 'climate_model' in data.columns
 
     # Data added
     ts.add_timeseries(data)

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -65,8 +65,10 @@ def expected(df, ts):
 
 def wide(df):
     """Transform *df* from long to wide format."""
-    other_cols = [c for c in df.columns if c not in ['year', 'value'] + IAMC_IDX]
-    return df.pivot_table(index=IAMC_IDX + other_cols, columns='year', values='value') \
+    other_cols = [c for c in df.columns
+                  if c not in ['year', 'value'] + IAMC_IDX]
+    return df.pivot_table(index=IAMC_IDX + other_cols,
+                          columns='year', values='value') \
         .reset_index() \
         .rename_axis(columns=None)
 
@@ -184,8 +186,8 @@ def test_add_timeseries_with_extra_col(caplog, ts, format):
     ts.add_timeseries(data)
     # TODO: add check that warning message is displayed
     ts.commit('')
-    assert (["dropping index columns ['climate_model'] from data"] ==
-            [rec.message for rec in caplog.records])
+    assert (["dropping index columns ['climate_model'] from data"] == [
+        rec.message for rec in caplog.records])
 
 
 @pytest.mark.parametrize('format', ['long', 'wide'])

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -201,9 +201,6 @@ def test_get(ts, format):
 
     # Data can be retrieved and has the expected value
     obs = ts.timeseries(**args)
-    print('>>>>>>>>')
-    print(obs.columns)
-    print(exp.columns)
     assert_frame_equal(exp, obs)
 
 

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -153,7 +153,7 @@ def year_list(x):
         try:
             int(i)  # this is a year
             lst.append(i)
-        except TypeError:
+        except ValueError:
             pass
     return lst
 

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -4,7 +4,6 @@ import re
 from urllib.parse import urlparse
 
 import pandas as pd
-import six
 from pathlib import Path
 
 
@@ -147,11 +146,16 @@ def pd_write(df, f, *args, **kwargs):
         writer.save()
 
 
-def numcols(df):
-    """Return the indices of the numeric columns of *df*."""
-    dtypes = df.dtypes
-    return [i for i in dtypes.index
-            if dtypes.loc[i].name.startswith(('float', 'int'))]
+def year_list(x):
+    """Return the elements of x that can be cast to year (int)."""
+    lst = []
+    for i in x:
+        try:
+            int(i)  # this is a year
+            lst.append(i)
+        except TypeError:
+            pass
+    return lst
 
 
 def filtered(df, filters):

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -175,7 +175,7 @@ def import_timeseries(scenario, data, firstyear=None, lastyear=None):
     df = pd_read(data)
     df = df.rename(columns={c: str(c).lower() for c in df.columns})
 
-    cols = numcols(df)
+    cols = year_list(df.columns)
     years = [int(i) for i in cols]
     fyear = int(firstyear or min(years))
     lyear = int(lastyear or max(years))


### PR DESCRIPTION
This PR adds a warning when trying to import a timeseries dataframe with unexpected coumns (e.g., `time`, `climate_model`) - this would have helped me last week to understand why my trials didn't work.

The PR also fixes a problem that timeseries-data-columns were categorised by the content (`dtype`) rather than whether the column name is like a year. A test is added to check for correct behaviour.