### PR TITLE
Reporter.describe modified to not print by default

### DIFF
--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -536,12 +536,12 @@ class Reporter:
         key = key if key else 'file:{}'.format(path.name)
         return self.add(key, (partial(computations.load_file, path),), True)
 
-    def describe(self, key=None, quiet=False):
+    def describe(self, key=None, quiet=True):
         """Return a string describing the computations that produce *key*.
 
         If *key* is not provided, all keys in the Reporter are described.
 
-        The string is also printed. If *quiet*, do not print to the console.
+        The string can be printed to the console, if not *quiet*.
         """
         if key is None:
             # Sort with 'all' at the end

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -491,9 +491,14 @@ def test_reporter_describe(test_mp, test_data_path, capsys):
     - <ixmp.core.Scenario object at {id}>
   - 'config':
     - {{'filters': {{}}}}""".format(id=id_)
-    assert desc1 == r.describe('d:i', quiet=False)
+    assert desc1 == r.describe('d:i')
 
-    # Description was also written to stdout
+    # With quiet=True (default), nothing is printed to stdout
+    out1, _ = capsys.readouterr()
+    assert '' == out1
+
+    # With quiet=False, description is also printed to stdout
+    assert desc1 == r.describe('d:i', quiet=False)
     out1, _ = capsys.readouterr()
     assert desc1 + '\n' == out1
 
@@ -502,7 +507,7 @@ def test_reporter_describe(test_mp, test_data_path, capsys):
                                                     .format(id=id_)
     assert desc2 == r.describe(quiet=False) + '\n'
 
-    # Result was also written to stdout
+    # Since quiet=False, description is also printed to stdout
     out2, _ = capsys.readouterr()
     assert desc2 == out2
 

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -491,7 +491,7 @@ def test_reporter_describe(test_mp, test_data_path, capsys):
     - <ixmp.core.Scenario object at {id}>
   - 'config':
     - {{'filters': {{}}}}""".format(id=id_)
-    assert desc1 == r.describe('d:i')
+    assert desc1 == r.describe('d:i', quiet=False)
 
     # Description was also written to stdout
     out1, _ = capsys.readouterr()
@@ -500,7 +500,7 @@ def test_reporter_describe(test_mp, test_data_path, capsys):
     # Description of all keys is as expected
     desc2 = (test_data_path / 'report-describe.txt').read_text() \
                                                     .format(id=id_)
-    assert desc2 == r.describe() + '\n'
+    assert desc2 == r.describe(quiet=False) + '\n'
 
     # Result was also written to stdout
     out2, _ = capsys.readouterr()


### PR DESCRIPTION
Per suggestion by @awais307 via issue #271, this PR slightly modifies the code in `Reporter.describe()` so that the output is not printed by default. 


## How to review
The method can be run without passing any argument to _quiet_, and the results shouldn't be printed.

## PR checklist

- [x] ~Tests added.~ Minor change in behaviour, no test and documentation is needed.
