### PR TITLE
Write only sets and parameters to Excel by default

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,7 +5,8 @@ All changes
 -----------
 
 - `#295 <https://github.com/iiasa/ixmp/pull/295>`_: Add option to include `subannual` column in dataframe returned by `Scenario.timeseries()`.
-- `#286 <https://github.com/iiasa/ixmp/pull/286>`_: Add :meth:`.Scenario.to_excel` and :meth:`.read_excel`; this functionality is transferred to ixmp from :mod:`message_ix`.
+- `#286 <https://github.com/iiasa/ixmp/pull/286>`_,
+  `#297 <https://github.com/iiasa/ixmp/pull/297>`_: Add :meth:`.Scenario.to_excel` and :meth:`.read_excel`; this functionality is transferred to ixmp from :mod:`message_ix`.
 - `#270 <https://github.com/iiasa/ixmp/pull/270>`_: Include all tests in the ixmp package.
 - `#212 <https://github.com/iiasa/ixmp/pull/212>`_: Add :meth:`Model.initialize` API to help populate new Scenarios according to a model scheme.
 - `#267 <https://github.com/iiasa/ixmp/pull/267>`_: Apply units to reported quantities.

--- a/doc/source/api-backend.rst
+++ b/doc/source/api-backend.rst
@@ -13,7 +13,12 @@ Provided backends
 -----------------
 
 .. automodule:: ixmp.backend
-   :members: BACKENDS, ItemType
+   :members: BACKENDS
+
+   .. autoclass:: ItemType
+      :members:
+      :undoc-members:
+      :member-order: bysource
 
 .. currentmodule:: ixmp.backend.jdbc
 

--- a/ixmp/backend/__init__.py
+++ b/ixmp/backend/__init__.py
@@ -21,21 +21,38 @@ BACKENDS = {}
 
 
 class ItemType(IntFlag):
-    """Type of data items."""
-    #: Time series data variable.
-    TS = 1
-    #: Set.
-    SET = 2
-    #: Parameter.
-    PAR = 4
-    #: Model variable.
-    VAR = 8
-    #: Equation.
-    EQU = 16
+    """Type of data items in :class:`.TimeSeries` and :class:`.Scenario`."""
+    # NB the docstring comments ('#:') are placed as they are to ensure the
+    #    output is readable.
 
+    TS = 1
+    #: Time series data variable.
+    T = TS
+
+    SET = 2
+    #: Set.
+    S = SET
+
+    PAR = 4
+    #: Parameter.
+    P = PAR
+
+    VAR = 8
+    #: Model variable.
+    V = VAR
+
+    EQU = 16
+    #: Equation.
+    E = EQU
+
+    MODEL = SET + PAR + VAR + EQU
     #: All kinds of model-related data, i.e. :attr:`SET`, :attr:`PAR`,
     #: :attr:`VAR` and :attr:`EQU`.
-    MODEL = SET + PAR + VAR + EQU
+    M = MODEL
 
-    #: All data, i.e. :attr:`MODEL` and :attr:`TS`.
+    #: Model solution data, i.e. :attr:`VAR` and :attr:`EQU`.
+    SOLUTION = VAR + EQU
+
     ALL = TS + MODEL
+    #: All data, i.e. :attr:`MODEL` and :attr:`TS`.
+    A = ALL

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -305,8 +305,9 @@ class Backend(ABC):
 
         The default implementation supports:
 
-        - `path` ending in '.xlsx', `item_type` is ItemType.MODEL: write a
-          single Scenario given by kwargs['filters']['scenario'] to file using
+        - `path` ending in '.xlsx', `item_type` is either :attr:`.MODEL` or
+          :attr:`.SET` | :attr:`.PAR`: write a single Scenario given by
+          kwargs['filters']['scenario'] to file using
           :meth:`pandas.DataFrame.to_excel`.
 
         Parameters
@@ -329,8 +330,9 @@ class Backend(ABC):
         read_file
         """
         s, filters = self._handle_rw_filters(kwargs.pop('filters', {}))
-        if path.suffix == '.xlsx' and item_type is ItemType.MODEL and s:
-            s_write_excel(self, s, path)
+        xlsx_types = (ItemType.SET | ItemType.PAR, ItemType.MODEL)
+        if path.suffix == '.xlsx' and item_type in xlsx_types and s:
+            s_write_excel(self, s, path, item_type)
         else:
             raise NotImplementedError
 

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -58,6 +58,7 @@ def s_write_excel(be, s, path, item_type):
     writer = pd.ExcelWriter(path, engine='xlsxwriter')
 
     omitted = set()
+    empty_sets = []
 
     for name, ix_type in name_type.items():
         # Extract data: dict, pd.Series, or pd.DataFrame
@@ -73,12 +74,20 @@ def s_write_excel(be, s, path, item_type):
             # Index set: use own name as the header
             data.name = name
 
-        # Write empty sets, but not equ/par/var
-        if ix_type != 'set' and data.empty:
-            omitted.add(name)
-            continue
+        if data.empty:
+            if ix_type != 'set':
+                # Don't write empty equ/par/var
+                omitted.add(name)
+                continue
+            else:
+                # Write empty sets later
+                empty_sets.append((name, data))
 
         data.to_excel(writer, sheet_name=name, index=False)
+
+    # Write empty sets last
+    for name, data in empty_sets:
+        data.to_excel(writer, sheer_name=name, index=False)
 
     # Discard entries that were not written
     for name in omitted:

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -51,7 +51,8 @@ def s_write_excel(be, s, path, item_type):
     # item name -> ixmp type
     name_type = {}
     for ix_type in ix_types:
-        name_type.update({n: ix_type for n in be.list_items(s, ix_type)})
+        names = sorted(be.list_items(s, ix_type))
+        name_type.update({n: ix_type for n in names})
 
     # Open file
     writer = pd.ExcelWriter(path, engine='xlsxwriter')

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -3,6 +3,7 @@ import logging
 import pandas as pd
 
 from ixmp.utils import as_str_list
+from . import ItemType
 
 
 log = logging.getLogger(__name__)
@@ -33,16 +34,23 @@ def ts_read_file(ts, path, firstyear=None, lastyear=None):
     ts.commit(msg)
 
 
-def s_write_excel(be, s, path):
+def s_write_excel(be, s, path, item_type):
     """Write *s* to a Microsoft Excel file at *path*.
 
     See also
     --------
     Scenario.to_excel
     """
+    # Types of items to write
+    ix_types = ['set', 'par']
+    if ItemType.VAR in item_type:
+        ix_types.append('var')
+    if ItemType.EQU in item_type:
+        ix_types.append('equ')
+
     # item name -> ixmp type
     name_type = {}
-    for ix_type in ('set', 'par', 'var', 'equ'):
+    for ix_type in ix_types:
         name_type.update({n: ix_type for n in be.list_items(s, ix_type)})
 
     # Open file

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -79,15 +79,11 @@ def s_write_excel(be, s, path, item_type):
             if ix_type != 'set':
                 # Don't write empty equ/par/var
                 omitted.add(name)
-                continue
             else:
                 # Write empty sets later
                 empty_sets.append((name, data))
+            continue
 
-        data.to_excel(writer, sheet_name=name, index=False)
-
-    # Write empty sets last
-    for name, data in empty_sets:
         data.to_excel(writer, sheet_name=name, index=False)
 
     # Discard entries that were not written
@@ -99,6 +95,10 @@ def s_write_excel(be, s, path, item_type):
       .rename_axis(index='item') \
       .reset_index() \
       .to_excel(writer, sheet_name='ix_type_mapping', index=False)
+
+    # Write empty sets last
+    for name, data in empty_sets:
+        data.to_excel(writer, sheet_name=name, index=False)
 
     writer.save()
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1515,20 +1515,24 @@ class Scenario(TimeSeries):
         self._backend('set_meta', name, value)
 
     # Input and output
-    def to_excel(self, path):
+    def to_excel(self, path, items=ItemType.SET | ItemType.PAR):
         """Write Scenario to a Microsoft Excel file.
 
         Parameters
         ----------
         path : os.PathLike
-            File to write. Must have suffix '.xlsx'.
+            File to write. Must have suffix :file:`.xlsx`.
+        items : ItemType, optional
+            Types of items to write. Either :attr:`.SET` | :attr:`.PAR` (i.e.
+            only sets and parameters), or :attr:`.MODEL` (also variables and
+            equations, i.e. model solution data).
 
         See also
         --------
         :ref:`excel-data-format`
         read_excel
         """
-        self.platform._backend.write_file(Path(path), ItemType.MODEL,
+        self.platform._backend.write_file(Path(path), items,
                                           filters=dict(scenario=self))
 
     def read_excel(self, path, add_units=False, init_items=False,

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -222,7 +222,8 @@ class TestScenario:
         # Solved Scenario can be written to file
         scen.to_excel(tmp_path)
 
-        # With init_items=False, can't be read into an empty Scenario
+        # With init_items=False, can't be read into an empty Scenario.
+        # Exception raised is the first index set, alphabetically
         with pytest.raises(ValueError, match="no set 'i'; "
                                              "try init_items=True"):
             scen_empty.read_excel(tmp_path)

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -215,12 +215,14 @@ class TestScenario:
         # A 2-D set with ambiguous index names
         scen.init_set('baz_3', ['i', 'i'], ['i', 'i_also'])
         scen.add_set('baz_3', [['seattle', 'seattle']])
+        # A set with no elements
+        scen.init_set('foo_2', ['j'])
 
         scen.commit('')
         scen.solve()
 
         # Solved Scenario can be written to file
-        scen.to_excel(tmp_path)
+        scen.to_excel(tmp_path, items=ixmp.ItemType.MODEL)
 
         # With init_items=False, can't be read into an empty Scenario.
         # Exception raised is the first index set, alphabetically


### PR DESCRIPTION
As discussed at https://github.com/iiasa/message_ix/pull/321#issuecomment-605433824, `Scenario.to_excel()` and underlying code are changed:

- By default, only sets and parameters are written; not variables and equations.
- There is an option to write equations and variables.
- The order of sheets changes:
  1. Non-empty sets, in alphabetical order.
  2. Non-empty parameters, in alphabetical order.
  3. ix_type_mapping.
  4. Empty sets.

Empty parameters, variables, and equations are still not written.

## How to review

- Check that the code works in combination with iiasa/message_ix#321.
- Confirm that CI checks pass.

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.