### PR TITLE
Ensure Java garbage collection

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,4 +37,4 @@ build: false
 
 test_script:
 # Run tests. These include the equivalent of Travis R tests via test_r.py.
-- pytest -m 'rixmp or not performance' --verbose
+- pytest -m "rixmp or not performance" --verbose

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -37,4 +37,4 @@ build: false
 
 test_script:
 # Run tests. These include the equivalent of Travis R tests via test_r.py.
-- pytest --test-r --verbose
+- pytest -m 'rixmp or not performance' --verbose

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,6 +1,11 @@
 # Continuous integration configuration for AppVeyor
 # Based on https://github.com/rmcgibbo/python-appveyor-conda-example
 
+branches:
+  only:
+  - master
+  - 2.0.x
+
 environment:
   # Use the JDK installed on AppVeyor images
   JAVA_HOME: C:\Program Files\Java\jdk13

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 # Continuous integration configuration for Travis
 # NB use https://config.travis-ci.com/explore to validate changes
 
+branches:
+  only:
+  - master
+  - 2.0.x
+
 dist: xenial
 
 language: r

--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,7 @@ install:
 script:
   - python -c "import os, sys; assert os.environ['PYVERSION'] == sys.version[0]"
   # Run tests. These include the equivalent of Travis R tests via test_r.py.
-  - pytest --test-r --verbose ixmp --cov-report=xml
+  - pytest ixmp -m 'rixmp or not performance' --verbose --cov-report=xml
   # Test that documentation can be built
   - cd doc
   - pip install -r requirements.txt

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- `#298 <https://github.com/iiasa/ixmp/pull/298>`_: Improve memory management in :class:`.JDBCBackend`.
 - `#316 <https://github.com/iiasa/ixmp/pull/316>`_: Raise user-friendly exceptions from :meth:`.Reporter.get` in Jupyter notebooks and other read–evaluate–print loops (REPLs).
 - `#315 <https://github.com/iiasa/ixmp/pull/315>`_: Ensure :meth:`.Model.initialize` is always called for new *and* cloned objects.
 - `#320 <https://github.com/iiasa/ixmp/pull/320>`_: Add CLI command `ixmp show-versions` to print ixmp and dependency versions for debugging.

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -4,8 +4,8 @@ FROM openjdk:11-slim-buster
 ARG VIRTUAL_ENV=/opt/python3
 
 RUN apt-get update &&\
-    apt-get install -y --no-install-recommends curl graphviz python3 \
-      python3-distlib python3-pip python3-setuptools unzip &&\
+    apt-get install -y --no-install-recommends curl gcc graphviz python3 \
+      python3-dev python3-distlib python3-pip python3-setuptools unzip &&\
     pip3 install virtualenv &&\
     virtualenv -p python3 $VIRTUAL_ENV
 

--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -5,7 +5,8 @@ ARG VIRTUAL_ENV=/opt/python3
 
 RUN apt-get update &&\
     apt-get install -y --no-install-recommends curl gcc graphviz python3 \
-      python3-dev python3-distlib python3-pip python3-setuptools unzip &&\
+      python3-dev python3-distlib python3-pip python3-setuptools python3-zmq \
+      unzip &&\
     pip3 install virtualenv &&\
     virtualenv -p python3 $VIRTUAL_ENV
 

--- a/ci/conda-requirements.txt
+++ b/ci/conda-requirements.txt
@@ -8,6 +8,7 @@ JPype1 != 0.7.2, != 0.7.3, != 0.7.4
 
 jupyter
 numpydoc
+memory_profiler
 pandas
 pint
 pytest-cov

--- a/conftest.py
+++ b/conftest.py
@@ -12,9 +12,18 @@ def pytest_addoption(parser):
         action='store_true',
         help='also run tests of the ixmp R interface.',
     )
+    parser.addoption(
+        '--test-gc',
+        action='store_true',
+        default=False,
+        help='also run GC tests.',
+    )
 
 
 def pytest_runtest_setup(item):
     if 'rixmp' in item.keywords and \
        not item.config.getoption('--test-r'):
         pytest.skip('skipping rixmp test without --test-r flag')
+    test_gc = item.config.getoption('--test-gc')
+    if bool('test_gc' in item.keywords) != bool(test_gc):
+        pytest.skip('skipping gc test without --test-gc flag')

--- a/conftest.py
+++ b/conftest.py
@@ -1,6 +1,3 @@
-import pytest
-
-
 pytest_plugins = ['ixmp.testing']
 
 
@@ -8,22 +5,16 @@ pytest_plugins = ['ixmp.testing']
 
 def pytest_addoption(parser):
     parser.addoption(
-        '--test-r',
-        action='store_true',
-        help='also run tests of the ixmp R interface.',
+        '--jvm-mem-limit',
+        action='store',
+        default=-1,
+        help=('Memory limit, in MiB, for the Java Virtual Machine (JVM) '
+              'started by the ixmp JDBCBackend'),
     )
     parser.addoption(
-        '--test-gc',
-        action='store_true',
-        default=False,
-        help='also run GC tests.',
+        '--resource-limit',
+        action='store',
+        default='DATA:-1',
+        help=("Limit a Python resource via the ixmp.testing.resource_limit "
+              "fixture. Use e.g. 'DATA:500' to limit RLIMIT_DATA to 500 MiB"),
     )
-
-
-def pytest_runtest_setup(item):
-    if 'rixmp' in item.keywords and \
-       not item.config.getoption('--test-r'):
-        pytest.skip('skipping rixmp test without --test-r flag')
-    test_gc = item.config.getoption('--test-gc')
-    if bool('test_gc' in item.keywords) != bool(test_gc):
-        pytest.skip('skipping gc test without --test-gc flag')

--- a/ixmp/__init__.py
+++ b/ixmp/__init__.py
@@ -1,3 +1,5 @@
+import logging
+
 from ._config import config
 from ._version import get_versions
 from .backend import BACKENDS, ItemType
@@ -8,6 +10,18 @@ from .model.dantzig import DantzigModel
 from .model.gams import GAMSModel
 from .reporting import Reporter
 from .utils import show_versions
+
+__all__ = [
+    'IAMC_IDX',
+    'ItemType',
+    'Platform',
+    'Reporter',
+    'Scenario',
+    'TimeSeries',
+    'config',
+    'log',
+    'show_versions',
+]
 
 __version__ = get_versions()['version']
 del get_versions
@@ -22,13 +36,9 @@ MODELS.update({
     'dantzig': DantzigModel,
 })
 
-__all__ = [
-    'IAMC_IDX',
-    'ItemType',
-    'Platform',
-    'Reporter',
-    'Scenario',
-    'TimeSeries',
-    'config',
-    'show_versions',
-]
+
+# Configure the 'ixmp' logger: write messages to std out, defaulting to level
+# WARNING and above
+log = logging.getLogger(__name__)
+log.addHandler(logging.StreamHandler())
+log.setLevel(logging.WARNING)

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -1007,6 +1007,9 @@ class Backend(ABC):
 class CachingBackend(Backend):
     """Backend with additional features for caching data."""
 
+    #: :obj:`True` if caching is enabled.
+    cache_enabled = True
+
     #: Cache of values. Keys are given by :meth:`_cache_key`; values depend on
     #: the subclass' usage of the cache.
     _cache = {}
@@ -1017,8 +1020,10 @@ class CachingBackend(Backend):
 
     # Backend API methods
 
-    def __init__(self):
+    def __init__(self, cache_enabled=True):
         super().__init__()
+
+        self.cache_enabled = cache_enabled
 
         # Empty the cache
         self._cache = {}
@@ -1072,7 +1077,7 @@ class CachingBackend(Backend):
         """
         key = self._cache_key(ts, ix_type, name, filters)
 
-        if key in self._cache:
+        if self.cache_enabled and key in self._cache:
             self._cache_hit[key] = self._cache_hit.setdefault(key, 0) + 1
             return copy(self._cache[key])
         else:
@@ -1087,6 +1092,10 @@ class CachingBackend(Backend):
             :obj:`True` if the key was already in the cache and its value was
             overwritten.
         """
+        if not self.cache_enabled:
+            # Don't store anything if cache is disabled
+            return False
+
         key = self._cache_key(ts, ix_type, name, filters)
 
         refreshed = key in self._cache

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -1015,12 +1015,20 @@ class CachingBackend(Backend):
     #: using :meth:`cache_get`.
     _cache_hit = {}
 
+    # Backend API methods
+
     def __init__(self):
         super().__init__()
 
         # Empty the cache
         self._cache = {}
         self._cache_hit = {}
+
+    def del_ts(self, ts: TimeSeries):
+        """Invalidate cache entries associated with *ts*."""
+        self.cache_invalidate(ts)
+
+    # New methods for CachingBackend
 
     @classmethod
     def _cache_key(self, ts, ix_type, name, filters=None):

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -445,6 +445,12 @@ class Backend(ABC):
         set_as_default
         """
 
+    def del_ts(self, ts: TimeSeries):
+        """OPTIONAL: Free memory associated with the TimeSeries *ts*.
+
+        The default implementation has no effect.
+        """
+
     @abstractmethod
     def check_out(self, ts: TimeSeries, timeseries_only):
         """Check out *ts* for modification.

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -501,14 +501,6 @@ class JDBCBackend(CachingBackend):
 
         self._index_and_set_attrs(jobj, ts)
 
-    def del_ts(self, ts):
-        # Invalidate CachingBackend entries associated with *ts*
-        super().del_ts(ts)
-
-        # Free the reference to the Java TimeSeries/Scenario object, so it can
-        # be GC'd
-        del self.jindex[ts]
-
     def check_out(self, ts, timeseries_only):
         try:
             self.jindex[ts].checkOut(timeseries_only)
@@ -928,10 +920,6 @@ class JDBCBackend(CachingBackend):
                 raise KeyError(name) from None
             else:  # pragma: no cover
                 _raise_jexception(e)
-
-    def __del__(self):
-        log.debug('Removing platform and closing DB')
-        self.close_db()
 
 
 def start_jvm(jvmargs=None):

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -32,7 +32,7 @@ LOG_LEVELS = {
     'WARNING': 'WARN',
     'INFO': 'INFO',
     'DEBUG': 'DEBUG',
-    'NOTSET': 'ALL',
+    'NOTSET': 'OFF',
 }
 
 # Java classes, loaded by start_jvm(). These become available as e.g.
@@ -213,6 +213,7 @@ class JDBCBackend(CachingBackend):
 
         try:
             self.jobj = java.Platform('Python', properties)
+            self.set_log_level('INFO')
         except java.NoClassDefFoundError as e:  # pragma: no cover
             raise NameError(f'{e}\nCheck that dependencies of ixmp.jar are '
                             f"included in {Path(__file__).parents[2] / 'lib'}")
@@ -922,7 +923,6 @@ class JDBCBackend(CachingBackend):
                 _raise_jexception(e)
 
     def __del__(self):
-        log.debug('Removing platform and closing DB')
         self.close_db()
 
 

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -277,6 +277,8 @@ class JDBCBackend(CachingBackend):
                             'already closed')
             else:
                 log.warning(str(e))
+        except AttributeError:
+            pass  # self.jobj is None, e.g. cleanup after __init__ fails
 
     def get_auth(self, user, models, kind):
         return self.jobj.checkModelAccess(user, kind, to_jlist(models))

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -527,8 +527,8 @@ class JDBCBackend(CachingBackend):
 
     def last_update(self, ts):
         timestamp = self.jindex[ts].getLastUpdateTimestamp()
-        if timestamp:
-            timestamp.toString()
+        if timestamp is not None:
+            return timestamp.toString()
         else:
             return timestamp  # None
 

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -7,6 +7,7 @@ import os
 from pathlib import Path, PurePosixPath
 import re
 from types import SimpleNamespace
+from weakref import WeakKeyDictionary
 
 import jpype
 from jpype import JClass
@@ -132,30 +133,6 @@ def _domain_enum(domain):
                          f'existing domains: {domains}')
 
 
-class IDdict:
-    """Dictionary that stores objects by id(), rather than by reference."""
-    items = {}
-
-    # Set, get, and delete, used by JDBCBackend
-    def __setitem__(self, name, value):
-        self.items[id(name)] = value
-
-    def __getitem__(self, name):
-        return self.items[id(name)]
-
-    def __delitem__(self, name):
-        del self.items[id(name)]
-
-    # String representation for debugging
-    def __repr__(self):
-        from sys import getrefcount
-
-        result = []
-        for k, v in self.items.items():
-            result.append(f'{k}: {v} ({getrefcount(v)} refs)')
-        return '\n'.join(result)
-
-
 class JDBCBackend(CachingBackend):
     """Backend using JPype/JDBC to connect to Oracle and HyperSQLDB instances.
 
@@ -198,7 +175,7 @@ class JDBCBackend(CachingBackend):
 
     #: Mapping from ixmp.TimeSeries object to the underlying
     #: at.ac.iiasa.ixmp.Scenario object (or subclasses of either)
-    jindex = IDdict()
+    jindex = WeakKeyDictionary()
 
     def __init__(self, jvmargs=None, **kwargs):
         properties = None

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -952,6 +952,10 @@ class JDBCBackend(CachingBackend):
             else:  # pragma: no cover
                 _raise_jexception(e)
 
+    def __del__(self):
+        log.debug('Removing platform and closing DB')
+        self.close_db()
+
 
 def start_jvm(jvmargs=None):
     """Start the Java Virtual Machine via :mod:`JPype`.

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -207,6 +207,9 @@ class JDBCBackend(CachingBackend):
         # Invoke the parent constructor to initialize the cache
         super().__init__(cache_enabled=kwargs.pop('cache', True))
 
+        # Extract a log_level keyword argument before _create_properties()
+        log_level = kwargs.pop('log_level', 'INFO')
+
         # Create a database properties object
         if properties:
             # ...using file contents
@@ -226,7 +229,6 @@ class JDBCBackend(CachingBackend):
 
         try:
             self.jobj = java.Platform('Python', properties)
-            self.set_log_level('INFO')
         except java.NoClassDefFoundError as e:  # pragma: no cover
             raise NameError(f'{e}\nCheck that dependencies of ixmp.jar are '
                             f"included in {Path(__file__).parents[2] / 'lib'}")
@@ -240,6 +242,9 @@ class JDBCBackend(CachingBackend):
             elif jclass.endswith('FlywayException'):
                 msg = f'when initializing database:'
             _raise_jexception(e, f'{msg}\n(Java: {jclass})')
+
+        # Set the log level
+        self.set_log_level(log_level)
 
     # Platform methods
 

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -525,6 +525,11 @@ class JDBCBackend(CachingBackend):
         self._index_and_set_attrs(jobj, ts)
 
     def del_ts(self, ts):
+        # Invalidate CachingBackend entries associated with *ts*
+        super().del_ts(ts)
+
+        # Free the reference to the Java TimeSeries/Scenario object, so it can
+        # be GC'd
         del self.jindex[ts]
 
     def check_out(self, ts, timeseries_only):

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -921,6 +921,10 @@ class JDBCBackend(CachingBackend):
             else:  # pragma: no cover
                 _raise_jexception(e)
 
+    def __del__(self):
+        log.debug('Removing platform and closing DB')
+        self.close_db()
+
 
 def start_jvm(jvmargs=None):
     """Start the Java Virtual Machine via :mod:`JPype`.

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -134,7 +134,7 @@ def _domain_enum(domain):
 
 
 class JDBCBackend(CachingBackend):
-    """Backend using JPype/JDBC to connect to Oracle and HyperSQLDB instances.
+    """Backend using JPype/JDBC to connect to Oracle and HyperSQL databases.
 
     Parameters
     ----------
@@ -150,6 +150,9 @@ class JDBCBackend(CachingBackend):
         Database user name.
     password : str, optional
         Database user password.
+    cache : bool, optional
+        If :obj:`True` (the default), cache Python objects after conversion
+        from Java objects.
     jvmargs : str, optional
         Java Virtual Machine arguments. See :meth:`.start_jvm`.
     dbprops : path-like, optional
@@ -194,6 +197,9 @@ class JDBCBackend(CachingBackend):
 
         start_jvm(jvmargs)
 
+        # Invoke the parent constructor to initialize the cache
+        super().__init__(cache_enabled=kwargs.pop('cache', True))
+
         # Create a database properties object
         if properties:
             # ...using file contents
@@ -227,9 +233,6 @@ class JDBCBackend(CachingBackend):
             elif jclass.endswith('FlywayException'):
                 msg = f'when initializing database:'
             _raise_jexception(e, f'{msg}\n(Java: {jclass})')
-
-        # Invoke the parent constructor to initialize the cache
-        super().__init__()
 
     # Platform methods
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -51,6 +51,9 @@ class Platform:
         :class:`.JDBCBackend`.
     """
 
+    # Storage back end for the platform
+    _backend = None
+
     # List of method names which are handled directly by the backend
     _backend_direct = [
         'open_db',
@@ -442,6 +445,10 @@ class TimeSeries:
     def _backend(self, method, *args, **kwargs):
         """Convenience for calling *method* on the backend."""
         return self.platform._backend(self, method, *args, **kwargs)
+
+    def __del__(self):
+        # Instruct the back end to free memory associated with the TimeSeries
+        self._backend('del_ts')
 
     # Transactions and versioning
     # functions for platform management

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -817,10 +817,6 @@ class Scenario(TimeSeries):
         # Use the model class to initialize the Scenario
         model_class.initialize(self, **model_init_args)
 
-    @property
-    def _cache(self):
-        return hasattr(self.platform._backend, '_cache')
-
     @classmethod
     def from_url(cls, url, errors='warn'):
         """Instantiate a Scenario given an ixmp-scheme URL.
@@ -895,7 +891,7 @@ class Scenario(TimeSeries):
         ValueError
             If the Scenario was instantiated with ``cache=False``.
         """
-        if not self._cache:
+        if not getattr(self.platform._backend, 'cache_enabled', False):
             raise ValueError('Cache must be enabled to load scenario data')
 
         for ix_type in 'equ', 'par', 'set', 'var':

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -109,12 +109,21 @@ class Platform:
         level : str
             Name of a :py:ref:`Python logging level <levels>`.
         """
-        if level not in dir(logging):
-            msg = '{} not a valid Python logger level, see ' + \
+        if not (level in dir(logging) or isinstance(level, int)):
+            raise ValueError(
+                f'{repr(level)} is not a valid Python logger level, see '
                 'https://docs.python.org/3/library/logging.html#logging-level'
-            raise ValueError(msg.format(level))
-        log.setLevel(level)
-        logger().setLevel(level)
+            )
+
+        # Set the level for the 'ixmp' logger
+        # NB this may produce unexpected results when multiple Platforms exist
+        #    and different log levels are set. To fix, could use a sub-logger
+        #    per Platform instance.
+        logging.getLogger('ixmp').setLevel(level)
+
+        # Set the level for the 'ixmp.backend.*' logger. For JDBCBackend, this
+        # also has the effect of setting the level for Java log messages that
+        # are printed to stdout.
         self._backend.set_log_level(level)
 
     def get_log_level(self):

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -39,7 +39,12 @@ from itertools import product
 import logging
 from math import ceil
 import os
-import resource
+try:
+    import resource
+    has_resource_module = True
+except ImportError:
+    # Windows
+    has_resource_module = False
 import shutil
 import subprocess
 import sys
@@ -685,6 +690,9 @@ def resource_limit(request):
     The original limit, if any, is reset after the test function in which the
     fixture is used.
     """
+    if not has_resource_module:
+        pytest.skip("Python module 'resource' not available (non-Unix OS)")
+
     name, value = request.config.getoption('--resource-limit').split(':')
     res = getattr(resource, f'RLIMIT_{name.upper()}')
     value = int(value)

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -33,7 +33,8 @@ These include:
 
 """
 from collections import namedtuple
-from contextlib import contextmanager, nullcontext
+import contextlib
+from contextlib import contextmanager
 from copy import deepcopy
 import io
 from itertools import chain, product
@@ -453,6 +454,8 @@ def assert_logs(caplog, message_or_messages=None, at_level=None):
         # temporarily set the level of the 'ixmp' logger
         ctx = caplog.at_level(at_level, logger='ixmp')
     else:
+        # Python 3.6 compatibility: use suppress for nullcontext
+        nullcontext = getattr(contextlib, 'nullcontext', contextlib.suppress)
         # ctx does nothing
         ctx = nullcontext()
 

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -33,9 +33,10 @@ These include:
 
 """
 from collections import namedtuple
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
+from copy import deepcopy
 import io
-from itertools import product
+from itertools import chain, product
 import logging
 from math import ceil
 import os
@@ -104,7 +105,10 @@ def protect_pint_app_registry():
     other tests is not altered.
     """
     import pint
-    saved = pint.get_application_registry()
+    # Use deepcopy() in case the wrapped code modifies the application
+    # registry without swapping out the UnitRegistry instance for a different
+    # one
+    saved = deepcopy(pint.get_application_registry())
     yield
     pint.set_application_registry(saved)
 

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -130,8 +130,10 @@ def test_mp(request, tmp_env, test_data_path):
                              url=f'jdbc:hsqldb:mem:{platform_name}')
 
     # Launch Platform
-    yield Platform(name=platform_name)
-
+    mp = Platform(name=platform_name)
+    yield mp
+    mp.set_log_level('NOTSET')
+    del mp
     # Teardown: remove from config
     ixmp_config.remove_platform(platform_name)
 

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -138,6 +138,15 @@ def test_mp(request, tmp_env, test_data_path):
     ixmp_config.remove_platform(platform_name)
 
 
+def bool_param_id(name):
+    """Parameter ID callback for :meth:`pytest.mark.parametrize`.
+
+    This formats a boolean value as 'name0' (False) or 'name1' (True) for
+    easier selection with e.g. ``pytest -k 'name0'``.
+    """
+    return lambda value: '{}{}'.format(name, int(value))
+
+
 # Create and populate ixmp databases
 
 MODEL = "canning problem"

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -145,9 +145,13 @@ def test_mp(request, tmp_env, test_data_path):
     # Launch Platform
     mp = Platform(name=platform_name)
     yield mp
-    mp.set_log_level('NOTSET')
+
+    # Teardown: don't show log messages when destroying the platform, even if
+    # the test using the fixture modified the log level
+    mp._backend.set_log_level(logging.CRITICAL)
     del mp
-    # Teardown: remove from config
+
+    # Remove from config
     ixmp_config.remove_platform(platform_name)
 
 

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -32,14 +32,18 @@ These include:
      get_cell_output
 
 """
+from collections import namedtuple
 from contextlib import contextmanager
 import io
+import logging
 import os
+import resource
 import shutil
 import subprocess
 import sys
 
 from click.testing import CliRunner
+import numpy as np
 import pandas as pd
 from pandas.testing import assert_series_equal
 import pytest
@@ -47,6 +51,8 @@ import pytest
 from . import cli, config as ixmp_config
 from .core import Platform, TimeSeries, Scenario, IAMC_IDX
 
+
+log = logging.getLogger(__name__)
 
 models = {
     'dantzig': {
@@ -484,3 +490,202 @@ def assert_qty_allclose(a, b, check_attrs=True, **kwargs):
     # check attributes are equal
     if check_attrs:
         assert a.attrs == b.attrs
+
+
+# Data structure for memory information used by :meth:`memory_usage`.
+_MemInfo = namedtuple('MemInfo', [
+    'profiled',
+    'max_rss',
+    'jvm_total',
+    'jvm_free',
+    'jvm_used',
+    'python',
+])
+
+
+def MemInfo(arr, cls=float):
+    """Return a namedtuple for *array*, with values as *cls*."""
+    # Format strings
+    cls = '{: >7.2f}'.format if cls is str else cls
+    return _MemInfo(*map(cls, arr))
+
+
+# Variables for memory_usage
+_COUNT = 0
+_PREV = np.zeros(6)
+_RT = None
+
+
+def memory_usage(message='', reset=False):
+    """Profile memory usage from within a test function.
+
+    The Python package ``memory_profiler`` and :mod:`jpype` are used to report
+    memory usage. A message is logged at the ``DEBUG`` level, similar to::
+
+       DEBUG    ixmp.testing:testing.py:527  42 <message>
+       MemInfo(profiled=' 533.76', max_rss=' 534.19', jvm_total=' 213.50',
+               jvm_free='  79.22', jvm_used=' 134.28', python='399.48')
+       MemInfo(profiled='   0.14', max_rss='   0.00', jvm_total='   0.00',
+               jvm_free=' -37.75', jvm_used='  37.75', python=' -37.61')
+
+    Parameters
+    ----------
+    message : str, optional
+        A string added to the log message, to aid in identifying points in
+        profiled code.
+    reset : bool, optional
+        If :obj:`True`, start profiling anew.
+
+    Returns
+    -------
+    collections.namedtuple
+        A ``MemInfo`` tuple with the following fields, all in MiB:
+
+        - ``profiled``: the instantaneous memory usage reported by
+          memory_profiler.
+        - ``max_rss``: the maximum resident set size (i.e. the maximum over
+          the entire life of the process) reported by
+          :meth:`resource.getrusage`.
+        - ``jvm_total``: total memory allocated for the Java Virtual Machine
+          (JVM) underlying JPype, used by :class:`.JDBCBackend`; the same as
+          ``java.lang.Runtime.getRuntime().totalMemory()``.
+        - ``jvm_free``: memory allocated to the JVM that is free.
+        - ``jvm_used``: memory used by the JVM, i.e. ``jvm_total`` minus
+          ``jvm_free``.
+        - ``python``: a rough estimate of Python memory usage, i.e.
+          ``profiled`` minus ``jvm_used``. This may not be accurate.
+    """
+    import memory_profiler
+    from ixmp.backend.jdbc import java
+
+    global _COUNT, _PREV, _RT
+
+    if reset:
+        _COUNT = 0
+        _PREV = np.zeros(6)
+    else:
+        _COUNT += 1
+
+    try:
+        # Get the Java runtime
+        runtime = _RT or java.Runtime.getRuntime()
+    except AttributeError:
+        # JVM not loaded
+        runtime = None
+
+    # Collect data
+    result = [
+        memory_profiler.memory_usage()[0],
+        resource.getrusage(resource.RUSAGE_SELF).ru_maxrss / 1024,  # to MiB
+        ]
+    if runtime:
+        _RT = runtime
+        result.extend([
+            _RT.totalMemory() / 1024 ** 2,
+            _RT.freeMemory() / 1024 ** 2,
+        ])
+    else:
+        result.extend([0, 0])
+
+    # JVM total - JVM free = JVM used
+    result.append(result[-2] - result[-1])
+
+    # Python used - JVM used = only-Python used?
+    result.append(result[0] - result[-1])
+
+    # Convert to a numpy array
+    result = np.array(result)
+
+    # Difference versus previous call
+    delta = result - _PREV
+
+    # Store current *result* to compute *delta* in subsequent calls
+    _PREV = result
+
+    # Log the results
+    msg = '\n'.join([
+        f'{_COUNT:3d} {message}',
+        repr(MemInfo(result, str)),
+        repr(MemInfo(delta, str)),
+    ])
+    log.debug(msg)
+
+    # Return the current result
+    return MemInfo(result)
+
+
+def random_ts_data(length):
+    """A :class:`pandas.DataFrame` of time series data with *length* rows.
+
+    Suitable for passage to :meth:`TimeSeries.add_timeseries`.
+    """
+    return pd.DataFrame.from_dict(dict(
+         region='World',
+         variable=[f'foo|{i}' for i in range(int(length))],
+         year=2020,
+         value=np.random.rand(int(length)),
+         unit='GWa',
+    ))
+
+
+def add_random_model_data(scenario, length):
+    """Add a set and parameter with given *length* to *scenario*.
+
+    The set is named 'random_set'. The parameter is named 'random_par', and
+    has one dimension indexed by 'random_set'.
+    """
+    set_data, par_data = random_model_data(length)
+    scenario.init_set('random_set')
+    scenario.add_set('random_set', set_data)
+    scenario.init_par('random_par', ['random_set'])
+    scenario.add_par('random_par', par_data)
+
+
+def random_model_data(length):
+    """Random (set, parameter) data with *length* elements.
+
+    See also
+    --------
+    add_random_model_data
+    """
+    set_data = list(str(i) for i in range(int(length)))
+    par_data = pd.DataFrame.from_dict(dict(
+         region='World',
+         random_set=set_data,
+         value=np.random.rand(int(length)),
+         unit='GWa',
+    ))
+    return set_data, par_data
+
+
+@pytest.fixture(scope='function')
+def resource_limit(request):
+    """A fixture that limits Python :mod:`resources`.
+
+    See the documentation (``pytest --help``) for the ``--resource-limit``
+    command-line option that selects (1) the specific resource and (2) the
+    level of the limit.
+
+    The original limit, if any, is reset after the test function in which the
+    fixture is used.
+    """
+    name, value = request.config.getoption('--resource-limit').split(':')
+    res = getattr(resource, f'RLIMIT_{name.upper()}')
+    value = int(value)
+
+    if res in (resource.RLIMIT_AS, resource.RLIMIT_DATA, resource.RLIMIT_RSS):
+        value = value * 1024 ** 2  # MiB → bytes
+
+    if value > 0:
+        # Store existing limit
+        before = resource.getrlimit(res)
+
+        log.debug(f'Change {res} from {before} to ({value}, {before[1]})')
+        resource.setrlimit(res, (value, before[1]))
+
+    try:
+        yield
+    finally:
+        if value > 0:
+            log.debug(f'Restore {res} to {before}')
+            resource.setrlimit(res, before)

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -197,26 +197,6 @@ def test_del_ts():
     # Backend is again empty
     assert len(mp._backend.jindex) == 0
 
-    # Create a single Scenario
-    s = ixmp.Scenario(mp, 'foo', 'bar', version='new')
-
-    backend = mp._backend
-
-    # Delete the Platform. Note that this only has an effect if there are no
-    # existing references to it
-    del mp
-
-    # But s.platform is still a reference
-    assert isinstance(s.platform, ixmp.Platform)
-    # So there are *two* remaining references to the *backend*:
-    # - *backend* in the local scope.
-    # - s.platform._backend
-    assert getrefcount(backend) - 1 == 2
-
-    # Only once *s* is deleted is the backend dereferenced/available for GC:
-    del s
-    assert getrefcount(backend) - 1 == 1
-
 
 @pytest.mark.test_gc
 def test_gc():

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -49,6 +49,13 @@ def test_close(test_mp, capfd):
     # Close again, once already closed
     test_mp.close_db()
 
+    # With the default log level, WARNING, nothing is printed
+    captured = capfd.readouterr()
+    assert captured.out == ''
+
+    # With log level INFO, a message is printed
+    test_mp.set_log_level(logging.INFO)
+    test_mp.close_db()
     captured = capfd.readouterr()
     msg = 'Database connection could not be closed or was already closed'
     assert msg in captured.out

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -191,7 +191,7 @@ def test_del_ts(test_mp):
         del s_jobj
 
 
-@pytest.mark.skip(reason='Cannot run normally as not possible to recreate JVM')
+@pytest.mark.test_gc
 def test_gc():
     from ixmp import config as ixmp_config
     platform_name = 'test_del_ts'

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -207,7 +207,7 @@ def test_gc():
 
     # create a list of some Scenario objects
     scenarios = []
-    raises(RuntimeError, allocate_scenarios, 1000)
+    raises(RuntimeError, allocate_scenarios, 100000)
     max = len(scenarios)
 
     # cleanup

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -155,7 +155,7 @@ def test_del_ts():
                        url=f'jdbc:hsqldb:mem:test_del_ts')
 
     # Number of Java objects referenced by the JDBCBackend
-    N_obj = len(mp._backend.jindex.items)
+    N_obj = len(mp._backend.jindex)
     assert N_obj == 0
 
     # Create a list of some Scenario objects
@@ -167,7 +167,7 @@ def test_del_ts():
         )
 
     # Number of referenced objects has increased by 8
-    assert len(mp._backend.jindex.items) == N_obj + N
+    assert len(mp._backend.jindex) == N_obj + N
 
     # Pop and free the objects
     for i in range(N):
@@ -186,16 +186,16 @@ def test_del_ts():
         del s
 
         # Number of referenced objects decreases by 1
-        assert len(mp._backend.jindex.items) == N_obj + N - (i + 1)
+        assert len(mp._backend.jindex) == N_obj + N - (i + 1)
         # ID is no longer in JDBCBackend.jindex
-        assert s_id not in mp._backend.jindex.items
+        assert s_id not in mp._backend.jindex
 
         # s_jobj is the only remaining reference to the Java object
         assert getrefcount(s_jobj) - 1 == 1
         del s_jobj
 
     # Backend is again empty
-    assert len(mp._backend.jindex.items) == 0
+    assert len(mp._backend.jindex) == 0
 
     # Create a single Scenario
     s = ixmp.Scenario(mp, 'foo', 'bar', version='new')

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -156,7 +156,6 @@ def test_del_ts():
 
     # Number of Java objects referenced by the JDBCBackend
     N_obj = len(mp._backend.jindex)
-    assert N_obj == 0
 
     # Create a list of some Scenario objects
     N = 8
@@ -195,7 +194,7 @@ def test_del_ts():
         del s_jobj
 
     # Backend is again empty
-    assert len(mp._backend.jindex) == 0
+    assert len(mp._backend.jindex) == N_obj
 
 
 @pytest.mark.test_gc

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -191,6 +191,7 @@ def test_del_ts(test_mp):
         del s_jobj
 
 
+@pytest.mark.skip(reason='Cannot run normally as not possible to recreate JVM')
 def test_gc():
     from ixmp import config as ixmp_config
     platform_name = 'test_del_ts'

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -70,6 +70,20 @@ def test_connect_message(capfd, caplog):
     assert msg in captured.out
 
 
+@pytest.mark.parametrize('arg', [True, False])
+def test_cache_arg(arg):
+    """Test 'cache' argument, passed to CachingBackend."""
+    mp = ixmp.Platform(backend='jdbc', driver='hsqldb',
+                       url='jdbc:hsqldb:mem://test_cache_false',
+                       cache=arg)
+    scen = make_dantzig(mp)
+
+    # Maybe put something in the cache
+    scen.par('a')
+
+    assert len(mp._backend._cache) == (1 if arg else 0)
+
+
 def test_read_file(test_mp, tmp_path):
     be = test_mp._backend
 

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -200,17 +200,14 @@ def test_del_ts():
 
 @pytest.mark.test_gc
 def test_gc():
-    from ixmp import config as ixmp_config
-    platform_name = 'test_del_ts'
-    ixmp_config.add_platform(platform_name, 'jdbc', 'hsqldb',
-                             url=f'jdbc:hsqldb:mem:{platform_name}')
-    test_mp = ixmp.Platform(name=platform_name, jvmargs='-Xmx7m')
+    mp = ixmp.Platform(backend='jdbc', driver='hsqldb',
+                       url=f'jdbc:hsqldb:mem:test_gc', jvmargs='-Xmx7m')
     jpype.java.lang.System.gc()
 
     def allocate_scenarios(n):
         for i in range(n):
             scenarios.append(
-                ixmp.Scenario(test_mp, 'foo', f'bar{i}', version='new')
+                ixmp.Scenario(mp, 'foo', f'bar{i}', version='new')
             )
 
     # create a list of some Scenario objects

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -169,7 +169,7 @@ def test_weakref():
     del mp
 
     # s.platform is a dead weak reference, so it can't be accessed
-    with pytest.raises(AttributeError):
+    with pytest.raises(ReferenceError):
         s.platform._backend
 
     # There is only one remaining reference to the backend: the *backend* name

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -147,7 +147,7 @@ def test_add_timeslice_duplicate_raise(test_mp):
 def test_weakref():
     """Weak references allow Platforms to be del'd while Scenarios live."""
     mp = ixmp.Platform(backend='jdbc', driver='hsqldb',
-                       url=f'jdbc:hsqldb:mem:test_del_ts')
+                       url=f'jdbc:hsqldb:mem:test_weakref')
 
     # There is one reference to the Platform, and zero weak references
     assert getrefcount(mp) - 1 == 1

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -34,13 +34,6 @@ def log_level_mp(test_mp):
     ('NOTSET', None),
     # An unknown string fails
     ('FOO', ValueError),
-    # TODO also support Python standard library values
-    (logging.CRITICAL, ValueError),
-    (logging.ERROR, ValueError),
-    (logging.WARNING, ValueError),
-    (logging.INFO, ValueError),
-    (logging.DEBUG, ValueError),
-    (logging.NOTSET, ValueError),
 ])
 def test_log_level(log_level_mp, level, exc):
     """Log level can be set and retrieved."""

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -1,5 +1,7 @@
 """Test all functionality of ixmp.Platform."""
 import logging
+from sys import getrefcount
+from weakref import getweakrefcount
 
 import pandas as pd
 import pytest
@@ -140,3 +142,43 @@ def test_add_timeslice_duplicate_raise(test_mp):
     with raises(ValueError, match='timeslice `foo_slice` already defined with '
                                   'duration 0.2'):
         test_mp.add_timeslice('foo_slice', 'bar_category', 0.3)
+
+
+def test_weakref():
+    """Weak references allow Platforms to be del'd while Scenarios live."""
+    mp = ixmp.Platform(backend='jdbc', driver='hsqldb',
+                       url=f'jdbc:hsqldb:mem:test_del_ts')
+
+    # There is one reference to the Platform, and zero weak references
+    assert getrefcount(mp) - 1 == 1
+    assert getweakrefcount(mp) == 0
+
+    # Create a single Scenario
+    s = ixmp.Scenario(mp, 'foo', 'bar', version='new')
+
+    # Still one reference to the Platform
+    assert getrefcount(mp) - 1 == 1
+    # …but additionally one weak reference
+    assert getweakrefcount(mp) == 1
+
+    # Make a local reference to the backend
+    backend = mp._backend
+
+    # Delete the Platform. Note that this only has an effect if there are no
+    # existing references to it
+    del mp
+
+    # s.platform is a dead weak reference, so it can't be accessed
+    with pytest.raises(AttributeError):
+        s.platform._backend
+
+    # There is only one remaining reference to the backend: the *backend* name
+    # in the local scope
+    assert getrefcount(backend) - 1 == 1
+
+    # The backend is garbage-collected at this point
+
+    # The Scenario object still lives, but can't be used for anything
+    assert s.model == 'foo'
+
+    # *s* is garbage-collected at this point

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -7,6 +7,7 @@ from pandas.testing import assert_frame_equal
 
 from ixmp import TimeSeries, Scenario
 from ixmp.core import IAMC_IDX
+from datetime import datetime, timedelta
 
 # Test data.
 # NB the columns are in a specific order; model and scenario come last in the
@@ -185,9 +186,10 @@ def test_last_update(ts):
 
     ts.commit('')
 
-    pytest.xfail()  # FIXME
     # After committing, last_update() returns a string
-    assert ts.last_update() == 'foo'
+    last_update = ts.last_update()
+    actual = datetime.strptime(last_update, '%Y-%m-%d %H:%M:%S.%f')
+    assert abs(actual - datetime.now()) < timedelta(seconds=1)
 
 
 @pytest.mark.parametrize('fmt', ['long', 'wide'])

--- a/ixmp/tests/reporting/test_computations.py
+++ b/ixmp/tests/reporting/test_computations.py
@@ -31,10 +31,9 @@ def test_apply_units(data, caplog):
     # No change in values
     assert_series_equal(result.to_series(), x.to_series())
 
-    caplog.set_level(logging.DEBUG)
-
     # Compatible units: magnitudes are also converted
-    with assert_logs(caplog, "Convert 'kilogram' to 'metric_ton'"):
+    with assert_logs(caplog, "Convert 'kilogram' to 'metric_ton'",
+                     at_level=logging.DEBUG):
         result = computations.apply_units(x, 'tonne')
     assert result.attrs['_unit'] == registry.Unit('tonne')
     assert_series_equal(result.to_series(), x.to_series() * 0.001)

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -1,4 +1,5 @@
 """Tests for ixmp.reporting."""
+import logging
 import os
 
 import ixmp
@@ -524,13 +525,15 @@ def test_platform_units(test_mp, caplog, ureg):
     x.loc[0, 'unit'] = 'kg'
     scen.add_par('x', x)
 
-    with assert_logs(caplog, "x: mixed units ['kg', 'USD/pkm'] discarded"):
+    with assert_logs(caplog, "x: mixed units ['kg', 'USD/pkm'] discarded",
+                     at_level=logging.INFO):
         rep.get(x_key)
 
     # Configured unit substitutions are applied
     rep.graph['config']['units'] = dict(apply=dict(x='USD/pkm'))
 
-    with assert_logs(caplog, "x: replace units dimensionless with USD/pkm"):
+    with assert_logs(caplog, "x: replace units dimensionless with USD/pkm",
+                     at_level=logging.INFO):
         x = rep.get(x_key)
 
     # Applied units are pint objects with the correct dimensionality

--- a/ixmp/tests/test_model.py
+++ b/ixmp/tests/test_model.py
@@ -51,14 +51,15 @@ def test_model_initialize(test_mp, caplog):
 
     # Unrecognized Scenario(scheme=...) is initialized using the base method, a
     # no-op
-    caplog.set_level(logging.DEBUG)
     with assert_logs(caplog, [
             "No scheme for new Scenario model-name/scenario-name",
-            "No initialization for None-scheme Scenario"]):
+            "No initialization for None-scheme Scenario",
+            ], at_level=logging.DEBUG):
         Scenario(test_mp, model='model-name', scenario='scenario-name',
                  version='new')
 
-    with assert_logs(caplog, "No initialization for 'foo'-scheme Scenario"):
+    with assert_logs(caplog, "No initialization for 'foo'-scheme Scenario",
+                     at_level=logging.DEBUG):
         Scenario(test_mp, model='model-name', scenario='scenario-name',
                  version='new', scheme='foo')
 
@@ -81,7 +82,6 @@ def test_model_initialize(test_mp, caplog):
     s.init_par('b', idx_sets=['i'], idx_names=['i_dim'])
 
     # Logs an error message
-    caplog.set_level(logging.WARNING)
     with assert_logs(caplog,
                      "Existing index sets of 'b' ['i'] do not match ['j']"):
         DantzigModel.initialize(s)

--- a/ixmp/tests/test_model.py
+++ b/ixmp/tests/test_model.py
@@ -51,10 +51,11 @@ def test_model_initialize(test_mp, caplog):
 
     # Unrecognized Scenario(scheme=...) is initialized using the base method, a
     # no-op
-    with assert_logs(caplog, [
-            "No scheme for new Scenario model-name/scenario-name",
-            "No initialization for None-scheme Scenario",
-            ], at_level=logging.DEBUG):
+    messages = [
+        "No scheme for new Scenario model-name/scenario-name",
+        "No initialization for None-scheme Scenario",
+    ]
+    with assert_logs(caplog, messages, at_level=logging.DEBUG):
         Scenario(test_mp, model='model-name', scenario='scenario-name',
                  version='new')
 

--- a/ixmp/tests/test_utils.py
+++ b/ixmp/tests/test_utils.py
@@ -1,4 +1,6 @@
 """Tests for ixmp.utils."""
+import logging
+
 import pytest
 from pytest import mark, param
 
@@ -103,5 +105,6 @@ def test_maybe_commit(caplog, test_mp):
 
     # *s* is already commited. No commit is performed, but the function call
     # succeeds and a message is logged
+    caplog.set_level(logging.INFO, logger='ixmp')
     assert utils.maybe_commit(s, True, message='foo') is False
     assert caplog.messages[-1].startswith("maybe_commit() didn't commit: ")

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,10 +13,11 @@ parentdir_prefix = ixmp-
 # - https://github.com/iiasa/ixmp/issues/229
 # - https://github.com/iiasa/ixmp/issues/247
 addopts = --cov=ixmp --cov-config=ci/coveragerc --cov-report=
+    -m 'not rixmp and not performance'
     -p no:faulthandler
 markers =
-    rixmp: test of the ixmp R interface
-    test_gc: test of using gc
+    rixmp: test of the ixmp R interface.
+    performance: ixmp performance test.
 
 [aliases]
 test = pytest

--- a/setup.cfg
+++ b/setup.cfg
@@ -16,6 +16,7 @@ addopts = --cov=ixmp --cov-config=ci/coveragerc --cov-report=
     -p no:faulthandler
 markers =
     rixmp: test of the ixmp R interface
+    test_gc: test of using gc
 
 [aliases]
 test = pytest

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ INSTALL_REQUIRES = [
 ]
 
 EXTRAS_REQUIRE = {
-    'tests': ['codecov', 'jupyter', 'pretenders>=1.4.4', 'pytest-cov',
-              'pytest>=5', 'sparse'],
+    'tests': ['codecov', 'jupyter', 'memory_profiler', 'pretenders>=1.4.4',
+              'pytest-cov', 'pytest>=5', 'sparse'],
     'docs': ['numpydoc', 'sphinx', 'sphinx_rtd_theme', 'sphinxcontrib-bibtex'],
     'tutorial': ['jupyter'],
 }


### PR DESCRIPTION
This PR responds to reports from @OFR-IIASA that JDBCBackend was exhausting memory after loading ~5 Scenarios of the MESSAGEix-GLOBIOM global model.
- The symptom was that Python or GAMS would be unable to allocate sufficient memory; this was because Java was using it.

UPD: symptom was Java toGDX was throwing OutOfMemory exception due to the objects from heap could not be garbage collected (having referenced either from java or from python via JPype1).

The changes:
- Add the base.Backend method `del_ts`, called by `TimeSeries.__del__`.
  This signals the Backend to perform any clean-up when the TimeSeries (or Scenario) object is cleaned up.
- `CachingBackend.del_ts` empties the Python cache associated with the TimeSeries object that's being deleted. Add `test_cache_del_ts` to test this behaviour.
- Modify `JDBCBackend.jindex` to use a [WeakKeyDictionary](https://docs.python.org/3/library/weakref.html#weakref.WeakKeyDictionary)
  *Technical explanation:* Formerly this was a dict of (Python TimeSeries/Scenario object → Java TimeSeries/Scenario object, via JPype); but the keys referencing the TimeSeries objects prevented them from being garbage collected. WeakRefDictionary ensures that the dict key is not counted as a reference to the object.
  Add `test_del_ts()` to test this.
- `{TimeSeries,Scenario}.platform` are now [proxy objects](https://docs.python.org/3/library/weakref.html#weakref.proxy), with the same logic: an existing Scenario that references a Platform does not prevent `del platform`. Add `test_weakref` to test this.
- `test_jdbc.test_gc` and the pytest mark `test_gc` are added (by @zikolach) to check that Java-side  garbage collection under JDBCBackend functions as intended.

May fix #227.

## How to review

Confirm that a reasonable number of 'large' Scenarios can be loaded using this code.

## PR checklist

- [x] Tests added.
- [x] ~Documentation added.~ N/A
- [x] Release notes updated.