### PR TITLE
Coerce CLI 'config' inputs to expected type

### DIFF
--- a/ixmp/_config.py
+++ b/ixmp/_config.py
@@ -152,8 +152,13 @@ class Config:
 
         type_, _ = KEYS[name]
         if not isinstance(value, type_):
-            raise TypeError('expected {} for {!r}; got {} {!r}'
-                            .format(type_, name, type(value), value))
+            # Value is not of the expected type
+            try:
+                # Attempt to cast to the correct type
+                value = type_(value)
+            except Exception:
+                raise TypeError('expected {} for {!r}; got {} {!r}'
+                                .format(type_, name, type(value), value))
 
         self.values[name] = value
 

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -9,6 +9,8 @@ ScenarioClass = ixmp.Scenario
 
 class VersionType(click.ParamType):
     """A Click parameter type that accepts :class:`int` or 'all'."""
+    name = 'version'  # https://github.com/pallets/click/issues/411
+
     def convert(self, value, param, ctx):
         if value == 'new':
             return value

--- a/ixmp/tests/test_config.py
+++ b/ixmp/tests/test_config.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import pytest
 
 from ixmp._config import KEYS, _JSONEncoder, Config, _locate
@@ -59,6 +61,13 @@ def test_register(cfg):
     # Can't re-register an existing key
     with pytest.raises(KeyError):
         cfg.register('new key', int, 43)
+
+    # Register a key with type Path
+    cfg.register('new key 2', Path)
+
+    # The key can be with a string value, automatically converted to Path
+    cfg.set('new key 2', '/foo/bar/baz')
+    assert isinstance(cfg.get('new key 2'), Path)
 
 
 def test_config_platform(cfg):

--- a/ixmp/tests/test_config.py
+++ b/ixmp/tests/test_config.py
@@ -47,8 +47,9 @@ def test_set_get(cfg):
     assert cfg.get('test key') == 'bar'
 
     # set() with invalid type raises exception
+    KEYS['test key'] = (int, None)
     with pytest.raises(TypeError):
-        cfg.set('test key', 12)
+        cfg.set('test key', 'foo')
 
 
 def test_register(cfg):


### PR DESCRIPTION
CLI inputs that are expected in a certain type are converted automatically to that type, if possible.

As reported by @volker-krey.

## PR checklist

- [x] Tests added.
- [x] ~Documentation added.~ Correct to expected behaviour.
- [x] ~Release notes updated.~ Ditto
