### PR TITLE
rixmp installation and use in documentation

### DIFF
--- a/doc/README.rst
+++ b/doc/README.rst
@@ -30,13 +30,9 @@ Building the docs locally
 
 Install the dependencies, above.
 
-On Linux or Apple macOS, from the command line, run::
+From the command line, run::
 
     make html
-
-On Windows, from the command line, run::
-
-    ./make.bat
 
 The build documentation is in ``doc/build/html/`` and can be viewed by opening
 ``doc/build/html/index.html`` in a web browser.

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -125,9 +125,14 @@ See also the :ref:`rixmp documentation <rixmp>`.
 
    $ R CMD INSTALL rixmp_*
 
-4. (Optional) Install `Rtools <https://cran.r-project.org/bin/windows/Rtools/>`_ and add the path to the environment variables.
+4. (Optional) Run the built-in test suite to check that *ixmp* and *rixmp* functions, as in *Install ixmp from source 6.* (installing
+   the R ``devtools`` package might be a pre-requisite). In the ``ixmp`` directory type::
+
+    $ py.test --test-r
 
 5. (Optional) For working with Jupyter notebooks using R, install the `IR kernel <https://irkernel.github.io>`_.
+
+6. (Optional) Install `Rtools <https://cran.r-project.org/bin/windows/Rtools/>`_ and add the path to the environment variables.
 
 .. _reticulate: https://rstudio.github.io/reticulate/
 

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -112,19 +112,22 @@ See also the :ref:`rixmp documentation <rixmp>`.
 1. `Install R <https://www.r-project.org>`_.
 
    .. warning::
-      Ensure the the R version installed is either 32- *or* 64-bit (and >= 3.3.0), consistently with GAMS and Java.
+      Ensure the the R version installed is either 32- *or* 64-bit (and >= 3.5.0), consistently with GAMS and Java.
       Having both 32- and 64-bit versions of R, or mixed 32- and 64-bit versions of different packages, can cause errors.
 
 2. Enter the directory ``rixmp/`` and use R to build and install the package and its dependencies, including reticulate_::
 
    $ cd rixmp
-   $ Rscript -e "install.packages(c('knitr', 'reticulate'))"
+   $ Rscript -e "install.packages(c('knitr', 'reticulate'), repos='http://cran.rstudio.com/')"
    $ R CMD build .
+
+3. Check that there is only one ``*tar.gz`` in the folder::
+
    $ R CMD INSTALL rixmp_*
 
-3. (Optional) Install `Rtools <https://cran.r-project.org/bin/windows/Rtools/>`_ and add the path to the environment variables.
+4. (Optional) Install `Rtools <https://cran.r-project.org/bin/windows/Rtools/>`_ and add the path to the environment variables.
 
-4. (Optional) For working with Jupyter notebooks using R, install the `IR kernel <https://irkernel.github.io>`_.
+5. (Optional) For working with Jupyter notebooks using R, install the `IR kernel <https://irkernel.github.io>`_.
 
 .. _reticulate: https://rstudio.github.io/reticulate/
 


### PR DESCRIPTION
I changed the documentation to make sure installation of `rixmp` works and explain to to run the tests.

## How to review

- Build the documentation and look atthe section on `rixmp`.
- Possibly delete ` knitr` and `reticulate` packages
- proceed with the installation following the documentation
- try the` py.test --test-r` command and check whether the R tests pass (see doc)

