### PR TITLE
Protect some Reporter keys from dask scheduler

### DIFF
--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -141,10 +141,13 @@ class Reporter:
         for name in scenario.set_list():
             elements = scenario.set(name)
             try:
-                elements = elements.tolist()
+                # Convert Series to list; protect list so that dask schedulers
+                # do not try to interpret its contents as further tasks
+                elements = dask.core.quote(elements.tolist())
             except AttributeError:
                 # pd.DataFrame for a multidimensional set; store as-is
                 pass
+
             rep.add(RENAME_DIMS.get(name, name), elements)
 
         # Add the scenario itself

--- a/ixmp/reporting/describe.py
+++ b/ixmp/reporting/describe.py
@@ -2,6 +2,7 @@ from collections.abc import Hashable
 from functools import partial
 from itertools import chain
 
+import dask.core
 import xarray as xr
 
 from .key import Key
@@ -64,6 +65,9 @@ def describe_recursive(graph, comp, depth=0, seen=None):
             item = "list of:\n{}".format(
                 describe_recursive(graph, tuple(arg), depth + 1, seen))
             seen.update(arg)
+        elif isinstance(arg, dask.core.literal):
+            # Item protected with dask.core.quote()
+            item = str(arg.data)
         else:
             item = str(arg)
 


### PR DESCRIPTION
#303 triggered dask/dask#3523; here we use the fix suggested at https://github.com/dask/dask/issues/3523#issuecomment-391318041: `dask.core.quote()` is used around some items when we don't want the scheduler to interpret their contents as other tasks:
- 'config': i.e. the whole configuration dictionary.
- ixmp sets, e.g. a set 'technology' with members ['foo', 'bar', 'all'] should not trigger the calculation of 'all' and thus everything else in the Reporter.

`reporting.describe` is also updated to unwrap these protected values when generating description strings.

## How to review

- Run the message_data reporting command with this branch and confirm the reported bug no longer occurs.

## PR checklist

- [x] ~Tests added.~ N/A
- [x] ~Documentation added.~ N/A; internal
- [x] ~Release notes updated.~