### PR TITLE
Extend Excel write/read to handle large data beyond the row limits

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -8,7 +8,7 @@ All changes
 - `#303 <https://github.com/iiasa/ixmp/pull/303>`_: Add `dims` and `units` arguments to :meth:`Reporter.add_file`; remove :meth:`Reporter.read_config` (redundant with :meth:`Reporter.configure`).
 - `#295 <https://github.com/iiasa/ixmp/pull/295>`_: Add option to include `subannual` column in dataframe returned by `Scenario.timeseries()`.
 - `#286 <https://github.com/iiasa/ixmp/pull/286>`_,
-  `#297 <https://github.com/iiasa/ixmp/pull/297>`_: Add :meth:`.Scenario.to_excel` and :meth:`.read_excel`; this functionality is transferred to ixmp from :mod:`message_ix`.
+  `#297 <https://github.com/iiasa/ixmp/pull/297>`_: Add :meth:`.Scenario.to_excel` and :meth:`.read_excel`; this functionality is transferred to ixmp from :mod:`message_ix` and enhanced for dealing with maximum row limits in Excel.
 - `#270 <https://github.com/iiasa/ixmp/pull/270>`_: Include all tests in the ixmp package.
 - `#212 <https://github.com/iiasa/ixmp/pull/212>`_: Add :meth:`Model.initialize` API to help populate new Scenarios according to a model scheme.
 - `#267 <https://github.com/iiasa/ixmp/pull/267>`_: Apply units to reported quantities.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -8,7 +8,8 @@ All changes
 - `#303 <https://github.com/iiasa/ixmp/pull/303>`_: Add `dims` and `units` arguments to :meth:`Reporter.add_file`; remove :meth:`Reporter.read_config` (redundant with :meth:`Reporter.configure`).
 - `#295 <https://github.com/iiasa/ixmp/pull/295>`_: Add option to include `subannual` column in dataframe returned by `Scenario.timeseries()`.
 - `#286 <https://github.com/iiasa/ixmp/pull/286>`_,
-  `#297 <https://github.com/iiasa/ixmp/pull/297>`_: Add :meth:`.Scenario.to_excel` and :meth:`.read_excel`; this functionality is transferred to ixmp from :mod:`message_ix` and enhanced for dealing with maximum row limits in Excel.
+  `#297 <https://github.com/iiasa/ixmp/pull/297>`_,
+  `#309 <https://github.com/iiasa/ixmp/pull/309>`_: Add :meth:`.Scenario.to_excel` and :meth:`.read_excel`; this functionality is transferred to ixmp from :mod:`message_ix` and enhanced for dealing with maximum row limits in Excel.
 - `#270 <https://github.com/iiasa/ixmp/pull/270>`_: Include all tests in the ixmp package.
 - `#212 <https://github.com/iiasa/ixmp/pull/212>`_: Add :meth:`Model.initialize` API to help populate new Scenarios according to a model scheme.
 - `#267 <https://github.com/iiasa/ixmp/pull/267>`_: Apply units to reported quantities.

--- a/doc/source/api-python.rst
+++ b/doc/source/api-python.rst
@@ -159,6 +159,12 @@ Scenario
       var_list
 
 
+.. currentmodule:: ixmp.backend.io
+
+.. automodule:: ixmp.backend.io
+   :members: EXCEL_MAX_ROWS
+
+
 .. _configuration:
 
 Configuration

--- a/doc/source/file-io.rst
+++ b/doc/source/file-io.rst
@@ -27,10 +27,11 @@ The files have the following structure:
   - 'item': the name of an ixmp item.
   - 'ix_type': the item's type as a length-3 string: 'set', 'par', 'var', or 'equ'.
 
-- One sheet per item.
+- One sheet per item. If the length of data is greater than the maximum row numbers per Excel sheet, the item will be saved in multiple sheets,
+e.g., foo, foo(2), foo(3).
+
 - Sets:
 
-  - Sheets for index sets have one column, with a header cell that is the set name.
   - Sheets for one-dimensional indexed sets have one column, with a header cell that is the index set name.
   - Sheets for multi-dimensional indexed sets have multiple columns.
   - Sets with no elements are represented by empty sheets.

--- a/doc/source/file-io.rst
+++ b/doc/source/file-io.rst
@@ -27,8 +27,7 @@ The files have the following structure:
   - 'item': the name of an ixmp item.
   - 'ix_type': the item's type as a length-3 string: 'set', 'par', 'var', or 'equ'.
 
-- One sheet per item. If the length of data is greater than the maximum row numbers per Excel sheet, the item will be saved in multiple sheets,
-e.g., foo, foo(2), foo(3).
+- One or more sheet per item. If the length of data is greater than the maximum number of rows per sheet supported by the Excel file format (:data:`.EXCEL_MAX_ROWS`), the item is split across multiple sheets named, e.g., 'foo', 'foo(2)', 'foo(3)'.
 
 - Sets:
 

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -332,7 +332,7 @@ class Backend(ABC):
         s, filters = self._handle_rw_filters(kwargs.pop('filters', {}))
         xlsx_types = (ItemType.SET | ItemType.PAR, ItemType.MODEL)
         if path.suffix == '.xlsx' and item_type in xlsx_types and s:
-            s_write_excel(self, s, path, item_type)
+            s_write_excel(self, s, path, item_type, **kwargs)
         else:
             raise NotImplementedError
 

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -199,9 +199,8 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
             data = xf.parse(name)
             # Appending data from repeated sheets due to max row limit
             sheets = [x for x in xf.sheet_names if x.startswith(name + '(')]
-            if sheets:
-                for x in sheets:
-                    data = data.append(xf.parse(x), ignore_index=True)
+            for x in sheets:
+                data = data.append(xf.parse(x), ignore_index=True)
 
         # Determine index set(s) for this set
         idx_sets = data.columns.to_list()
@@ -263,9 +262,8 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
         df = xf.parse(name)
         # Appending data from repeated sheets due to max row limit
         sheets = [x for x in xf.sheet_names if x.startswith(name + '(')]
-        if sheets:
-            for x in sheets:
-                df = df.append(xf.parse(x), ignore_index=True)
+        for x in sheets:
+            df = df.append(xf.parse(x), ignore_index=True)
 
         if add_units:
             # New units appearing in this parameter

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -85,13 +85,13 @@ def s_write_excel(be, s, path, item_type, max_row=1e6):
                 empty_sets.append((name, data))
             continue
 
-        if len(data) > max_row:
-            for i in range(1, int(np.ceil(len(data) / max_row)) + 1):
-                last_row = min(max_row * i, len(data))
+        if len(data) > int(max_row):
+            for i in range(1, int(np.ceil(len(data) / int(max_row))) + 1):
+                last_row = min(int(max_row) * i, len(data))
                 if isinstance(data, pd.Series):
-                    part = data.loc[(i - 1) * max_row:last_row]
+                    part = data.loc[(i - 1) * int(max_row):last_row]
                 else:
-                    part = data.iloc[(i - 1) * max_row:last_row, :]
+                    part = data.iloc[(i - 1) * int(max_row):last_row, :]
 
                 if i > 1:
                     suffix = '({})'.format(i)
@@ -194,7 +194,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
             # Read data
             data = xf.parse(name)
             # appending data from repeated sheets due to max row limit
-            sheets = [s for s in xf.sheet_names() if name + '(' in s]
+            sheets = [s for s in xf.sheet_names if name + '(' in s]
             if sheets:
                 for s in sheets:
                     data.append(xf.parse(s), ignore_index=True)
@@ -258,7 +258,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
 
         df = xf.parse(name)
         # appending data from repeated sheets due to max row limit
-        sheets = [s for s in xf.sheet_names() if name + '(' in s]
+        sheets = [s for s in xf.sheet_names if name + '(' in s]
         if sheets:
             for s in sheets:
                 data.append(xf.parse(s), ignore_index=True)

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -261,7 +261,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
         sheets = [s for s in xf.sheet_names if name + '(' in s]
         if sheets:
             for s in sheets:
-                data.append(xf.parse(s), ignore_index=True)
+                df.append(xf.parse(s), ignore_index=True)
 
         if add_units:
             # New units appearing in this parameter

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -193,6 +193,11 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
         if first_pass:
             # Read data
             data = xf.parse(name)
+            # appending data from repeated sheets due to max row limit
+            sheets = [s for s in xf.sheet_names() if name + '(' in s]
+            if sheets:
+                for s in sheets:
+                    data.append(xf.parse(s), ignore_index=True)
 
         # Determine index set(s) for this set
         idx_sets = data.columns.to_list()
@@ -252,6 +257,11 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
         # Only parameters beyond this point
 
         df = xf.parse(name)
+        # appending data from repeated sheets due to max row limit
+        sheets = [s for s in xf.sheet_names() if name + '(' in s]
+        if sheets:
+            for s in sheets:
+                data.append(xf.parse(s), ignore_index=True)
 
         if add_units:
             # New units appearing in this parameter

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -7,8 +7,12 @@ import numpy as np
 from ixmp.utils import as_str_list
 from . import ItemType
 
-EXCEL_MAX_ROWS = 1048576
+
 log = logging.getLogger(__name__)
+
+#: Maximum number of rows supported by the Excel file format. See
+#: :meth:`.to_excel` and :ref:`excel-data-format`.
+EXCEL_MAX_ROWS = 1048576
 
 
 def ts_read_file(ts, path, firstyear=None, lastyear=None):

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -89,15 +89,16 @@ def s_write_excel(be, s, path, item_type, max_row=None):
             continue
 
         if len(data) > max_row:
-            for i in range(1, int(np.ceil(len(data) / max_row)) + 1):
-                last_row = min(max_row * i, len(data))
+            for sheet_num in range(1, int(np.ceil(len(data) / max_row)) + 1):
+                first_row = (sheet_num - 1) * max_row
+                last_row = min(max_row * sheet_num, len(data))
                 if isinstance(data, pd.Series):
-                    part = data.loc[(i - 1) * max_row:last_row]
+                    part = data.loc[first_row:last_row]
                 else:
-                    part = data.iloc[(i - 1) * max_row:last_row, :]
+                    part = data.iloc[first_row:last_row, :]
 
-                if i > 1:
-                    suffix = '({})'.format(i)
+                if sheet_num > 1:
+                    suffix = '({})'.format(sheet_num)
                 else:
                     suffix = ''
 
@@ -197,7 +198,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
             # Read data
             data = xf.parse(name)
             # appending data from repeated sheets due to max row limit
-            sheets = [x for x in xf.sheet_names if (name + '(') in x]
+            sheets = [x for x in xf.sheet_names if x.startswith(name + '(')]
             if sheets:
                 for x in sheets:
                     data = data.append(xf.parse(x), ignore_index=True)
@@ -261,7 +262,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
 
         df = xf.parse(name)
         # appending data from repeated sheets due to max row limit
-        sheets = [x for x in xf.sheet_names if (name + '(') in x]
+        sheets = [x for x in xf.sheet_names if x.startswith(name + '(')]
         if sheets:
             for x in sheets:
                 df = df.append(xf.parse(x), ignore_index=True)

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -197,7 +197,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
         if first_pass:
             # Read data
             data = xf.parse(name)
-            # appending data from repeated sheets due to max row limit
+            # Appending data from repeated sheets due to max row limit
             sheets = [x for x in xf.sheet_names if x.startswith(name + '(')]
             if sheets:
                 for x in sheets:
@@ -261,7 +261,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
         # Only parameters beyond this point
 
         df = xf.parse(name)
-        # appending data from repeated sheets due to max row limit
+        # Appending data from repeated sheets due to max row limit
         sheets = [x for x in xf.sheet_names if x.startswith(name + '(')]
         if sheets:
             for x in sheets:

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -67,7 +67,7 @@ def s_write_excel(be, s, path, item_type, max_row=None):
     empty_sets = []
 
     # Don't allow the user to set a value that will truncate data
-    max_row = int(min([x for x in [max_row, EXCEL_MAX_ROWS] if x is not None]))
+    max_row = min(int(max_row or EXCEL_MAX_ROWS), EXCEL_MAX_ROWS)
 
     for name, ix_type in name_type.items():
         # Extract data: dict, pd.Series, or pd.DataFrame

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -200,7 +200,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
             sheets = [x for x in xf.sheet_names if (name + '(') in x]
             if sheets:
                 for x in sheets:
-                    data.append(xf.parse(x), ignore_index=True)
+                    data = data.append(xf.parse(x), ignore_index=True)
 
         # Determine index set(s) for this set
         idx_sets = data.columns.to_list()
@@ -264,7 +264,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
         sheets = [x for x in xf.sheet_names if (name + '(') in x]
         if sheets:
             for x in sheets:
-                df.append(xf.parse(x), ignore_index=True)
+                df = df.append(xf.parse(x), ignore_index=True)
 
         if add_units:
             # New units appearing in this parameter

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -140,7 +140,7 @@ def config(action, key, value):
 
 
 @main.command()
-@click.option('--max-row', type=int, default=10,
+@click.option('--max-row', type=int, default=5,
               help='Max row numbers in each sheet.')
 @click.argument('path', type=click.Path(writable=True))
 @click.pass_obj

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -140,7 +140,7 @@ def config(action, key, value):
 
 
 @main.command()
-@click.option('--max-row', type=int, default=5,
+@click.option('--max-row', type=int,
               help='Max row numbers in each sheet.')
 @click.argument('path', type=click.Path(writable=True))
 @click.pass_obj

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -140,8 +140,7 @@ def config(action, key, value):
 
 
 @main.command()
-@click.option('--max-row', type=int,
-              help='Max row numbers in each sheet.')
+@click.option('--max-row', type=int, help='Max row numbers in each sheet.')
 @click.argument('path', type=click.Path(writable=True))
 @click.pass_obj
 def export(context, path, max_row):

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -153,7 +153,7 @@ def export(context, path, max_row):
         raise click.UsageError('give --url, or --platform, --model, and '
                                '--scenario, before export')
 
-    context['scen'].to_excel(path, max_row)
+    context['scen'].to_excel(path, max_row=max_row)
 
 
 @main.group('import')

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -140,9 +140,11 @@ def config(action, key, value):
 
 
 @main.command()
+@click.option('--max-row', type=int, default=10,
+              help='Max row numbers in each sheet.')
 @click.argument('path', type=click.Path(writable=True))
 @click.pass_obj
-def export(context, path):
+def export(context, path, max_row):
     """Export scenario data to PATH."""
     # NB want to use type=click.Path(..., path_type=Path), but fails on bytes
     path = Path(path)
@@ -151,7 +153,7 @@ def export(context, path):
         raise click.UsageError('give --url, or --platform, --model, and '
                                '--scenario, before export')
 
-    context['scen'].to_excel(path)
+    context['scen'].to_excel(path, max_row)
 
 
 @main.group('import')

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1527,7 +1527,10 @@ class Scenario(TimeSeries):
             only sets and parameters), or :attr:`.MODEL` (also variables and
             equations, i.e. model solution data).
         max_row: int, optional
-            max number of rows
+            Maximum number of rows in each sheet. If the number of elements in
+            an item exceeds this number or :data:`.EXCEL_MAX_ROWS`, then an
+            item is written to multiple sheets named, e.g. 'foo', 'foo(2)',
+            'foo(3)', etc.
 
         See also
         --------

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1515,7 +1515,7 @@ class Scenario(TimeSeries):
         self._backend('set_meta', name, value)
 
     # Input and output
-    def to_excel(self, path, items=ItemType.SET | ItemType.PAR):
+    def to_excel(self, path, items=ItemType.SET | ItemType.PAR, max_row=1e6):
         """Write Scenario to a Microsoft Excel file.
 
         Parameters
@@ -1526,6 +1526,8 @@ class Scenario(TimeSeries):
             Types of items to write. Either :attr:`.SET` | :attr:`.PAR` (i.e.
             only sets and parameters), or :attr:`.MODEL` (also variables and
             equations, i.e. model solution data).
+        max_row: int, optional
+            max number of rows
 
         See also
         --------
@@ -1533,7 +1535,8 @@ class Scenario(TimeSeries):
         read_excel
         """
         self.platform._backend.write_file(Path(path), items,
-                                          filters=dict(scenario=self))
+                                          filters=dict(scenario=self),
+                                          max_row=max_row)
 
     def read_excel(self, path, add_units=False, init_items=False,
                    commit_steps=False):

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1515,7 +1515,7 @@ class Scenario(TimeSeries):
         self._backend('set_meta', name, value)
 
     # Input and output
-    def to_excel(self, path, items=ItemType.SET | ItemType.PAR, max_row=1e6):
+    def to_excel(self, path, items=ItemType.SET | ItemType.PAR, max_row=None):
         """Write Scenario to a Microsoft Excel file.
 
         Parameters

--- a/ixmp/reporting/describe.py
+++ b/ixmp/reporting/describe.py
@@ -2,6 +2,7 @@ from collections.abc import Hashable
 from functools import partial
 from itertools import chain
 
+import dask.core
 import xarray as xr
 
 from .key import Key
@@ -64,6 +65,9 @@ def describe_recursive(graph, comp, depth=0, seen=None):
             item = "list of:\n{}".format(
                 describe_recursive(graph, tuple(arg), depth + 1, seen))
             seen.update(arg)
+        elif isinstance(arg, dask.core.literal):
+            # Item protected with dask.core.quote()
+            item = str(arg.data)
         else:
             item = str(arg)
 

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -197,6 +197,13 @@ def test_excel_io(ixmp_cli, test_mp, tmp_path):
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 
+    # Export with a maximum row limit per sheet
+    tmp_path2 = tmp_path.split('dentzig')[0] + 'dantzig2.xlsx'
+    cmd[cmd.index(str(tmp_path))] = str(tmp_path2)
+    cmd.insert(-1, '--max-row')
+    result = ixmp_cli.invoke(cmd)
+    assert result.exit_code == 0, result.output
+
     # Fails without platform/scenario info
     assert ixmp_cli.invoke(cmd[6:]).exit_code == UsageError.exit_code
 
@@ -234,6 +241,11 @@ def test_excel_io(ixmp_cli, test_mp, tmp_path):
 
     # Succeeds
     cmd.insert(-1, '--init-items')
+    result = ixmp_cli.invoke(cmd)
+    assert result.exit_code == 0, result.output
+
+    # Import from a file that has multiple sheets (due to row limit)
+    cmd[cmd.index(str(tmp_path))] = str(tmp_path2)
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -200,7 +200,7 @@ def test_excel_io(ixmp_cli, test_mp, tmp_path):
     # Export with a maximum row limit per sheet
     tmp_path2 = str(tmp_path).split('dantzig')[0] + 'dantzig2.xlsx'
     cmd[cmd.index(str(tmp_path))] = str(tmp_path2)
-    cmd = cmd + ['--max-row', 4]
+    cmd = cmd + ['--max-row']
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -198,9 +198,10 @@ def test_excel_io(ixmp_cli, test_mp, tmp_path):
     assert result.exit_code == 0, result.output
 
     # Export with a maximum row limit per sheet
-    tmp_path2 = tmp_path.split('dentzig')[0] + 'dantzig2.xlsx'
+    tmp_path2 = str(tmp_path).split('dantzig')[0] + 'dantzig2.xlsx'
+    #assert 'value' in (str(tmp_path2))
     cmd[cmd.index(str(tmp_path))] = str(tmp_path2)
-    cmd.insert(-1, '--max-row')
+    cmd = cmd + ['--max-row', 4]
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -198,9 +198,8 @@ def test_excel_io(ixmp_cli, test_mp, tmp_path):
     assert result.exit_code == 0, result.output
 
     # Export with a maximum row limit per sheet
-    tmp_path2 = str(tmp_path).split('dantzig')[0] + 'dantzig2.xlsx'
-    cmd[cmd.index(str(tmp_path))] = str(tmp_path2)
-    cmd = cmd + ['--max-row', 2]
+    tmp_path2 = tmp_path.with_name('dantzig2.xlsx')
+    cmd = cmd[:-1] + [str(tmp_path2), '--max-row', 2]
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -200,7 +200,7 @@ def test_excel_io(ixmp_cli, test_mp, tmp_path):
     # Export with a maximum row limit per sheet
     tmp_path2 = str(tmp_path).split('dantzig')[0] + 'dantzig2.xlsx'
     cmd[cmd.index(str(tmp_path))] = str(tmp_path2)
-    cmd = cmd + ['--max-row']
+    cmd = cmd + ['--max-row', 2]
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 


### PR DESCRIPTION
In response to issue #292, this PR extends the code in `ixmp.backend.io.py` to write and read large data, i.e., dataframes and series longer than the maximum row number of Excel.

## How to review
You can test this branch as it is. The tests are improved to reflect the new changes. ALternatively, you can export one of the global scenarios and check if parameter _land_output_ is completely transferred to Excel in two sheets.

## PR checklist
- [x] Tests improved to reflect the enhancements.
- [x] Documentation is not needed, minor enhancement.
- [x] Release notes updated by adding a short note.
