### PR TITLE
Reporting improvements for 2020-W16

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- `#312 <https://github.com/iiasa/ixmp/pull/312>`_: Add :meth:`~.computations.apply_units`, :meth:`~computations.select` reporting calculations; expand :meth:`.Reporter.add`.
 - `#310 <https://github.com/iiasa/ixmp/pull/310>`_: :meth:`.Reporter.add_product` accepts a :class:`.Key` with a tag; :func:`~.computations.aggregate` preserves :class:`.Quantity` attributes.
 - `#304 <https://github.com/iiasa/ixmp/pull/304>`_: Add CLI command ``ixmp solve`` to run model solver.
 - `#303 <https://github.com/iiasa/ixmp/pull/303>`_: Add `dims` and `units` arguments to :meth:`Reporter.add_file`; remove :meth:`Reporter.read_config` (redundant with :meth:`Reporter.configure`).

--- a/doc/source/reporting.rst
+++ b/doc/source/reporting.rst
@@ -179,6 +179,7 @@ Computations
       disaggregate_shares
       product
       ratio
+      select
       sum
 
    Input and output:

--- a/doc/source/reporting.rst
+++ b/doc/source/reporting.rst
@@ -175,6 +175,7 @@ Computations
 
    .. autosummary::
       aggregate
+      apply_units
       disaggregate_shares
       product
       ratio

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -33,6 +33,7 @@ from dask.optimization import cull
 import pint
 import yaml
 
+from ixmp.utils import partial_split
 from . import computations
 from .describe import describe_recursive
 from .exceptions import ComputationError
@@ -268,9 +269,10 @@ class Reporter:
                 return getattr(self, f'add_{name}')(*args, **kwargs)
             else:
                 # Get the function directly
-                computation = getattr(self._computations, name)
+                func = getattr(self._computations, name)
                 # Rearrange arguments: key, computation function, args, …
-                return self.add(args[0], computation, *args[1:], **kwargs)
+                func, kwargs = partial_split(func, kwargs)
+                return self.add(args[0], func, *args[1:], **kwargs)
 
         elif isinstance(data, str) and data in dir(self):
             # Name of another method, e.g. 'apply'

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -69,7 +69,6 @@ class Reporter:
     """Class for generating reports on :class:`ixmp.Scenario` objects."""
     # TODO meet the requirements:
     # A3iii. Interpolation.
-    # A7. Renaming of outputs.
 
     #: A dask-format :doc:`graph <graphs>`.
     graph = {'config': {}}

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -804,7 +804,7 @@ def configure(path=None, **config):
     RENAME_DIMS.update(config.get('rename_dims', {}))
 
 
-def _config_args(path=None, keys={}, sections=set()):
+def _config_args(path=None, keys={}):
     """Handle configuration arguments."""
     result = {}
 
@@ -820,12 +820,7 @@ def _config_args(path=None, keys={}, sections=set()):
     # Update with keys
     result.update(keys)
 
-    if sections:
-        if path:
-            sections.add('config_dir')
-        return {s: result[s] for s in sections}
-    else:
-        return result
+    return result
 
 
 def keys_for_quantity(ix_type, name, scenario):

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -321,6 +321,28 @@ def ratio(numerator, denominator):
     return result
 
 
+def select(qty, indexers, inverse=True):
+    """Select from *qty* based on *indexers*.
+
+    Parameters
+    ----------
+    qty : .Quantity
+    select : dict (str -> list of str)
+        Elements to be selected from *qty*. Mapping from dimension names to
+        labels along each dimension.
+    inverse : bool, optional
+        If :obj:`True`, *remove* the items in indexers instead of keeping them.
+    """
+    if inverse:
+        new_indexers = {}
+        for dim, labels in indexers.items():
+            new_indexers[dim] = list(filter(lambda l: l not in labels,
+                                            qty.coords[dim]))
+        indexers = new_indexers
+
+    return qty.sel(indexers)
+
+
 # Input and output
 def load_file(path, dims={}, units=None):
     """Read the file at *path* and return its contents as a :class:`.Quantity`.

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -22,12 +22,14 @@ from .utils import (
 
 __all__ = [
     'aggregate',
+    'apply_units',
     'concat',
     'data_for_quantity',
     'disaggregate_shares',
     'load_file',
     'product',
     'ratio',
+    'select',
     'sum',
     'write_report',
 ]
@@ -335,8 +337,8 @@ def select(qty, indexers, inverse=True):
 def sum(quantity, weights=None, dimensions=None):
     """Sum *quantity* over *dimensions*, with optional *weights*.
 
-    Parameter
-    ---------
+    Parameters
+    ----------
     quantity : .Quantity
     weights : .Quantity, optional
         If *dimensions* is given, *weights* must have at least these

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -62,17 +62,19 @@ def apply_units(qty, units, quiet=False):
     existing_dims = getattr(existing, 'dimensionality', {})
     new_units = REGISTRY.parse_units(units)
 
-    if existing:
-        if existing_dims != new_units.dimensionality:
-            msg = f"Replace '{existing}' with incompatible '{new_units}'"
-            log.warning(msg)
-            result = qty.copy()
-        else:
+    if len(existing_dims):
+        # Some existing dimensions: log a message either way
+        if existing_dims == new_units.dimensionality:
             log.debug(f"Convert '{existing}' to '{new_units}'")
             # NB use a factor because pint.Quantity cannot wrap AttrSeries
             factor = REGISTRY.Quantity(1.0, existing).to(new_units).magnitude
             result = qty * factor
+        else:
+            msg = f"Replace '{existing}' with incompatible '{new_units}'"
+            log.warning(msg)
+            result = qty.copy()
     else:
+        # No units, or dimensionless
         result = qty.copy()
 
     result.attrs['_unit'] = new_units

--- a/ixmp/reporting/key.py
+++ b/ixmp/reporting/key.py
@@ -135,9 +135,11 @@ class Key:
         from . import computations
 
         for agg_dims, others in combo_partition(self.dims):
-            yield Key(self.name, agg_dims, self.tag), \
-                (partial(computations.sum, dimensions=others, weights=None),
-                 self)
+            yield (
+                Key(self.name, agg_dims, self.tag),
+                partial(computations.sum, dimensions=others, weights=None),
+                self,
+            )
 
 
 def combo_partition(iterable):

--- a/ixmp/reporting/quantity.py
+++ b/ixmp/reporting/quantity.py
@@ -178,6 +178,8 @@ def as_sparse_xarray(obj, units=None):  # pragma: no cover
     return result
 
 
+#: Convert args to :class:`.Quantity` class.
+#:
 #: Returns
 #: -------
 #: .Quantity

--- a/ixmp/tests/reporting/__init__.py
+++ b/ixmp/tests/reporting/__init__.py
@@ -1,0 +1,34 @@
+import numpy as np
+import pint
+import xarray as xr
+
+REGISTRY = pint.get_application_registry()
+
+
+def add_test_data(scen):
+    # New sets
+    t_foo = ['foo{}'.format(i) for i in (1, 2, 3)]
+    t_bar = ['bar{}'.format(i) for i in (4, 5, 6)]
+    t = t_foo + t_bar
+    y = list(map(str, range(2000, 2051, 10)))
+
+    # Add to scenario
+    scen.init_set('t')
+    scen.add_set('t', t)
+    scen.init_set('y')
+    scen.add_set('y', y)
+
+    # Data
+    ureg = pint.get_application_registry()
+    x = xr.DataArray(np.random.rand(len(t), len(y)),
+                     coords=[t, y], dims=['t', 'y'],
+                     attrs={'_unit': ureg.Unit('kg')})
+
+    # As a pd.DataFrame with units
+    x_df = x.to_series().rename('value').reset_index()
+    x_df['unit'] = 'kg'
+
+    scen.init_par('x', ['t', 'y'])
+    scen.add_par('x', x_df)
+
+    return t, t_foo, t_bar, x

--- a/ixmp/tests/reporting/test_computations.py
+++ b/ixmp/tests/reporting/test_computations.py
@@ -1,0 +1,56 @@
+import logging
+
+from pandas.testing import assert_series_equal
+import pytest
+
+import ixmp
+from ixmp.reporting import Reporter, as_quantity, computations
+from ixmp.testing import assert_logs
+
+from . import add_test_data
+
+
+@pytest.fixture(scope='function')
+def data(test_mp, request):
+    scen = ixmp.Scenario(test_mp, request.node.name, request.node.name, 'new')
+    rep = Reporter.from_scenario(scen)
+    yield [scen, rep] + list(add_test_data(scen))
+
+
+def test_apply_units(data, caplog):
+    # Unpack
+    *_, x = data
+
+    # Brute-force replacement with incompatible units
+    with assert_logs(caplog, "Replace 'kilogram' with incompatible 'liter'"):
+        result = computations.apply_units(x, 'litres')
+    assert_series_equal(result.to_series(), x.to_series())
+
+    caplog.set_level(logging.DEBUG)
+
+    # Compatible units are converted
+    with assert_logs(caplog, "Convert 'kilogram' to 'metric_ton'"):
+        result = computations.apply_units(x, 'tonne')
+    assert_series_equal(result.to_series(), x.to_series() * 0.001)
+
+
+def test_select(data):
+    # Unpack
+    *_, t_foo, t_bar, x = data
+
+    x = as_quantity(x)
+    assert len(x) == 6 * 6
+
+    # Selection with inverse=False
+    indexers = {'t': t_foo[0:1] + t_bar[0:1]}
+    result_0 = computations.select(x, indexers=indexers)
+    assert len(result_0) == 2 * 6
+
+    # Single indexer along one dimension results in 1D data
+    indexers['y'] = '2010'
+    result_1 = computations.select(x, indexers=indexers)
+    assert len(result_1) == 2 * 1
+
+    # Selection with inverse=True
+    result_2 = computations.select(x, indexers=indexers, inverse=True)
+    assert len(result_2) == 4 * 5

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -27,6 +27,8 @@ from ixmp.testing import (
     assert_qty_equal,
 )
 
+from . import add_test_data
+
 
 test_args = ('Douglas Adams', 'Hitchhiker')
 
@@ -675,35 +677,6 @@ def test_report_size(test_mp):
 
     # All quantities together trigger MemoryError
     rep.get('bigmem')
-
-
-def add_test_data(scen):
-    # New sets
-    t_foo = ['foo{}'.format(i) for i in (1, 2, 3)]
-    t_bar = ['bar{}'.format(i) for i in (4, 5, 6)]
-    t = t_foo + t_bar
-    y = list(map(str, range(2000, 2051, 10)))
-
-    # Add to scenario
-    scen.init_set('t')
-    scen.add_set('t', t)
-    scen.init_set('y')
-    scen.add_set('y', y)
-
-    # Data
-    ureg = pint.get_application_registry()
-    x = xr.DataArray(np.random.rand(len(t), len(y)),
-                     coords=[t, y], dims=['t', 'y'],
-                     attrs={'_unit': ureg.Unit('kg')})
-
-    # As a pd.DataFrame with units
-    x_df = x.to_series().rename('value').reset_index()
-    x_df['unit'] = 'kg'
-
-    scen.init_par('x', ['t', 'y'])
-    scen.add_par('x', x_df)
-
-    return t, t_foo, t_bar, x
 
 
 def test_aggregate(test_mp):

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -135,6 +135,9 @@ def test_reporter_add_product(test_mp, ureg):
     exp.attrs['_unit'] = ureg('kilogram ** 2').units
     assert_qty_equal(exp, rep.get(key))
 
+    # add('product', ...) works
+    key = rep.add('product', 'x_squared', 'x', 'x', sums=True)
+
 
 def test_reporter_from_scenario(scenario):
     r = Reporter.from_scenario(scenario)

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -235,7 +235,7 @@ def test_reporter_apply():
     def _product(a, b):
         return a * b
 
-    # A generator method that yields keys and computations
+    # A generator function that yields keys and computations
     def baz_qux(key):
         yield key + ':baz', (_product, key, 0.5)
         yield key + ':qux', (_product, key, 1.1)
@@ -264,12 +264,24 @@ def test_reporter_apply():
     assert r.get('foo:baz__bar:qux') == 42 * 0.5 * 11 * 1.1
 
     # A useless generator that does nothing
-    def useless(key):
+    def useless():
         return
-    r.apply(useless, 'foo:baz__bar:qux')
+    r.apply(useless)
 
     # Nothing added to the reporter
     assert len(r.keys()) == N
+
+    # Adding with a generator that takes Reporter as the first argument
+    def add_many(rep: Reporter, max=5):
+        [rep.add(f'foo{x}', _product, 'foo', x) for x in range(max)]
+
+    r.apply(add_many, max=10)
+
+    # Function was called, adding keys
+    assert len(r.keys()) == N + 10
+
+    # Keys work
+    assert r.get('foo9') == 42 * 9
 
 
 def test_reporter_disaggregate():

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -117,6 +117,15 @@ def test_reporter_add():
     r.add('foo:a-b-c', [], sums=True)
     assert 'foo:b' in r
 
+    # add(name, ...) where name is the name of a computation
+    r.add('select', 'bar', 'a', indexers={'dim': ['d0', 'd1', 'd2']})
+
+    # add(name, ...) with keyword arguments not recognized by the computation
+    # raises an exception
+    msg = "unexpected keyword argument 'bad_kwarg'"
+    with pytest.raises(TypeError, match=msg):
+        r.add('select', 'bar', 'a', bad_kwarg='foo', index=True)
+
 
 def test_reporter_add_queue():
     r = Reporter()

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -1,4 +1,6 @@
 from collections.abc import Iterable
+from functools import partial
+from inspect import Parameter, signature
 import logging
 import re
 from urllib.parse import urlparse
@@ -116,6 +118,24 @@ def parse_url(url):
         scenario_info['version'] = int(components.fragment)
 
     return platform_info, scenario_info
+
+
+def partial_split(func, kwargs):
+    """Forgiving version of :func:`functools.partial`.
+
+    Returns a partial object and leftover kwargs not applicable to `func`.
+    """
+    # Names of parameters to
+    par_names = signature(func).parameters
+    func_args, extra = {}, {}
+    for name, value in kwargs.items():
+        if name in par_names and \
+                par_names[name].kind == Parameter.POSITIONAL_OR_KEYWORD:
+            func_args[name] = value
+        else:
+            extra[name] = value
+
+    return partial(func, **func_args), extra
 
 
 def year_list(x):


### PR DESCRIPTION
- `Reporter.add()` becomes more flexible, e.g.
  - It can be used to invoke other methods like `Reporter.aggregate(...)` by calling `Reporter.add('aggregate', ...)`
  - It can be used with the name of a computation, e.g. 'product', in which case `Reporter.add('product', ...)` → `Reporter.add_product(...)`
  - It can be used with a list/iterable of such arguments, to add many computations at once.
- `Reporter.apply()` becomes more flexible; accepts functions that operate just on keys, or on the Reporter itself.
- New functions in `reporting.computations`: `apply_units` and `select`, moved upstream from iiasa/message_data#116

## How to review

- Note that the CI checks all pass.

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.