### PR TITLE
Always fetch the pint 'application registry' from within functions

### DIFF
--- a/ixmp/reporting/quantity.py
+++ b/ixmp/reporting/quantity.py
@@ -169,7 +169,6 @@ def as_sparse_xarray(obj, units=None):  # pragma: no cover
     elif isinstance(obj, pd.Series):
         result = xr.DataArray.from_series(obj, sparse=True)
     else:
-        print(type(obj), type(obj.data))
         result = obj
 
     if units:


### PR DESCRIPTION
- As a follow-up to #312, switch to an implementation where `pint.get_application_registry()` is always called from within functions. This allows downstream code to replace this registry.
- Add a comment explaining this choice for future developers.

## PR checklist

- [x] ~Tests added.~ N/A
- [x] ~Documentation added.~
- [x] ~Release notes updated.~