### PR TITLE
Add precautionary checks to Model.initialize_items

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- `#315 <https://github.com/iiasa/ixmp/pull/315>`_: Ensure :meth:`.Model.initialize` is always called for new *and* cloned objects.
 - `#320 <https://github.com/iiasa/ixmp/pull/320>`_: Add CLI command `ixmp show-versions` to print ixmp and dependency versions for debugging.
 - `#312 <https://github.com/iiasa/ixmp/pull/312>`_: Add :meth:`~.computations.apply_units`, :meth:`~computations.select` reporting calculations; expand :meth:`.Reporter.add`.
 - `#310 <https://github.com/iiasa/ixmp/pull/310>`_: :meth:`.Reporter.add_product` accepts a :class:`.Key` with a tag; :func:`~.computations.aggregate` preserves :class:`.Quantity` attributes.

--- a/ci/conda-requirements.txt
+++ b/ci/conda-requirements.txt
@@ -4,7 +4,7 @@ dask
 graphviz
 
 # Temporary exclusions; see iiasa/ixmp#279
-JPype1 != 0.7.2, != 0.7.3
+JPype1 != 0.7.2, != 0.7.3, != 0.7.4
 
 jupyter
 numpydoc

--- a/doc/source/api-backend.rst
+++ b/doc/source/api-backend.rst
@@ -122,7 +122,7 @@ Backend API
       get
       get_data
       get_geo
-      init_ts
+      init
       is_default
       last_update
       preload
@@ -142,7 +142,6 @@ Backend API
       delete_item
       get_meta
       has_solution
-      init_s
       init_item
       item_delete_elements
       item_get_elements

--- a/doc/source/api-python.rst
+++ b/doc/source/api-python.rst
@@ -213,7 +213,7 @@ Utilities
 .. currentmodule:: ixmp.utils
 
 .. automodule:: ixmp.utils
-   :members: format_scenario_list, parse_url, update_par
+   :members: format_scenario_list, maybe_check_out, maybe_commit, parse_url, update_par
 
 
 Testing utilities

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -357,10 +357,10 @@ class Backend(ABC):
     # Methods for ixmp.TimeSeries
 
     @abstractmethod
-    def init_ts(self, ts: TimeSeries, annotation=None):
-        """Initialize the TimeSeries *ts*.
+    def init(self, ts: TimeSeries, annotation, scheme=None):
+        """Create a new TimeSeries (or Scenario) *ts*.
 
-        ts_init **may** modify the :attr:`~TimeSeries.version` attribute of
+        init **may** modify the :attr:`~TimeSeries.version` attribute of
         *ts*.
 
         Parameters
@@ -368,15 +368,14 @@ class Backend(ABC):
         annotation : str
             If *ts* is newly-created, the Backend **must** store this
             annotation with the TimeSeries.
+        scheme : str or None
+            Name of the model scheme, if *ts* is a :class:`Scenario`; the
+            Backend **must** set the :attr:`.Scenario.scheme` attribute to this
+            value. Otherwise, :obj:`None`.
 
         Returns
         -------
         None
-
-        Raises
-        ------
-        RuntimeError
-            if *ts* is newly created and :meth:`commit` has not been called.
         """
 
     @abstractmethod
@@ -644,25 +643,6 @@ class Backend(ABC):
         """OPTIONAL: Load *ts* data into memory."""
 
     # Methods for ixmp.Scenario
-
-    @abstractmethod
-    def init_s(self, s: Scenario, scheme, annotation):
-        """Initialize the Scenario *s*.
-
-        s_init **may** modify the :attr:`~.TimeSeries.version` attribute of
-        *s*.
-
-        Parameters
-        ----------
-        scheme : str
-            Description of the scheme of the Scenario.
-        annotation : str
-            Description of the Scenario.
-
-        Returns
-        -------
-        None
-        """
 
     @abstractmethod
     def clone(self, s: Scenario, platform_dest, model, scenario, annotation,

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -357,21 +357,20 @@ class Backend(ABC):
     # Methods for ixmp.TimeSeries
 
     @abstractmethod
-    def init(self, ts: TimeSeries, annotation, scheme=None):
+    def init(self, ts: TimeSeries, annotation):
         """Create a new TimeSeries (or Scenario) *ts*.
 
         init **may** modify the :attr:`~TimeSeries.version` attribute of
         *ts*.
+
+        If *ts* is a :class:`Scenario`; the Backend **must** store the
+        :attr:`.Scenario.scheme` attribute.
 
         Parameters
         ----------
         annotation : str
             If *ts* is newly-created, the Backend **must** store this
             annotation with the TimeSeries.
-        scheme : str or None
-            Name of the model scheme, if *ts* is a :class:`Scenario`; the
-            Backend **must** set the :attr:`.Scenario.scheme` attribute to this
-            value. Otherwise, :obj:`None`.
 
         Returns
         -------
@@ -379,20 +378,22 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def get(self, ts: TimeSeries, version):
-        """Retrieve the existing TimeSeries or Scenario *ts*.
+    def get(self, ts: TimeSeries):
+        """Retrieve the existing TimeSeries (or Scenario) *ts*.
 
-        The TimeSeries is identified based on its (:attr:`~.TimeSeries.model`,
-        :attr:`~.TimeSeries.scenario`) and *version*.
+        The TimeSeries is identified based on the unique combination of the
+        attributes of *ts*:
+
+        - :attr:`~.TimeSeries.model`,
+        - :attr:`~.TimeSeries.scenario`, and
+        - :attr:`~.TimeSeries.version`.
+
+        If :attr:`.version` is :obj:`None`, the Backend **must** return the
+        version marked as default, and **must** set the attribute value.
 
         If *ts* is a Scenario, :meth:`get` **must** set the
-        :attr:`~.Scenario.scheme` attribute on it.
-
-        Parameters
-        ----------
-        version : int or None
-            If :obj:`None`, the version marked as the default is returned, and
-            ts_get **must** set :attr:`.TimeSeries.version` attribute on *ts*.
+        :attr:`~.Scenario.scheme` attribute with the value previously passed to
+        :meth:`init`.
 
         Returns
         -------
@@ -406,7 +407,8 @@ class Backend(ABC):
 
         See also
         --------
-        ts_set_as_default
+        is_default
+        set_as_default
         """
 
     @abstractmethod
@@ -601,9 +603,8 @@ class Backend(ABC):
 
         See also
         --------
-        ts_is_default
-        ts_get
-        s_get
+        get
+        is_default
         """
 
     @abstractmethod
@@ -616,9 +617,8 @@ class Backend(ABC):
 
         See also
         --------
-        ts_set_as_default
-        ts_get
-        s_get
+        get
+        set_as_default
         """
 
     @abstractmethod

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -611,7 +611,8 @@ class JDBCBackend(CachingBackend):
 
         # Instantiate same class as the original object
         return s.__class__(platform_dest, model, scenario,
-                           version=jclone.getVersion())
+                           version=jclone.getVersion(),
+                           scheme=jclone.getScheme())
 
     def has_solution(self, s):
         return self.jindex[s].hasSolution()

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -420,14 +420,16 @@ class JDBCBackend(CachingBackend):
         if ts.version is None:
             # The default version was requested; update the attribute
             ts.version = v
-        elif v != ts.version:
+        elif v != ts.version:  # pragma: no cover
+            # Something went wrong on the Java side
             raise RuntimeError(f'got version {v} instead of {ts.version}')
 
         if isinstance(ts, Scenario):
             # Also retrieve the scheme
             s = jobj.getScheme()
 
-            if ts.scheme and s != ts.scheme:
+            if ts.scheme and s != ts.scheme:  # pragma: no cover
+                # Something went wrong on the Java side
                 raise RuntimeError(f'got scheme {s} instead of {ts.scheme}')
 
             ts.scheme = s

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -407,44 +407,53 @@ class JDBCBackend(CachingBackend):
 
     # Timeseries methods
 
-    def _index_and_set_attrs(self, jobj, ts, scheme, version=None):
-        """Helper for init and get."""
+    def _index_and_set_attrs(self, jobj, ts):
+        """Add *jobj* to index and update attributes of *ts*.
+
+        Helper for init and get.
+        """
         # Add to index
         self.jindex[ts] = jobj
 
-        # Retrieve or check the version
-        if version is None:
-            version = jobj.getVersion()
-        else:
-            assert version == jobj.getVersion()
-
-        # Update the version attribute
-        ts.version = version
+        # Retrieve the version of the Java object
+        v = jobj.getVersion()
+        if ts.version is None:
+            # The default version was requested; update the attribute
+            ts.version = v
+        elif v != ts.version:
+            raise RuntimeError(f'got version {v} instead of {ts.version}')
 
         if isinstance(ts, Scenario):
             # Also retrieve the scheme
-            ts.scheme = jobj.getScheme() or scheme
+            s = jobj.getScheme()
 
-    def init(self, ts, annotation, scheme):
-        # ixmp_source uses the reverse order; throw away 'scheme' if None
+            if ts.scheme and s != ts.scheme:
+                raise RuntimeError(f'got scheme {s} instead of {ts.scheme}')
+
+            ts.scheme = s
+
+    def init(self, ts, annotation):
         klass = ts.__class__.__name__
-        args = [scheme, annotation] if klass == 'Scenario' else [annotation]
+
+        # Final arguments: scheme only for Scenarios
+        args = [ts.scheme, annotation] if klass == 'Scenario' else [annotation]
 
         # Call either newTimeSeries or newScenario
         method = getattr(self.jobj, 'new' + klass)
         jobj = method(ts.model, ts.scenario, *args)
 
-        self._index_and_set_attrs(jobj, ts, scheme=scheme, version=None)
+        self._index_and_set_attrs(jobj, ts)
 
-    def get(self, ts, version):
+    def get(self, ts):
         args = [ts.model, ts.scenario]
-        if version is not None:
+        if ts.version is not None:
             # Load a TimeSeries of specific version
-            args.append(version)
+            args.append(ts.version)
 
         # either getTimeSeries or getScenario
         method = getattr(self.jobj, 'get' + ts.__class__.__name__)
         try:
+            # Either the 2- or 3- argument form, depending on args
             jobj = method(*args)
         except java.IxException as e:
             # Try to re-raise as a ValueError for bad model or scenario name
@@ -457,7 +466,7 @@ class JDBCBackend(CachingBackend):
             # Failed
             _raise_jexception(e)
 
-        self._index_and_set_attrs(jobj, ts, version)
+        self._index_and_set_attrs(jobj, ts)
 
     def check_out(self, ts, timeseries_only):
         try:

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -433,7 +433,15 @@ class TimeSeries:
         return False
 
     def check_out(self, timeseries_only=False):
-        """Check out the TimeSeries for modification."""
+        """Check out the TimeSeries.
+
+        Data in the TimeSeries can only be modified when it is in a checked-out
+        state.
+
+        See Also
+        --------
+        utils.maybe_check_out
+        """
         self._backend('check_out', timeseries_only)
 
     def commit(self, comment):
@@ -447,6 +455,10 @@ class TimeSeries:
         ----------
         comment : str
             Description of the changes being committed.
+
+        See Also
+        --------
+        utils.maybe_commit
         """
         self._backend('commit', comment)
 
@@ -817,7 +829,18 @@ class Scenario(TimeSeries):
             return scenario, platform
 
     def check_out(self, timeseries_only=False):
-        """Check out the Scenario for modification."""
+        """Check out the Scenario.
+
+        Raises
+        ------
+        ValueError
+            If :meth:`has_solution` is :obj:`True`.
+
+        See Also
+        --------
+        TimeSeries.check_out
+        utils.maybe_check_out
+        """
         if not timeseries_only and self.has_solution():
             raise ValueError('This Scenario has a solution, '
                              'use `Scenario.remove_solution()` or '

--- a/ixmp/model/base.py
+++ b/ixmp/model/base.py
@@ -37,7 +37,7 @@ class Model(ABC):
         Parameters
         ----------
         scenario : .Scenario
-            Scenario object to initialize.
+            Object to initialize.
 
         See also
         --------
@@ -50,18 +50,28 @@ class Model(ABC):
     def initialize_items(cls, scenario, items):
         """Helper for :meth:`initialize`.
 
-        All of the *items* are added to *scenario*. Existing items are not
-        modified.
+        All of the `items` are added to `scenario`. Existing items are not
+        modified. Errors are logged if the description in `items` conflicts
+        with the index set(s) and/or index name(s) of existing items.
+
+        initialize_items may perform one commit. `scenario` is in the same
+        state (checked in, or checked out) after initialize_items is complete.
 
         Parameters
         ----------
         scenario : .Scenario
-            Scenario object to initialize.
+            Object to initialize.
         items : dict of (str -> dict)
             Each key is the name of an ixmp item (set, parameter, equation, or
             variable) to initialize. Each dict **must** have the key 'ix_type';
             one of 'set', 'par', 'equ', or 'var'; any other entries are keyword
             arguments to the methods :meth:`.init_set` etc.
+
+        Raises
+        ------
+        ValueError
+            if `scenario` has a solution, i.e. :meth:`.has_solution` is
+            :obj:`True`.
 
         See also
         --------

--- a/ixmp/model/base.py
+++ b/ixmp/model/base.py
@@ -108,9 +108,10 @@ class Model(ABC):
                 for key, values in item_info.items():
                     values = values or []
                     existing = getattr(scenario, key)(name)
+                    print(name, key, values, existing)
                     if existing != values:
                         # The existing index sets or names do not match
-                        log.error(
+                        log.warning(
                             f"Existing index {key.split('_')[-1]} of "
                             f"{repr(name)} {repr(existing)} do not match "
                             f"{repr(values)}"
@@ -124,8 +125,11 @@ class Model(ABC):
             # Possibly check out the Scenario
             try:
                 checkout = maybe_check_out(scenario, checkout)
-            except ValueError as exc:
-                # The Scenario has a solution; can't proceed
+            except ValueError as exc:  # pragma: no cover
+                # The Scenario has a solution. This indicates an inconsistent
+                # situation: the Scenario lacks the item *name*, but somehow it
+                # was successfully solved without it, and the solution stored.
+                # Can't proceed further.
                 log.error(str(exc))
                 return
 

--- a/ixmp/model/dantzig.py
+++ b/ixmp/model/dantzig.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pandas as pd
 
-from ixmp.utils import update_par
+from ixmp.utils import maybe_check_out, maybe_commit, update_par
 from .gams import GAMSModel
 
 
@@ -78,6 +78,8 @@ class DantzigModel(GAMSModel):
         if not with_data:
             return
 
+        checkout = maybe_check_out(scenario)
+
         # Add set elements
         scenario.add_set('i', DATA['i'])
         scenario.add_set('j', DATA['j'])
@@ -89,3 +91,5 @@ class DantzigModel(GAMSModel):
 
         # TODO avoid overwriting the existing value
         scenario.change_scalar('f', *DATA['f'])
+
+        maybe_commit(scenario, checkout, f'{cls.__name__}.initialize')

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -138,7 +138,8 @@ class GAMSModel(Model):
             # Write model data to file
             backend.write_file(self.in_file, ItemType.SET | ItemType.PAR,
                                **s_arg)
-        except NotImplementedError:
+        except NotImplementedError:  # pragma: no cover
+            # Currently there is no such Backend
             raise NotImplementedError('GAMSModel requires a Backend that can '
                                       'write to GDX files, e.g. JDBCBackend')
 

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -82,6 +82,20 @@ def ixmp_cli(tmp_env):
     yield Runner()
 
 
+@pytest.fixture
+def protect_pint_app_registry():
+    """Protect pint's application registry.
+
+    Use this fixture on tests which invoke code that calls
+    :meth:`pint.set_application_registry`. It ensures that the environment for
+    other tests is not altered.
+    """
+    import pint
+    saved = pint.get_application_registry()
+    yield
+    pint.set_application_registry(saved)
+
+
 @pytest.fixture(scope='session')
 def tmp_env(tmp_path_factory):
     """Return the os.environ dict with the IXMP_DATA variable set.

--- a/ixmp/tests/backend/test_base.py
+++ b/ixmp/tests/backend/test_base.py
@@ -40,9 +40,8 @@ def test_class():
         get_timeslices = noop
         get_units = noop
         has_solution = noop
+        init = noop
         init_item = noop
-        init_s = noop
-        init_ts = noop
         is_default = noop
         item_delete_elements = noop
         item_get_elements = noop

--- a/ixmp/tests/reporting/test_computations.py
+++ b/ixmp/tests/reporting/test_computations.py
@@ -11,9 +11,6 @@ from ixmp.testing import assert_logs
 from . import add_test_data
 
 
-REGISTRY = pint.get_application_registry()
-
-
 @pytest.fixture(scope='function')
 def data(test_mp, request):
     scen = ixmp.Scenario(test_mp, request.node.name, request.node.name, 'new')
@@ -25,10 +22,12 @@ def test_apply_units(data, caplog):
     # Unpack
     *_, x = data
 
+    registry = pint.get_application_registry()
+
     # Brute-force replacement with incompatible units
     with assert_logs(caplog, "Replace 'kilogram' with incompatible 'liter'"):
         result = computations.apply_units(x, 'litres')
-    assert result.attrs['_unit'] == REGISTRY.Unit('litre')
+    assert result.attrs['_unit'] == registry.Unit('litre')
     # No change in values
     assert_series_equal(result.to_series(), x.to_series())
 
@@ -37,17 +36,17 @@ def test_apply_units(data, caplog):
     # Compatible units: magnitudes are also converted
     with assert_logs(caplog, "Convert 'kilogram' to 'metric_ton'"):
         result = computations.apply_units(x, 'tonne')
-    assert result.attrs['_unit'] == REGISTRY.Unit('tonne')
+    assert result.attrs['_unit'] == registry.Unit('tonne')
     assert_series_equal(result.to_series(), x.to_series() * 0.001)
 
     # Remove unit
-    x.attrs['_unit'] = REGISTRY.Unit('dimensionless')
+    x.attrs['_unit'] = registry.Unit('dimensionless')
 
     caplog.clear()
     result = computations.apply_units(x, 'kg')
     # Nothing logged when _unit attr is missing
     assert len(caplog.messages) == 0
-    assert result.attrs['_unit'] == REGISTRY.Unit('kg')
+    assert result.attrs['_unit'] == registry.Unit('kg')
     assert_series_equal(result.to_series(), x.to_series())
 
 

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -501,8 +501,13 @@ def test_platform_units(test_mp, caplog, ureg):
     scen.add_par('x', x)
 
     # Unrecognized units are added automatically, with log messages emitted
-    with assert_logs(caplog, ['Add unit definition: kWa = [kWa]']):
-        rep.get(x_key)
+    caplog.clear()
+    rep.get(x_key)
+    # NB cannot use assert_logs here. reporting.utils.parse_units uses the
+    #    pint application registry, so depending which tests are run and in
+    #    which order, this unit may already be defined.
+    if len(caplog.messages):
+        assert 'Add unit definition: kWa = [kWa]' in caplog.messages
 
     # Mix of recognized/unrecognized units can be added: USD is already in the
     # unit registry, so is not re-added
@@ -531,7 +536,7 @@ def test_platform_units(test_mp, caplog, ureg):
     # Applied units are pint objects with the correct dimensionality
     unit = x.attrs['_unit']
     assert isinstance(unit, pint.Unit)
-    assert unit.dimensionality == {'[USD]': 1, '[km]': -1}
+    assert unit.dimensionality == {'[USD]': 1, '[pkm]': -1}
 
 
 def test_reporter_describe(test_mp, test_data_path, capsys):

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -255,6 +255,7 @@ def test_report(ixmp_cli):
     assert result.exit_code == UsageError.exit_code
 
 
+@pytest.mark.usefixtures('protect_pint_app_registry')
 def test_show_versions(ixmp_cli):
     result = ixmp_cli.invoke(['show-versions'])
     assert result.exit_code == 0, result.output

--- a/ixmp/tests/test_utils.py
+++ b/ixmp/tests/test_utils.py
@@ -2,7 +2,7 @@
 import pytest
 from pytest import mark, param
 
-from ixmp import utils
+from ixmp import Scenario, utils
 from ixmp.testing import populate_test_platform
 
 
@@ -93,3 +93,15 @@ def test_format_scenario_list(test_mp):
         'ixmp://{}/canning problem/standard#2',
     ]))
     assert exp == utils.format_scenario_list(test_mp, as_url=True)
+
+
+def test_maybe_commit(caplog, test_mp):
+    s = Scenario(test_mp, 'maybe_commit', 'maybe_commit', version='new')
+
+    # A new Scenario is not committed, so this works
+    assert utils.maybe_commit(s, True, message='foo') is True
+
+    # *s* is already commited. No commit is performed, but the function call
+    # succeeds and a message is logged
+    assert utils.maybe_commit(s, True, message='foo') is False
+    assert caplog.messages[-1].startswith("maybe_commit() didn't commit: ")

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -63,44 +63,66 @@ def check_year(y, s):
         return True
 
 
-def maybe_check_out(scenario, state=None):
-    """Check out *scenario* depending on *state*.
+def maybe_check_out(timeseries, state=None):
+    """Check out `timeseries` depending on `state`.
 
-    If `state` is :obj:`None`, then :meth:`.check_out` is called, and
-    maybe_check_out returns:
+    If `state` is :obj:`None`, then :meth:`check_out` is called.
 
-      - :obj:`True` if a check out was performed, i.e. the scenario was
-        previously not in a checked-out state.
-      - :obj:`False` if no check out was performed, i.e. the scenario was
-        already in a checked-out state.
+    Returns
+    -------
+    :obj:`True`
+        if `state` was :obj:`None` and a check out was performed, i.e.
+        `timeseries` was previously in a checked-in state.
+    :obj:`False`
+        if `state` was :obj:`None` and no check out was performed, i.e.
+        `timeseries` was already in a checked-out state.
+    `state`
+        if `state` was not :obj:`None` and no check out was attempted.
 
-    For any other value of `state`, maybe_check_out does nothing.
+    Raises
+    ------
+    ValueError
+        If `timeseries` is a :class:`.Scenario` object and
+        :meth:`.has_solution` is :obj:`True`.
+
+    See Also
+    --------
+    :meth:`.TimeSeries.check_out`
+    :meth:`.Scenario.check_out`
     """
     if state is not None:
-        return state  # Already tried to check out
+        return state
+
     try:
-        # If *scenario* is already committed to the Backend, it must be
-        # checked out.
-        scenario.check_out()
+        timeseries.check_out()
     except RuntimeError:
-        # If *scenario* is new (has not been committed), the checkout
+        # If `timeseries` is new (has not been committed), the checkout
         # attempt raises an exception
         return False
     else:
         return True
 
 
-def maybe_commit(scenario, condition, message):
-    """Commit *scenario* with *message* if *condition* is :obj:`True`.
+def maybe_commit(timeseries, condition, message):
+    """Commit `timeseries` with `message` if `condition` is :obj:`True`.
 
-    Any exception raised during an attempted commit is logged with level
-    `ERROR`, and :obj:`False` is returned. If a commit is performed,
-    :obj:`True` is returned.
+    Returns
+    -------
+    :obj:`True`
+        if a commit is performed.
+    :obj:`False`
+        if any exception is raised during the attempted commit. The exception
+        is logged with level ``ERROR``.
+
+    See Also
+    --------
+    :meth:`.TimeSeries.commit`
     """
     if not condition:
         return False
+
     try:
-        scenario.commit(message)
+        timeseries.commit(message)
     except RuntimeError as exc:
         log.error(str(exc))
         return False

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -112,7 +112,7 @@ def maybe_commit(timeseries, condition, message):
         if a commit is performed.
     :obj:`False`
         if any exception is raised during the attempted commit. The exception
-        is logged with level ``ERROR``.
+        is logged with level ``INFO``.
 
     See Also
     --------
@@ -124,7 +124,7 @@ def maybe_commit(timeseries, condition, message):
     try:
         timeseries.commit(message)
     except RuntimeError as exc:
-        log.error(str(exc))
+        log.info(f"maybe_commit() didn't commit: {exc}")
         return False
     else:
         return True

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open('README.md', 'r') as f:
 
 INSTALL_REQUIRES = [
     # Temporary exclusions; see iiasa/ixmp#279
-    'JPype1 >= 0.7, != 0.7.2, != 0.7.3',
+    'JPype1 >= 0.7, != 0.7.2, != 0.7.3, != 0.7.4',
     'click',
     'dask[array]',
     'graphviz',


### PR DESCRIPTION
This PR adds changes necessary for iiasa/message_ix#190. In particular, it ensures that the `Model.initialize()` method is *always* called when a Scenario is cloned *or* loaded.

This helps in the following way:
- In that PR, `MESSAGE.initialize()` is expanded to add sets and parameters related to storage to any existing Scenario that lacks them. E.g. in `test_legacy_version`, an old Scenario is loaded that lacks the storage parameters. Solving that Scenario with the updated MESSAGE GAMS code fails, because the items expected are not found.
- The code in this PR ensures that `MESSAGE.initialize()` is invoked when that Scenario is loaded: https://github.com/behnam-zakeri/message_ix/blob/43a98fe3e416bf1fe61af54f3243052dc162f23d/message_ix/tests/test_legacy_version.py#L15-L16

Also:
- `Model.initialize_items()` checks whether the returned object is in a checked-out state when it is received, and leaves the object in the same state.
- `Backend.init_ts()` and `Backend.init_s()` are consolidated and simplified.
- `Scenario.__init__()` now chains through its parent method, `TimeSeries.__init__()`.
- Made some follow-up changes to #320. `test_show_versions` would load pyam and message_data, which both change the pint 'application registry'; this would cause the ixmp reporting tests related to units to fail, depending on which subset of tests was run.

## How to review

- Note that CI passes.
- Run with iiasa/message_ix#190 and confirm the message_ix test `test_legacy_version` passes.

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.