### PR TITLE
Improve Reporting exception handling

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- `#316 <https://github.com/iiasa/ixmp/pull/316>`_: Raise user-friendly exceptions from :meth:`.Reporter.get` in Jupyter notebooks and other read–evaluate–print loops (REPLs).
 - `#315 <https://github.com/iiasa/ixmp/pull/315>`_: Ensure :meth:`.Model.initialize` is always called for new *and* cloned objects.
 - `#320 <https://github.com/iiasa/ixmp/pull/320>`_: Add CLI command `ixmp show-versions` to print ixmp and dependency versions for debugging.
 - `#312 <https://github.com/iiasa/ixmp/pull/312>`_: Add :meth:`~.computations.apply_units`, :meth:`~computations.select` reporting calculations; expand :meth:`.Reporter.add`.
@@ -23,8 +24,7 @@ All changes
   - positional and ``dbtype=`` arguments to :class:`.Platform`/:class:`.JDBCBackend`.
   - ``first_model_year=``, ``keep_sol=``, and ``scen=`` arguments to :meth:`~.Scenario.clone`.
   - ``rixmp.legacy``, an earlier version of :ref:`the R interface <rixmp>` that did not use reticulate.
-- `#261 <https://github.com/iiasa/ixmp/pull/261>`_: Increase minimum pandas
-  version to 1.0; adjust for `API changes and deprecations <https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html#backwards-incompatible-api-changes>`_.
+- `#261 <https://github.com/iiasa/ixmp/pull/261>`_: Increase minimum pandas version to 1.0; adjust for `API changes and deprecations <https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html#backwards-incompatible-api-changes>`_.
 - `#243 <https://github.com/iiasa/ixmp/pull/243>`_: Add :meth:`.export_timeseries_data` to write data for multiple scenarios to CSV.
 - `#264 <https://github.com/iiasa/ixmp/pull/264>`_: Implement methods to get and create new subannual timeslices.
 

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -480,6 +480,8 @@ class Reporter:
             # Print the exception in case ComputationError.__str__ fails;
             # workaround for https://github.com/iiasa/ixmp/issues/206
             print(exc)
+            # To debug unprintable ComputationErrors:
+            # c = ComputationError(); c.__cause__ = exc; str(c)
             raise ComputationError from exc
 
     def keys(self):

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -477,12 +477,7 @@ class Reporter:
         try:
             return dask_get(dsk, key)
         except Exception as exc:
-            # Print the exception in case ComputationError.__str__ fails;
-            # workaround for https://github.com/iiasa/ixmp/issues/206
-            print(exc)
-            # To debug unprintable ComputationErrors:
-            # c = ComputationError(); c.__cause__ = exc; str(c)
-            raise ComputationError from exc
+            raise ComputationError(exc) from None
 
     def keys(self):
         """Return the keys of :attr:`graph`."""

--- a/ixmp/reporting/exceptions.py
+++ b/ixmp/reporting/exceptions.py
@@ -88,7 +88,7 @@ def process_dask_tb(exc):
                 # their string repr().
                 key = frame.locals['key']
                 task = frame.locals['task']
-            except (TypeError, KeyError):
+            except (TypeError, KeyError):  # pragma: no cover
                 # No locals, or 'key' or 'task' not present
                 pass
 

--- a/ixmp/reporting/exceptions.py
+++ b/ixmp/reporting/exceptions.py
@@ -1,3 +1,14 @@
+from itertools import chain
+import logging
+from traceback import (
+    TracebackException,
+    format_exception_only,
+    format_list,
+)
+
+
+log = logging.getLogger(__name__)
+
 
 class ComputationError(Exception):
     """Wrapper to print intelligible exception information for Reporter.get().
@@ -7,65 +18,89 @@ class ComputationError(Exception):
     - Gives the key in the Reporter.graph and the computation task that
       caused the exception.
     """
+    def __init__(self, exc):
+        self._exc = exc
+
     def __str__(self):
-        from traceback import (
-            TracebackException,
-            format_exception_only,
-            format_list,
-        )
+        """String representation.
 
-        # Move the cause to a non-private attribute
-        self.cause = self.__cause__
-
-        # Suppress automatic printing of the cause
-        self.__cause__ = None
-
-        info = None  # Information about the call that triggered the exception
-        frames = []  # Frames for an abbreviated stacktrace
-        dask_internal = True  # Flag if the frame is internal to dask
-
+        Most exception handling (Python, IPython, Jupyter) will print the
+        traceback that led to *self* (i.e. the call to :meth:`.Reporter.get`),
+        followed by the string returned by this method.
+        """
         try:
-            # Get a traceback with captured locals
-            tb = TracebackException.from_exception(self.cause,
-                                                   capture_locals=True)
-        except Exception:
-            tb = TracebackException.from_exception(self.cause)
+            return self._format()
+        except Exception as format_exc:
+            # Something went wrong during _format()
+            log.error(f'Exception raised while formatting {self._exc}:\n'
+                      + repr(format_exc))
+            # Fall back to printing the underlying exception
+            return str(self._exc)
 
-        # Iterate over frames from the base of the stack
-        for frame in tb.stack:
-            if frame.name == 'execute_task':
-                # Current frame is the dask internal call to execute a task
+    def _format(self):
+        key, task, frames = process_dask_tb(self._exc)
 
+        # Assemble the exception printout
+        return ''.join(chain(
+            # Reporter information for debugging
+            [
+                f'computing {key} using:\n\n' if key else '',
+                f'{task}\n\n' if task else '',
+                'Use Reporter.describe(...) to trace the computation.\n\n',
+                'Computation traceback:\n',
+            ],
+            # Traceback; omitting a few dask internal calls below execute_task
+            format_list(frames),
+            # Type and message of the original exception
+            format_exception_only(self._exc.__class__, self._exc)
+        ))
+
+
+def process_dask_tb(exc):
+    """Process *exc* arising from :meth:`.Reporter.get`.
+
+    Returns a tuple with 3 elements:
+
+    - The key of the reporting computation.
+    - The info key of the reporting computation.
+    - A list of traceback.FrameSummary objects, without locals, for *only*
+      frames that are not internal to dask.
+    """
+    key = task = None  # Info about the computation that triggered *exc*
+    frames = []  # Frames for an abbreviated stacktrace
+
+    try:
+        # Get a traceback with captured locals
+        tbe = TracebackException.from_exception(exc, capture_locals=True)
+    except Exception:
+        # Some exception occurred when capturing locals; proceed without
+        tbe = TracebackException.from_exception(exc)
+
+    # Iterate over frames from the base of the stack
+    # Initial frames are internal to dask
+    dask_internal = True
+    for frame in tbe.stack:
+        if frame.name == 'execute_task':
+            # Current frame is the dask internal call to execute a task
+            try:
                 # Retrieve information about the key/task that triggered the
                 # exception. These are not the raw values of variables, but
                 # their string repr().
-                try:
-                    i = frame.locals
-                    info = f"computing {i['key']!r} using\n\n{i['task']}\n\n"
-                except (TypeError, KeyError):
-                    info = ''
+                key = frame.locals['key']
+                task = frame.locals['task']
+            except (TypeError, KeyError):
+                # No locals, or 'key' or 'task' not present
+                pass
 
-                # Remaining frames are related to the exception
-                dask_internal = False
+            # Subsequent frames are related to the exception
+            dask_internal = False
 
-            if not dask_internal:
-                # Don't display the locals when printing the traceback
-                frame.locals = None
+        if not dask_internal:
+            # Don't display the locals when printing the traceback
+            frame.locals = None
 
-                # Store the frame for printing the traceback
-                frames.append(frame)
+            # Store the frame for printing the traceback
+            frames.append(frame)
 
-        # Assemble the exception printout
-
-        # Reporter information for debugging
-        lines = [
-            info,
-            'Use Reporter.describe(...) to trace the computation.\n\n',
-            'Computation traceback:\n',
-        ]
-        # Traceback; omitting a few dask internal calls below execute_task
-        lines.extend(format_list(frames[3:]))
-        # Type and message of the original exception
-        lines.extend(format_exception_only(self.cause.__class__, self.cause))
-
-        return ''.join(lines)
+    # Omit a few dask internal calls below execute_task
+    return key, task, frames[3:]

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -375,7 +375,7 @@ def get_cell_output(nb, name_or_index, kind='data'):
 
     try:
         result = cell['outputs'][0][kind]
-    except NameError:
+    except NameError:  # pragma: no cover
         raise ValueError(f'no cell named {name_or_index}')
     else:
         return eval(result['text/plain']) if kind == 'data' else result

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -285,7 +285,7 @@ def make_dantzig(mp, solve=False):
 nbformat = pytest.importorskip('nbformat')
 
 
-def run_notebook(nb_path, tmp_path, env=None, kernel=None):
+def run_notebook(nb_path, tmp_path, env=None, kernel=None, allow_errors=False):
     """Execute a Jupyter notebook via ``nbconvert`` and collect output.
 
     Modified from
@@ -303,6 +303,10 @@ def run_notebook(nb_path, tmp_path, env=None, kernel=None):
     kernel : str, optional
         Jupyter kernel to use. Default: 'python2' or 'python3', matching the
         current Python version.
+    allow_errors : bool, optional
+        Whether to pass the ``--allow-errors`` option to ``nbconvert``. If
+        :obj:`True`, the execution always succeeds, and cell output contains
+        exception information.
 
     Returns
     -------
@@ -320,6 +324,7 @@ def run_notebook(nb_path, tmp_path, env=None, kernel=None):
     fname = tmp_path / 'test.ipynb'
     args = [
         "jupyter", "nbconvert", "--to", "notebook", "--execute",
+        "--allow-errors" if allow_errors else "",
         "--ExecutePreprocessor.timeout=60",
         "--ExecutePreprocessor.kernel_name={}".format(kernel),
         "--output", str(fname), str(nb_path)]
@@ -338,7 +343,7 @@ def run_notebook(nb_path, tmp_path, env=None, kernel=None):
     return nb, errors
 
 
-def get_cell_output(nb, name_or_index):
+def get_cell_output(nb, name_or_index, kind='data'):
     """Retrieve a cell from *nb* according to its metadata *name_or_index*:
 
     The Jupyter notebook format allows specifying a document-wide unique 'name'
@@ -349,6 +354,13 @@ def get_cell_output(nb, name_or_index):
 
     Return the cell matching *name_or_index* if a string; or the cell at the
     int index; or raise ValueError.
+
+    Parameters
+    ----------
+    kind : str, optional
+        Kind of cell output to retrieve. For 'data', the data in format
+        'text/plain' is run through :func:`eval`. To retrieve an exception
+        message, use 'evalue'.
     """
     if isinstance(name_or_index, int):
         cell = nb.cells[name_or_index]
@@ -362,9 +374,11 @@ def get_cell_output(nb, name_or_index):
                 continue
 
     try:
-        return eval(cell['outputs'][0]['data']['text/plain'])
+        result = cell['outputs'][0][kind]
     except NameError:
-        raise ValueError('no cell named {!r}'.format(name_or_index))
+        raise ValueError(f'no cell named {name_or_index}')
+    else:
+        return eval(result['text/plain']) if kind == 'data' else result
 
 
 # Assertions for testing

--- a/ixmp/tests/data/reporting-exceptions.ipynb
+++ b/ixmp/tests/data/reporting-exceptions.ipynb
@@ -1,0 +1,41 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import ixmp\n",
+    "\n",
+    "def fail():\n",
+    "    'x' + 3.4  # Raises TypeError\n",
+    "\n",
+    "rep = ixmp.Reporter()\n",
+    "rep.add('test', (fail,))\n",
+    "rep.get('test')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.5"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/ixmp/tests/reporting/test_exceptions.py
+++ b/ixmp/tests/reporting/test_exceptions.py
@@ -1,6 +1,16 @@
 import re
 
-from ixmp.testing import get_cell_output, run_notebook
+from ixmp.reporting import ComputationError
+from ixmp.testing import assert_logs, get_cell_output, run_notebook
+
+
+def test_computationerror(caplog):
+    ce_none = ComputationError(None)
+
+    msg = ("Exception raised while formatting None:\nAttributeError"
+           "(\"'NoneType' object has no attribute '__traceback__'\")")
+    with assert_logs(caplog, msg):
+        str(ce_none)
 
 
 # The TypeError message differs:

--- a/ixmp/tests/reporting/test_exceptions.py
+++ b/ixmp/tests/reporting/test_exceptions.py
@@ -1,0 +1,23 @@
+import re
+
+from ixmp.testing import get_cell_output, run_notebook
+
+
+EXPECTED = re.compile(r"""computing 'test' using:
+
+\(<function fail at \w+>,\)
+
+Use Reporter.describe\(...\) to trace the computation.
+
+Computation traceback:
+  File "<ipython-input-\d*-\w+>", line 4, in fail
+    'x' \+ 3.4  # Raises TypeError
+TypeError: can only concatenate str \(not "float"\) to str
+""")
+
+
+def test_computationerror_ipython(test_data_path, tmp_path, tmp_env):
+    fname = test_data_path / 'reporting-exceptions.ipynb'
+    nb, _ = run_notebook(fname, tmp_path, tmp_env, allow_errors=True)
+
+    assert EXPECTED.match(get_cell_output(nb, 0, kind='evalue'))

--- a/ixmp/tests/reporting/test_exceptions.py
+++ b/ixmp/tests/reporting/test_exceptions.py
@@ -3,6 +3,9 @@ import re
 from ixmp.testing import get_cell_output, run_notebook
 
 
+# The TypeError message differs:
+# - Python 3.6: "must be str, not float"
+# - Python 3.7: "can only concatenate str (not "float") to str"
 EXPECTED = re.compile(r"""computing 'test' using:
 
 \(<function fail at \w+>,\)
@@ -12,7 +15,7 @@ Use Reporter.describe\(...\) to trace the computation.
 Computation traceback:
   File "<ipython-input-\d*-\w+>", line 4, in fail
     'x' \+ 3.4  # Raises TypeError
-TypeError: can only concatenate str \(not "float"\) to str
+TypeError: .*str.*float.*
 """)
 
 
@@ -20,4 +23,5 @@ def test_computationerror_ipython(test_data_path, tmp_path, tmp_env):
     fname = test_data_path / 'reporting-exceptions.ipynb'
     nb, _ = run_notebook(fname, tmp_path, tmp_env, allow_errors=True)
 
-    assert EXPECTED.match(get_cell_output(nb, 0, kind='evalue'))
+    observed = get_cell_output(nb, 0, kind='evalue')
+    assert EXPECTED.match(observed), observed

--- a/ixmp/tests/reporting/test_exceptions.py
+++ b/ixmp/tests/reporting/test_exceptions.py
@@ -7,8 +7,9 @@ from ixmp.testing import assert_logs, get_cell_output, run_notebook
 def test_computationerror(caplog):
     ce_none = ComputationError(None)
 
+    # Message ends with ',)' on Python 3.6, only ')' on Python 3.7
     msg = ("Exception raised while formatting None:\nAttributeError"
-           "(\"'NoneType' object has no attribute '__traceback__'\")")
+           "(\"'NoneType' object has no attribute '__traceback__'\"")
     with assert_logs(caplog, msg):
         str(ce_none)
 


### PR DESCRIPTION
Closes #206.

## How to review

1. In Jupyter or the embedded console of an editor like Spyder, set up a Reporter to fail, e.g.

   ```python
   import ixmp
   rep = ixmp.Reporter()

   def fail():
       'x' + 3.4  # Raises an exception

   rep.add('failure,' (fail,))
   rep.get('failure')
   ```
   (can also do this using the file ixmp/tests/data/reporting-exceptions.ipynb added to the test suite)
2. Confirm that an intelligible message is printed.

## PR checklist

- [x] Tests added.
- [x] ~Documentation added.~
- [x] Release notes updated.
