### PR TITLE
Generalize reporting.Quantity in preparation for sparse xarray

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :pull:`317`: Make :class:`reporting.Quantity` classes interchangeable.
 - :pull:`330`: Use GitHub Actions for continuous testing and integration.
 
 

--- a/doc/source/conf.py
+++ b/doc/source/conf.py
@@ -102,6 +102,7 @@ intersphinx_mapping = {
     'pandas': ('https://pandas.pydata.org/pandas-docs/stable/', None),
     'pint': ('https://pint.readthedocs.io/en/stable/', None),
     'python': ('https://docs.python.org/3/', None),
+    'sparse': ('https://sparse.pydata.org/en/stable/', None),
     'xarray': ('https://xarray.pydata.org/en/stable/', None),
 }
 

--- a/doc/source/reporting.rst
+++ b/doc/source/reporting.rst
@@ -1,7 +1,7 @@
 .. currentmodule:: ixmp.reporting
 
 Reporting
-=========
+*********
 
 Top-level methods and classes:
 
@@ -11,7 +11,6 @@ Top-level methods and classes:
    Reporter
    Key
    Quantity
-   as_quantity
 
 Others:
 
@@ -184,12 +183,30 @@ Others:
           >>> foo('a b c')
           foo:a-b-c
 
-.. automodule:: ixmp.reporting
-   :members: Quantity, as_quantity
+.. autodata:: ixmp.reporting.Quantity(data, *args, **kwargs)
+   :annotation:
+
+The :data:`.Quantity` constructor converts its arguments to an internal, :class:`xarray.DataArray`-like data format:
+
+.. code-block:: python
+
+   # Existing data
+   data = pd.Series(...)
+
+   # Convert to a Quantity for use in reporting calculations
+   qty = Quantity(data, name="Quantity name", units="kg")
+   rep.add("new_qty", qty)
+
+Common :mod:`ixmp.reporting` usage, e.g. in :mod:`message_ix`, creates large, sparse data frames (billions of possible elements, but <1% populated); :class:`~xarray.DataArray`'s default, 'dense' storage format would be too large for available memory.
+
+- Currently, Quantity is :class:`.AttrSeries`, a wrapped :class:`pandas.Series` that behaves like a :class:`~xarray.DataArray`.
+- In the future, :mod:`ixmp.reporting` will use :class:`.SparseDataArray`, and eventually :class:`~xarray.DataArray` backed by sparse data, directly.
+
+The goal is that reporting code, including built-in and user computations, can treat quantity arguments as if they were :class:`~xarray.DataArray`.
 
 
 Computations
-------------
+============
 
 .. automodule:: ixmp.reporting.computations
    :members:
@@ -201,6 +218,7 @@ Computations
    Calculations:
 
    .. autosummary::
+      add
       aggregate
       apply_units
       disaggregate_shares
@@ -221,10 +239,27 @@ Computations
       concat
 
 
-Utilities
----------
+Internal format for reporting quantities
+========================================
 
-.. autoclass:: ixmp.reporting.quantity.AttrSeries
+.. currentmodule:: ixmp.reporting.quantity
+
+.. automodule:: ixmp.reporting.quantity
+   :members: assert_quantity
+
+.. currentmodule:: ixmp.reporting.attrseries
+
+.. automodule:: ixmp.reporting.attrseries
+   :members:
+
+.. currentmodule:: ixmp.reporting.sparsedataarray
+
+.. automodule:: ixmp.reporting.sparsedataarray
+   :members: SparseDataArray, SparseAccessor
+
+
+Utilities
+=========
 
 .. automodule:: ixmp.reporting.utils
    :members:

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -92,7 +92,7 @@ def report(context, config, key):
     r.configure(config)
 
     # Print the target
-    print(r.get(key))
+    print(r.get(key).to_series().sort_index())
 
 
 @main.command('show-versions')

--- a/ixmp/reporting/__init__.py
+++ b/ixmp/reporting/__init__.py
@@ -44,7 +44,7 @@ from . import computations
 from .describe import describe_recursive
 from .exceptions import ComputationError
 from .key import Key
-from .quantity import Quantity, as_quantity
+from .quantity import Quantity
 from .utils import (
     REPLACE_UNITS,
     RENAME_DIMS,
@@ -56,7 +56,6 @@ __all__ = [
     'Key',
     'Quantity',
     'Reporter',
-    'as_quantity',
     'configure',
 ]
 

--- a/ixmp/reporting/attrseries.py
+++ b/ixmp/reporting/attrseries.py
@@ -109,7 +109,7 @@ class AttrSeries(pd.Series):
                     # scalar
                     return self.loc[slice(key, key)]
 
-        idx = tuple(indexers.get(l, slice(None)) for l in self.index.names)
+        idx = tuple(indexers.get(n, slice(None)) for n in self.index.names)
         return AttrSeries(self.loc[idx])
 
     def sum(self, *args, **kwargs):

--- a/ixmp/reporting/attrseries.py
+++ b/ixmp/reporting/attrseries.py
@@ -1,0 +1,163 @@
+from collections.abc import Collection
+
+import pandas as pd
+import pandas.core.indexes.base as ibase
+import pint
+import xarray as xr
+
+
+class AttrSeries(pd.Series):
+    """:class:`pandas.Series` subclass imitating :class:`xarray.DataArray`.
+
+    Future versions of :mod:`ixmp.reporting` will use :class:`xarray.DataArray`
+    as :class:`Quantity`; however, because :mod:`xarray` currently lacks sparse
+    matrix support, ixmp quantities may be too large for available memory.
+
+    The AttrSeries class provides similar methods and behaviour to
+    :class:`xarray.DataArray`, so that :mod:`ixmp.reporting.computations`
+    methods can use xarray-like syntax.
+
+    Parameters
+    ----------
+    units : str or pint.Unit, optional
+        Set the units attribute. The value is converted to :class:`pint.Unit`
+        and added to `attrs`.
+    attrs : :class:`~collections.abc.Mapping`, optional
+        Set the :attr:`~pandas.Series.attrs` of the AttrSeries. This attribute
+        was added in `pandas 1.0
+        <https://pandas.pydata.org/docs/whatsnew/v1.0.0.html>`_, but is not
+        currently supported by the Series constructor.
+    """
+
+    # See https://pandas.pydata.org/docs/development/extending.html
+    @property
+    def _constructor(self):
+        return AttrSeries
+
+    def __init__(self, data=None, *args, name=None, units=None, attrs=None,
+                 **kwargs):
+        attrs = attrs or dict()
+        if units:
+            # Insert the units into the attrs
+            attrs['_unit'] = pint.Unit(units)
+
+        if isinstance(data, (AttrSeries, xr.DataArray)):
+            # Use attrs from an existing object
+            new_attrs = data.attrs.copy()
+
+            # Overwrite with explicit attrs argument
+            new_attrs.update(attrs)
+            attrs = new_attrs
+
+            # Pre-convert to pd.Series from xr.DataArray to preserve names and
+            # labels. For AttrSeries, this is a no-op (see below).
+            name = ibase.maybe_extract_name(name, data, type(self))
+            data = data.to_series()
+
+        # Don't pass attrs to pd.Series constructor; it currently does not
+        # accept them
+        super().__init__(data, *args, name=name, **kwargs)
+
+        # Update the attrs after initialization
+        self.attrs.update(attrs)
+
+    @classmethod
+    def from_series(cls, series, sparse=None):
+        return cls(series)
+
+    def assign_attrs(self, d):
+        self.attrs.update(d)
+        return self
+
+    def assign_coords(self, **kwargs):
+        return pd.concat([self], keys=kwargs.values(), names=kwargs.keys())
+
+    @property
+    def coords(self):
+        """Read-only."""
+        result = dict()
+        for name, levels in zip(self.index.names, self.index.levels):
+            result[name] = xr.Dataset(None, coords={name: levels})[name]
+        return result
+
+    @property
+    def dims(self):
+        return tuple(self.index.names)
+
+    def drop(self, label):
+        return self.droplevel(label)
+
+    def rename(self, new_name_or_name_dict):
+        if isinstance(new_name_or_name_dict, dict):
+            return self.rename_axis(index=new_name_or_name_dict)
+        else:
+            return super().rename(new_name_or_name_dict)
+
+    def sel(self, indexers=None, drop=False, **indexers_kwargs):
+        indexers = indexers or {}
+        indexers.update(indexers_kwargs)
+        if len(indexers) == 1:
+            level, key = list(indexers.items())[0]
+            if not isinstance(key, Collection) and not drop:
+                # When using .loc[] to select 1 label on 1 level, pandas drops
+                # the level. Use .xs() to avoid this behaviour unless drop=True
+                return AttrSeries(self.xs(key, level=level, drop_level=False))
+
+        idx = tuple(indexers.get(l, slice(None)) for l in self.index.names)
+        return AttrSeries(self.loc[idx])
+
+    def sum(self, *args, **kwargs):
+        obj = super(AttrSeries, self)
+        attrs = None
+
+        try:
+            dim = kwargs.pop('dim')
+        except KeyError:
+            dim = list(args)
+            args = tuple()
+
+        if isinstance(self.index, pd.MultiIndex):
+            if len(dim) == len(self.index.names):
+                # assume dimensions = full multi index, do simple sum
+                kwargs = {}
+            else:
+                # pivot and sum across columns
+                obj = self.unstack(dim)
+                kwargs['axis'] = 1
+                attrs = self.attrs
+        else:
+            if dim != [self.index.name]:
+                raise ValueError(dim, self.index.name, self)
+            kwargs['level'] = dim
+
+        return AttrSeries(obj.sum(*args, **kwargs), attrs=attrs)
+
+    def squeeze(self, *args, **kwargs):
+        kwargs.pop('drop')
+        return super().squeeze(*args, **kwargs) if len(self) > 1 else self
+
+    def as_xarray(self):
+        return xr.DataArray.from_series(self)
+
+    def transpose(self, *dims):
+        return self.reorder_levels(dims)
+
+    def to_dataframe(self):
+        return self.to_frame()
+
+    def to_series(self):
+        return self
+
+    def align_levels(self, other):
+        """Work around https://github.com/pandas-dev/pandas/issues/25760.
+
+        Return a copy of *obj* with common levels in the same order as *ref*.
+
+        .. todo:: remove when Quantity is xr.DataArray, or above issues is
+           closed.
+        """
+        if not isinstance(self.index, pd.MultiIndex):
+            return self
+        common = [n for n in other.index.names if n in self.index.names]
+        unique = [n for n in self.index.names if n not in common]
+        return self.reorder_levels(common + unique)

--- a/ixmp/reporting/attrseries.py
+++ b/ixmp/reporting/attrseries.py
@@ -6,10 +6,6 @@ import xarray as xr
 class AttrSeries(pd.Series):
     """:class:`pandas.Series` subclass imitating :class:`xarray.DataArray`.
 
-    Future versions of :mod:`ixmp.reporting` will use :class:`xarray.DataArray`
-    as :class:`Quantity`; however, because :mod:`xarray` currently lacks sparse
-    matrix support, ixmp quantities may be too large for available memory.
-
     The AttrSeries class provides similar methods and behaviour to
     :class:`xarray.DataArray`, so that :mod:`ixmp.reporting.computations`
     methods can use xarray-like syntax.
@@ -59,14 +55,16 @@ class AttrSeries(pd.Series):
 
     @classmethod
     def from_series(cls, series, sparse=None):
+        """Like :meth:`xarray.DataArray.from_series`."""
         return cls(series)
 
     def assign_coords(self, **kwargs):
+        """Like :meth:`xarray.DataArray.assign_coords`."""
         return pd.concat([self], keys=kwargs.values(), names=kwargs.keys())
 
     @property
     def coords(self):
-        """Read-only."""
+        """Like :attr:`xarray.DataArray.coords`. Read-only."""
         result = dict()
         for name, levels in zip(self.index.names, self.index.levels):
             result[name] = xr.Dataset(None, coords={name: levels})[name]
@@ -74,12 +72,15 @@ class AttrSeries(pd.Series):
 
     @property
     def dims(self):
+        """Like :attr:`xarray.DataArray.dims`."""
         return tuple(self.index.names)
 
     def drop(self, label):
+        """Like :meth:`xarray.DataArray.drop`."""
         return self.droplevel(label)
 
     def item(self, *args):
+        """Like :meth:`xarray.DataArray.item`."""
         if len(args) and args != (None,):
             raise NotImplementedError
         elif self.size != 1:
@@ -87,12 +88,14 @@ class AttrSeries(pd.Series):
         return self.iloc[0]
 
     def rename(self, new_name_or_name_dict):
+        """Like :meth:`xarray.DataArray.rename`."""
         if isinstance(new_name_or_name_dict, dict):
             return self.rename_axis(index=new_name_or_name_dict)
         else:
             return super().rename(new_name_or_name_dict)
 
     def sel(self, indexers=None, drop=False, **indexers_kwargs):
+        """Like :meth:`xarray.DataArray.sel`."""
         indexers = indexers or {}
         indexers.update(indexers_kwargs)
         if len(indexers) == 1:
@@ -113,6 +116,7 @@ class AttrSeries(pd.Series):
         return AttrSeries(self.loc[idx])
 
     def sum(self, *args, **kwargs):
+        """Like :meth:`xarray.DataArray.sum`."""
         obj = super(AttrSeries, self)
         attrs = None
 
@@ -140,6 +144,7 @@ class AttrSeries(pd.Series):
         return AttrSeries(obj.sum(*args, **kwargs), attrs=attrs)
 
     def squeeze(self, dim=None, *args, **kwargs):
+        """Like :meth:`xarray.DataArray.squeeze`."""
         assert kwargs.pop("drop", True)
 
         try:
@@ -168,25 +173,22 @@ class AttrSeries(pd.Series):
 
         return self.droplevel(to_drop)
 
-    def as_xarray(self):
-        return xr.DataArray.from_series(self)
-
     def transpose(self, *dims):
+        """Like :meth:`xarray.DataArray.transpose`."""
         return self.reorder_levels(dims)
 
     def to_dataframe(self):
+        """Like :meth:`xarray.DataArray.to_dataframe`."""
         return self.to_frame()
 
     def to_series(self):
+        """Like :meth:`xarray.DataArray.to_series`."""
         return self
 
     def align_levels(self, other):
         """Work around https://github.com/pandas-dev/pandas/issues/25760.
 
         Return a copy of *obj* with common levels in the same order as *ref*.
-
-        .. todo:: remove when Quantity is xr.DataArray, or above issues is
-           closed.
         """
         if not isinstance(self.index, pd.MultiIndex):
             return self

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -220,7 +220,8 @@ def data_for_quantity(ix_type, name, column, scenario, config):
     try:
         # Remove length-1 dimensions for scalars
         qty = qty.squeeze('index', drop=True)
-    except KeyError:
+    except (KeyError, ValueError):
+        # KeyError if "index" does not exist; ValueError if its length is > 1
         pass
 
     return qty

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -5,10 +5,10 @@
 from collections.abc import Mapping
 import logging
 from pathlib import Path
+from warnings import filterwarnings
 
 import pandas as pd
 import pint
-import xarray as xr
 
 from .quantity import Quantity
 from .utils import (
@@ -33,6 +33,15 @@ __all__ = [
     'sum',
     'write_report',
 ]
+
+
+# sparse 0.9.1, numba 0.49.0, triggered by xarray import
+for msg in ["No direct replacement for 'numba.targets' available",
+            "An import was requested from a module that has moved location."]:
+    filterwarnings(action='ignore', message=msg,
+                   module='sparse._coo.numba_extension')
+
+import xarray as xr  # noqa: E402
 
 
 log = logging.getLogger(__name__)

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -211,17 +211,6 @@ def data_for_quantity(ix_type, name, column, scenario, config):
         data = data.rename(columns=RENAME_DIMS) \
                    .set_index(dims)
 
-    # Check sparseness
-    # try:
-    #     shape = list(map(len, data.index.levels))
-    # except AttributeError:
-    #     shape = [data.index.size]
-    # size = reduce(mul, shape)
-    # filled = 100 * len(data) / size if size else 'NA'
-    # need_to_chunk = size > 1e7 and filled < 1
-    # info = (name, shape, filled, size, need_to_chunk)
-    # log.debug(' '.join(map(str, info)))
-
     # Convert to a Quantity, assign attrbutes and name
     qty = Quantity(
         data[column],

--- a/ixmp/reporting/quantity.py
+++ b/ixmp/reporting/quantity.py
@@ -1,186 +1,40 @@
-from collections.abc import Collection
-
-import numpy
 import pandas as pd
-import pandas.core.indexes.base as ibase
 import pint
-import xarray as xr
 
 
-class AttrSeries(pd.Series):
-    """:class:`pandas.Series` subclass imitating :class:`xarray.DataArray`.
+class _QuantityFactory:
+    #: The current internal class used to represent reporting quantities.
+    #: :meth:`as_quantity` always converts to this type.
+    CLASS = 'AttrSeries'
+    # CLASS = 'SparseDataArray'
 
-    Future versions of :mod:`ixmp.reporting` will use :class:`xarray.DataArray`
-    as :class:`Quantity`; however, because :mod:`xarray` currently lacks sparse
-    matrix support, ixmp quantities may be too large for available memory.
+    def __call__(self, data, *args, **kwargs):
+        name = kwargs.pop('name', None)
+        units = kwargs.pop('units', None)
+        attrs = kwargs.pop('attrs', dict())
 
-    The AttrSeries class provides similar methods and behaviour to
-    :class:`xarray.DataArray`, so that :mod:`ixmp.reporting.computations`
-    methods can use xarray-like syntax.
+        if self.CLASS == 'AttrSeries':
+            from .attrseries import AttrSeries as cls
+        elif self.CLASS == 'SparseDataArray':
+            from .sparsedataarray import SparseDataArray as cls
 
-    Parameters
-    ----------
-    units : str or pint.Unit, optional
-        Set the units attribute. The value is converted to :class:`pint.Unit`
-        and added to `attrs`.
-    attrs : :class:`~collections.abc.Mapping`, optional
-        Set the :attr:`~pandas.Series.attrs` of the AttrSeries. This attribute
-        was added in `pandas 1.0
-        <https://pandas.pydata.org/docs/whatsnew/v1.0.0.html>`_, but is not
-        currently supported by the Series constructor.
-    """
+        if isinstance(data, pd.Series):
+            result = cls.from_series(data)
+        elif self.CLASS == 'AttrSeries':
+            result = cls(data, *args, **kwargs)
+        else:
+            assert len(args) == len(kwargs) == 0, (args, kwargs)
+            result = data._sda.convert()
 
-    # See https://pandas.pydata.org/docs/development/extending.html
-    @property
-    def _constructor(self):
-        return AttrSeries
+        if name:
+            result.name = name
 
-    def __init__(self, data=None, *args, name=None, units=None, attrs=None,
-                 **kwargs):
-        attrs = attrs or dict()
         if units:
-            # Insert the units into the attrs
             attrs['_unit'] = pint.Unit(units)
 
-        if isinstance(data, (AttrSeries, xr.DataArray)):
-            # Use attrs from an existing object
-            new_attrs = data.attrs.copy()
+        result.attrs.update(attrs)
 
-            # Overwrite with explicit attrs argument
-            new_attrs.update(attrs)
-            attrs = new_attrs
-
-            # Pre-convert to pd.Series from xr.DataArray to preserve names and
-            # labels. For AttrSeries, this is a no-op (see below).
-            name = ibase.maybe_extract_name(name, data, type(self))
-            data = data.to_series()
-
-        # Don't pass attrs to pd.Series constructor; it currently does not
-        # accept them
-        super().__init__(data, *args, name=name, **kwargs)
-
-        # Update the attrs after initialization
-        self.attrs.update(attrs)
-
-    @classmethod
-    def from_series(cls, series, sparse=None):
-        return cls(series)
-
-    def assign_attrs(self, d):
-        self.attrs.update(d)
-        return self
-
-    def assign_coords(self, **kwargs):
-        return pd.concat([self], keys=kwargs.values(), names=kwargs.keys())
-
-    @property
-    def coords(self):
-        """Read-only."""
-        return dict(zip(self.index.names, self.index.levels))
-
-    @property
-    def dims(self):
-        return tuple(self.index.names)
-
-    def drop(self, label):
-        return self.droplevel(label)
-
-    def rename(self, new_name_or_name_dict):
-        if isinstance(new_name_or_name_dict, dict):
-            return self.rename_axis(index=new_name_or_name_dict)
-        else:
-            return super().rename(new_name_or_name_dict)
-
-    def sel(self, indexers=None, drop=False, **indexers_kwargs):
-        indexers = indexers or {}
-        indexers.update(indexers_kwargs)
-        if len(indexers) == 1:
-            level, key = list(indexers.items())[0]
-            if not isinstance(key, Collection) and not drop:
-                # When using .loc[] to select 1 label on 1 level, pandas drops
-                # the level. Use .xs() to avoid this behaviour unless drop=True
-                return AttrSeries(self.xs(key, level=level, drop_level=False))
-
-        idx = tuple(indexers.get(n, slice(None)) for n in self.index.names)
-        return AttrSeries(self.loc[idx])
-
-    def sum(self, *args, **kwargs):
-        try:
-            dim = kwargs.pop('dim')
-            if isinstance(self.index, pd.MultiIndex):
-                if len(dim) == len(self.index.names):
-                    # assume dimensions = full multi index, do simple sum
-                    obj = self
-                    kwargs = {}
-                else:
-                    # pivot and sum across columns
-                    obj = self.unstack(dim)
-                    kwargs['axis'] = 1
-            else:
-                if dim != [self.index.name]:
-                    raise ValueError(dim, self.index.name, self)
-                obj = super()
-                kwargs['level'] = dim
-        except KeyError:
-            obj = super()
-        return AttrSeries(obj.sum(*args, **kwargs))
-
-    def squeeze(self, *args, **kwargs):
-        kwargs.pop('drop')
-        return super().squeeze(*args, **kwargs) if len(self) > 1 else self
-
-    def as_xarray(self):
-        return xr.DataArray.from_series(self)
-
-    def transpose(self, *dims):
-        return self.reorder_levels(dims)
-
-    def to_dataframe(self):
-        return self.to_frame()
-
-    def to_series(self):
-        return self
+        return result
 
 
-#: The current internal class used to represent reporting quantities.
-#: :meth:`as_quantity` always converts to this type.
-Quantity = AttrSeries
-# See also:
-# - test_report_size() for a test that shows how non-sparse xr.DataArray
-#   triggers MemoryError.
-# Quantity = xr.DataArray
-
-
-def as_sparse_xarray(obj, units=None):  # pragma: no cover
-    """Convert *obj* to :class:`xarray.DataArray` with sparse.COO storage."""
-    import sparse
-    from xarray.core.dtypes import maybe_promote
-
-    if isinstance(obj, xr.DataArray) and isinstance(obj.data, numpy.ndarray):
-        result = xr.DataArray(
-            data=sparse.COO.from_numpy(
-                obj.data,
-                fill_value=maybe_promote(obj.data.dtype)[1]),
-            coords=obj.coords,
-            dims=obj.dims,
-            name=obj.name,
-            attrs=obj.attrs,
-        )
-    elif isinstance(obj, pd.Series):
-        result = xr.DataArray.from_series(obj, sparse=True)
-    else:
-        result = obj
-
-    if units:
-        result.attrs['_unit'] = pint.Unit(units)
-
-    return result
-
-
-#: Convert args to :class:`.Quantity` class.
-#:
-#: Returns
-#: -------
-#: .Quantity
-#:     `obj` converted to the current Quantity type.
-as_quantity = AttrSeries if Quantity is AttrSeries else as_sparse_xarray
+Quantity = _QuantityFactory()

--- a/ixmp/reporting/quantity.py
+++ b/ixmp/reporting/quantity.py
@@ -22,9 +22,12 @@ class _QuantityFactory:
             result = cls.from_series(data)
         elif self.CLASS == 'AttrSeries':
             result = cls(data, *args, **kwargs)
-        else:
-            assert len(args) == len(kwargs) == 0, (args, kwargs)
+        elif len(args) == len(kwargs) == 0:
+            # Single argument, possibly an xr.DataArray; convert to
+            # SparseDataArray
             result = data._sda.convert()
+        else:
+            result = cls(data, *args, **kwargs)
 
         if name:
             result.name = name

--- a/ixmp/reporting/quantity.py
+++ b/ixmp/reporting/quantity.py
@@ -3,8 +3,30 @@ import pint
 
 
 class _QuantityFactory:
-    #: The current internal class used to represent reporting quantities.
-    #: :meth:`as_quantity` always converts to this type.
+    """Convert arguments to the internal Quantity data format.
+
+    Parameters
+    ----------
+    data
+        Quantity data.
+    args
+        Positional arguments, passed to :class:`.AttrSeries` or
+        :class:`.SparseDataArray`.
+    kwargs
+        Keyword arguments, passed to :class:`.AttrSeries` or
+        :class:`.SparseDataArray`.
+
+    Other parameters
+    ----------------
+    name : str, optional
+        Quantity name.
+    units : str, optional
+        Quantity units.
+    attrs : dict, optional
+        Dictionary of attributes; similar to :attr:`~xarray.DataArray.attrs`.
+    """
+    # The current internal class used to represent reporting quantities.
+    # :meth:`as_quantity` always converts to this type.
     CLASS = 'AttrSeries'
     # CLASS = 'SparseDataArray'
 

--- a/ixmp/reporting/quantity.py
+++ b/ixmp/reporting/quantity.py
@@ -38,3 +38,19 @@ class _QuantityFactory:
 
 
 Quantity = _QuantityFactory()
+
+
+def assert_quantity(*args):
+    """Assert that each of `args` is a Quantity object.
+
+    Raises
+    ------
+    TypeError
+        with a indicative message.
+    """
+    for i, arg in enumerate(args):
+        if arg.__class__.__name__ != Quantity.CLASS:
+            raise TypeError(
+                f"arg #{i} ({repr(arg)}) is not Quantity; likely an incorrect "
+                "key"
+            )

--- a/ixmp/reporting/sparsedataarray.py
+++ b/ixmp/reporting/sparsedataarray.py
@@ -1,26 +1,14 @@
-from warnings import filterwarnings
-
 import numpy as np
 import pandas as pd
+import sparse  # NB warnings from sparse are filtered in computations.py
 import xarray as xr
 from xarray.core.utils import either_dict_or_kwargs
-
-# sparse 0.9.1, numba 0.49.0
-filterwarnings(
-    action='ignore',
-    message="An import was requested from a module that has moved location.",
-    module='sparse._coo.numba_extension',
-)
-
-import sparse  # noqa: E402
 
 
 @xr.register_dataarray_accessor('_sda')
 class SparseAccessor:
     """:mod:`xarray` accessor to help :class:`SparseDataArray`."""
     def __init__(self, obj):
-        if not isinstance(obj, xr.DataArray):
-            raise TypeError('._sda accessor only valid for xr.DataArray')
         self.da = obj
 
     def convert(self):
@@ -58,11 +46,8 @@ class SparseAccessor:
     @property
     def dense(self):
         """Return a copy with dense (:class:`.ndarray`) data."""
-        if self.COO_data:
-            # Use existing method xr.Variable._to_dense()
-            return self.da._replace(variable=self.da.variable._to_dense())
-        else:
-            return self.da
+        # Use existing method xr.Variable._to_dense()
+        return self.da._replace(variable=self.da.variable._to_dense())
 
     @property
     def dense_super(self):

--- a/ixmp/reporting/sparsedataarray.py
+++ b/ixmp/reporting/sparsedataarray.py
@@ -1,0 +1,129 @@
+from warnings import filterwarnings
+
+import numpy as np
+import pandas as pd
+import xarray as xr
+from xarray.core.utils import either_dict_or_kwargs
+
+# sparse 0.9.1, numba 0.49.0
+filterwarnings(
+    action='ignore',
+    message="An import was requested from a module that has moved location.",
+    module='sparse._coo.numba_extension',
+    )
+
+import sparse  # noqa: E402
+
+
+@xr.register_dataarray_accessor('_sda')
+class SparseAccessor:
+    """:mod:`xarray` accessor to help :class:`SparseDataArray`."""
+    def __init__(self, obj):
+        if not isinstance(obj, xr.DataArray):
+            raise TypeError('._sda accessor only valid for xr.DataArray')
+        self.da = obj
+
+    def convert(self):
+        """Return a :class:`SparseDataArray` instance."""
+        if not self.da._sda.COO_data:
+            # Dense (numpy.ndarray) data; convert to sparse
+            data = sparse.COO.from_numpy(self.da.data, fill_value=None)
+        elif not np.isnan(self.da.data.fill_value):
+            # sparse.COO with non-NaN fill value; copy and change
+            data = self.da.data.copy(deep=False)
+            data.fill_value = data.dtype.type(np.nan)
+        else:
+            # No change
+            data = self.da.data
+
+        if isinstance(self.da, SparseDataArray):
+            # Replace the variable, returning a copy
+            variable = self.da.variable._replace(data=data)
+            return self.da._replace(variable=variable)
+        else:
+            # Construct
+            return SparseDataArray(
+                data=data,
+                coords=self.da.coords,
+                dims=self.da.dims,
+                name=self.da.name,
+                attrs=self.da.attrs,
+                )
+
+    @property
+    def COO_data(self):
+        """:obj:`True` if the DataArray has :class:`sparse.COO` data."""
+        return isinstance(self.da.data, sparse.COO)
+
+    @property
+    def dense(self):
+        """Return a copy with dense (:class:`.ndarray`) data."""
+        if self.COO_data:
+            # Use existing method xr.Variable._to_dense()
+            return self.da._replace(variable=self.da.variable._to_dense())
+        else:
+            return self.da
+
+    @property
+    def dense_super(self):
+        """Return a proxy to a :class:`.ndarray`-backed :class:`.DataArray`."""
+        return super(SparseDataArray, self.dense)
+
+
+class SparseDataArray(xr.DataArray):
+    """:class:`xr.DataArray` with sparse data.
+
+    SparseDataArray uses :class:`sparse.COO` for storage with :data:`numpy.nan`
+    as its :attr:`sparse.COO.fill_value`. Some methods of :class:`.DataArray`
+    are overridden to ensure data is in sparse, or dense, format as necessary,
+    to provide expected functionality not currently supported by :mod:`sparse`,
+    and to avoid exhausting memory for some operations that require dense data.
+
+    See Also
+    --------
+    SparseAccessor
+    """
+    __slots__ = tuple()
+
+    @classmethod
+    def from_series(cls, obj, sparse=True):
+        # Call the parent method always with sparse=True, then re-wrap
+        return xr.DataArray.from_series(obj, sparse=True)._sda.convert()
+
+    def equals(self, other):
+        """Necessary for :meth:`xarray.testing.assert_equal` to work."""
+        return self.variable.equals(other.variable, equiv=np.equal)
+
+    @property
+    def loc(self):
+        # FIXME doesn't allow assignment
+        return self._sda.dense_super.loc
+
+    def sel(self, indexers=None, method=None, tolerance=None, drop=False,
+            **indexers_kwargs) -> 'SparseDataArray':
+        """Handle >1-D indexers with sparse data."""
+        indexers = either_dict_or_kwargs(indexers, indexers_kwargs, 'sel')
+        if isinstance(indexers, dict) and len(indexers) > 1:
+            result = self
+            for k, v in indexers.items():
+                result = result.sel({k: v}, method=method, tolerance=tolerance,
+                                    drop=drop)
+            return result
+        else:
+            return super().sel(indexers=indexers, method=method,
+                               tolerance=tolerance, drop=drop)
+
+    def to_dataframe(self):
+        # FIXME this does exactly match the behaviour of xr.DataArray; it omits
+        #       coordinate variable
+        return self.to_series().to_frame()
+
+    def to_series(self) -> pd.Series:
+        # Use SparseArray.coords and .data (each already 1-D) to construct a
+        # pd.Series without first converting to a potentially very large
+        # ndarray
+
+        # Construct a pd.MultiIndex without using .from_product
+        index = pd.MultiIndex.from_arrays(self.data.coords, names=self.dims) \
+                  .set_levels([self.coords[d].values for d in self.dims])
+        return pd.Series(self.data.data, index=index, name=self.name)

--- a/ixmp/reporting/sparsedataarray.py
+++ b/ixmp/reporting/sparsedataarray.py
@@ -10,7 +10,7 @@ filterwarnings(
     action='ignore',
     message="An import was requested from a module that has moved location.",
     module='sparse._coo.numba_extension',
-    )
+)
 
 import sparse  # noqa: E402
 
@@ -48,7 +48,7 @@ class SparseAccessor:
                 dims=self.da.dims,
                 name=self.da.name,
                 attrs=self.da.attrs,
-                )
+            )
 
     @property
     def COO_data(self):

--- a/ixmp/reporting/testing.py
+++ b/ixmp/reporting/testing.py
@@ -1,9 +1,58 @@
 from typing import Dict
 
 import numpy as np
+from pandas.testing import assert_series_equal
 import xarray as xr
 
 from .quantity import Quantity
+
+
+def assert_qty_equal(a, b, check_type=True, check_attrs=True, **kwargs):
+    """Assert that Quantity objects *a* and *b* are equal.
+
+    When Quantity is AttrSeries, *a* and *b* are first passed through
+    :meth:`as_quantity`.
+    """
+    if not check_type:
+        a = Quantity(a)
+        b = Quantity(b)
+
+    if Quantity.CLASS == 'AttrSeries':
+        try:
+            a = a.sort_index()
+            b = b.sort_index()
+        except TypeError:
+            pass
+        assert_series_equal(a, b, check_dtype=False, **kwargs)
+    else:
+        import xarray.testing
+        xarray.testing.assert_equal(a, b, **kwargs)
+
+    # check attributes are equal
+    if check_attrs:
+        assert a.attrs == b.attrs
+
+
+def assert_qty_allclose(a, b, check_type=True, check_attrs=True, **kwargs):
+    """Assert that Quantity objects *a* and *b* have numerically close values.
+
+    When Quantity is AttrSeries, *a* and *b* are first passed through
+    :meth:`as_quantity`.
+    """
+    if not check_type:
+        a = Quantity(a)
+        b = Quantity(b)
+
+    if Quantity.CLASS == 'AttrSeries':
+        assert_series_equal(a.sort_index(), b.sort_index(), **kwargs)
+    else:
+        import xarray.testing
+        kwargs.pop('check_dtype', None)
+        xarray.testing.assert_allclose(a._sda.dense, b._sda.dense, **kwargs)
+
+    # check attributes are equal
+    if check_attrs:
+        assert a.attrs == b.attrs
 
 
 def random_qty(shape: Dict[str, int], **kwargs):

--- a/ixmp/reporting/testing.py
+++ b/ixmp/reporting/testing.py
@@ -1,0 +1,36 @@
+from typing import Dict
+
+import numpy as np
+import xarray as xr
+
+from .quantity import Quantity
+
+
+def random_qty(shape: Dict[str, int], **kwargs):
+    """Return a Quantity with *shape* and random contents.
+
+    Parameters
+    ----------
+    shape : dict
+        Mapping from dimension names to
+    kwargs
+        Other keyword arguments to :class:`Quantity`.
+
+    Returns
+    -------
+    Quantity
+        Keys in `shape`—e.g. "foo"—result in a dimension named "foo" with
+        coords "foo0", "foo1", etc., with total length matching the value.
+        Data is random.
+    """
+    return Quantity(
+        xr.DataArray(
+            np.random.rand(*shape.values()),
+            coords={
+                dim: [f"{dim}{i}" for i in range(length)]
+                for dim, length in shape.items()
+            },
+            dims=shape.keys(),
+        ),
+        **kwargs,
+    )

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -134,15 +134,16 @@ def parse_units(units_series):
         # Quantity has no unit
         unit = registry.parse_units('')
     except pint.UndefinedUnitError:
-        # Unit(s) do not exist; define them in the UnitRegistry
-        define_unit_parts(unit)
-
-        # Try to parse again
         try:
+            # Unit(s) do not exist; define them in the UnitRegistry
+            define_unit_parts(unit)
+
+            # Try to parse again
             unit = registry.parse_units(unit)
-        except pint.UndefinedUnitError:
-            # Handle the silent failure of define(), above
-            raise invalid(unit)  # from None
+        except (pint.UndefinedUnitError, pint.RedefinitionError):
+            # Handle the silent failure of define(), above; or
+            # define_unit_parts didn't work
+            raise invalid(unit)
     except AttributeError:
         # Unit contains a character like '-' that throws off pint
         # NB this 'except' clause must be *after* UndefinedUnitError, since

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -98,6 +98,17 @@ def ixmp_cli(tmp_env):
     yield Runner()
 
 
+@pytest.fixture(params=['AttrSeries', 'SparseDataArray'])
+def parametrize_quantity_class(request):
+    """Fixture to run tests twice, for both reporting Quantity classes."""
+    pre = Quantity.CLASS
+
+    Quantity.CLASS = request.param
+    yield
+
+    Quantity.CLASS = pre
+
+
 @pytest.fixture
 def protect_pint_app_registry():
     """Protect pint's application registry.

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -54,13 +54,14 @@ import sys
 from click.testing import CliRunner
 import numpy as np
 import pandas as pd
-from pandas.testing import assert_series_equal
 import pytest
 
 from . import cli, config as ixmp_config
 from .core import Platform, TimeSeries, Scenario, IAMC_IDX
 from .reporting import Quantity
-
+from .reporting.testing import (  # noqa: F401
+    assert_qty_equal, assert_qty_allclose
+)
 
 log = logging.getLogger(__name__)
 
@@ -490,49 +491,6 @@ def assert_logs(caplog, message_or_messages=None, at_level=None):
                 [f'    {repr(msg)}' for msg in caplog.messages[first:]],
             )
             pytest.fail('\n'.join(lines))
-
-
-def assert_qty_equal(a, b, check_type=True, check_attrs=True, **kwargs):
-    """Assert that Quantity objects *a* and *b* are equal.
-
-    When Quantity is AttrSeries, *a* and *b* are first passed through
-    :meth:`as_quantity`.
-    """
-    if not check_type:
-        a = Quantity(a)
-        b = Quantity(b)
-
-    if Quantity.CLASS == 'AttrSeries':
-        assert_series_equal(a, b, check_dtype=False, **kwargs)
-    else:
-        import xarray.testing
-        xarray.testing.assert_equal(a, b, **kwargs)
-
-    # check attributes are equal
-    if check_attrs:
-        assert a.attrs == b.attrs
-
-
-def assert_qty_allclose(a, b, check_type=True, check_attrs=True, **kwargs):
-    """Assert that Quantity objects *a* and *b* have numerically close values.
-
-    When Quantity is AttrSeries, *a* and *b* are first passed through
-    :meth:`as_quantity`.
-    """
-    if not check_type:
-        a = Quantity(a)
-        b = Quantity(b)
-
-    if Quantity.CLASS == 'AttrSeries':
-        assert_series_equal(a, b, **kwargs)
-    else:
-        import xarray.testing
-        kwargs.pop('check_dtype', None)
-        xarray.testing.assert_allclose(a._sda.dense, b._sda.dense, **kwargs)
-
-    # check attributes are equal
-    if check_attrs:
-        assert a.attrs == b.attrs
 
 
 # Data structure for memory information used by :meth:`memory_usage`.

--- a/ixmp/tests/reporting/__init__.py
+++ b/ixmp/tests/reporting/__init__.py
@@ -23,6 +23,7 @@ def add_test_data(scen):
     x = xr.DataArray(np.random.rand(len(t), len(y)),
                      coords=[t, y], dims=['t', 'y'],
                      attrs={'_unit': ureg.Unit('kg')})
+    x = Quantity(x)
 
     # As a pd.DataFrame with units
     x_df = x.to_series().rename('value').reset_index()

--- a/ixmp/tests/reporting/__init__.py
+++ b/ixmp/tests/reporting/__init__.py
@@ -2,6 +2,9 @@ import numpy as np
 import pint
 import xarray as xr
 
+from ixmp.reporting import Quantity
+
+
 REGISTRY = pint.get_application_registry()
 
 

--- a/ixmp/tests/reporting/test_computations.py
+++ b/ixmp/tests/reporting/test_computations.py
@@ -5,7 +5,7 @@ import pint
 import pytest
 
 import ixmp
-from ixmp.reporting import Reporter, as_quantity, computations
+from ixmp.reporting import Reporter, Quantity, computations
 from ixmp.testing import assert_logs
 
 from . import add_test_data
@@ -53,19 +53,19 @@ def test_select(data):
     # Unpack
     *_, t_foo, t_bar, x = data
 
-    x = as_quantity(x)
-    assert len(x) == 6 * 6
+    x = Quantity(x)
+    assert x.size == 6 * 6
 
     # Selection with inverse=False
     indexers = {'t': t_foo[0:1] + t_bar[0:1]}
     result_0 = computations.select(x, indexers=indexers)
-    assert len(result_0) == 2 * 6
+    assert result_0.size == 2 * 6
 
     # Single indexer along one dimension results in 1D data
     indexers['y'] = '2010'
     result_1 = computations.select(x, indexers=indexers)
-    assert len(result_1) == 2 * 1
+    assert result_1.size == 2 * 1
 
     # Selection with inverse=True
     result_2 = computations.select(x, indexers=indexers, inverse=True)
-    assert len(result_2) == 4 * 5
+    assert result_2.size == 4 * 5

--- a/ixmp/tests/reporting/test_computations.py
+++ b/ixmp/tests/reporting/test_computations.py
@@ -11,6 +11,9 @@ from ixmp.testing import assert_logs
 from . import add_test_data
 
 
+pytestmark = pytest.mark.usefixtures('parametrize_quantity_class')
+
+
 @pytest.fixture(scope='function')
 def data(test_mp, request):
     scen = ixmp.Scenario(test_mp, request.node.name, request.node.name, 'new')

--- a/ixmp/tests/reporting/test_quantity.py
+++ b/ixmp/tests/reporting/test_quantity.py
@@ -4,21 +4,20 @@ import pytest
 import xarray as xr
 from xarray.testing import assert_equal as assert_xr_equal
 
-from ixmp.reporting.quantity import AttrSeries, Quantity, as_sparse_xarray
+from ixmp import Reporter, Scenario
+from ixmp.reporting import Quantity, computations
+from ixmp.reporting.attrseries import AttrSeries
+from ixmp.reporting.sparsedataarray import SparseDataArray
 from ixmp.testing import assert_qty_allclose, assert_qty_equal
 
 
+@pytest.mark.usefixtures('parametrize_quantity_class')
 class TestQuantity:
-    """Tests of Quantity.
-
-    NB. these tests should pass whether Quantity is set to AttrSeries or
-    xr.DataArray in ixmp.reporting.utils. As written, they only test the
-    current form of Quantity. @gidden tested both by hand-swapping the Quantity
-    class and running tests as of commit df1ec6f of PR #147.
-    """
-    @pytest.fixture()
+    """Tests of Quantity."""
+    @pytest.fixture
     def a(self):
-        yield xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
+        da = xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
+        yield Quantity(da)
 
     def test_assert(self, a):
         """Test assertions about Quantity.

--- a/ixmp/tests/reporting/test_quantity.py
+++ b/ixmp/tests/reporting/test_quantity.py
@@ -171,7 +171,6 @@ class TestAttrSeries:
 
     def test_others(self, foo, bar):
         # Exercise other compatibility functions
-        assert isinstance(foo.as_xarray(), xr.DataArray)
         assert type(foo.to_frame()) is pd.DataFrame
         assert foo.drop('a').dims == ('b',)
         assert bar.dims == ('a',)

--- a/ixmp/tests/reporting/test_quantity.py
+++ b/ixmp/tests/reporting/test_quantity.py
@@ -154,6 +154,10 @@ class TestAttrSeries:
         assert result.dims == ('a',)
         assert result.iloc[0] == 1
 
+    def test_squeeze(self, foo):
+        assert foo.sel(a="a1").squeeze().dims == ("b",)
+        assert foo.sel(a="a2", b="b1").squeeze().values == 2
+
     def test_sum(self, foo, bar):
         # AttrSeries can be summed across all dimensions
         result = foo.sum(dim=['a', 'b'])

--- a/ixmp/tests/reporting/test_quantity.py
+++ b/ixmp/tests/reporting/test_quantity.py
@@ -1,4 +1,5 @@
 """Tests for ixmp.reporting.quantity."""
+import numpy as np
 import pandas as pd
 import pytest
 import xarray as xr
@@ -18,6 +19,51 @@ class TestQuantity:
     def a(self):
         da = xr.DataArray([0.8, 0.2], coords=[['oil', 'water']], dims=['p'])
         yield Quantity(da)
+
+    @pytest.fixture(scope='class')
+    def scen_with_big_data(self, test_mp, num_params=10):
+        from itertools import zip_longest
+
+        # test_mp.add_unit('kg')
+        scen = Scenario(test_mp, 'TestQuantity', 'big data', version='new')
+
+        # Dimensions and their lengths (Fibonacci numbers)
+        N_dims = 6
+        dims = 'abcdefgh'[:N_dims + 1]
+        sizes = [1, 5, 21, 21, 89, 377, 1597, 6765][:N_dims + 1]
+
+        # commented: "377 / 73984365 elements = 0.00051% full"
+        # from functools import reduce
+        # from operator import mul
+        # size = reduce(mul, sizes)
+        # print('{} / {} elements = {:.5f}% full'
+        #       .format(max(sizes), size, 100 * max(sizes) / size))
+
+        # Names like f_0000 ... f_1596 along each dimension
+        coords = []
+        for d, N in zip(dims, sizes):
+            coords.append([f'{d}_{i:04d}' for i in range(N)])
+            # Add to Scenario
+            scen.init_set(d)
+            scen.add_set(d, coords[-1])
+
+        def _make_values():
+            """Make a DataFrame containing each label in *coords* ≥ 1 time."""
+            values = list(zip_longest(*coords, np.random.rand(max(sizes))))
+            result = pd.DataFrame(values, columns=list(dims) + ['value']) \
+                       .ffill()
+            result['unit'] = 'kg'
+            return result
+
+        # Fill the Scenario with quantities named q_01 ... q_09
+        names = []
+        for i in range(num_params):
+            name = f'q_{i:02d}'
+            scen.init_par(name, list(dims))
+            scen.add_par(name, _make_values())
+            names.append(name)
+
+        yield scen
 
     def test_assert(self, a):
         """Test assertions about Quantity.
@@ -63,6 +109,26 @@ class TestQuantity:
         # attrs are different
         a.attrs = {'bar': 'foo'}
         assert_qty_equal(a, b, check_attrs=False)
+
+    def test_size(self, scen_with_big_data):
+        """Stress-test reporting of large, sparse quantities."""
+        scen = scen_with_big_data
+
+        # Create the reporter
+        rep = Reporter.from_scenario(scen)
+
+        # Add a task to compute the product, i.e. requires all the q_*
+        keys = [rep.full_key(name) for name in scen.par_list()]
+        rep.add('bigmem', tuple([computations.product] + keys))
+
+        # One quantity fits in memory
+        rep.get(keys[0])
+
+        # All quantities can be multiplied without raising MemoryError
+        result = rep.get('bigmem')
+
+        # Result can be converted to pd.Series
+        result.to_series()
 
 
 class TestAttrSeries:

--- a/ixmp/tests/reporting/test_quantity.py
+++ b/ixmp/tests/reporting/test_quantity.py
@@ -195,8 +195,9 @@ def test_sda_accessor():
     assert not x_dense._sda.COO_data or x_dense._sda.nan_fill
     assert not y_dense._sda.COO_data or y_dense._sda.nan_fill
 
-    with pytest.raises(ValueError, match='make sure that the broadcast shape'):
-        x_dense * y
+    # As of sparse 0.10, sparse `y` is automatically broadcast to `x_dense`
+    # Previously, this raised ValueError.
+    x_dense * y
 
     z1 = x_dense._sda.convert() * y
 
@@ -210,9 +211,5 @@ def test_sda_accessor():
     z4 = x._sda.convert() * y
     assert_xr_equal(z1, z4)
 
-    # Doesn't work: can't align automatically
-    with pytest.raises(ValueError, match='Please make sure that the broadcast '
-                       'shape of just the sparse arrays is the same as the '
-                       'broadcast shape of all the operands.'):
-        SparseDataArray(x_series) * y  # = z5
-        # assert_xr_equal(z1, z5)
+    z5 = SparseDataArray.from_series(x_series) * y
+    assert_xr_equal(z1, z5)

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -620,12 +620,12 @@ def test_cli(ixmp_cli, test_mp, test_data_path):
     assert result.output.endswith(
         "i          j       "  # Trailing whitespace
         """
-seattle    new-york    2.5
-           chicago     1.7
-           topeka      1.8
-san-diego  new-york    2.5
-           chicago     1.8
+san-diego  chicago     1.8
+           new-york    2.5
            topeka      1.4
+seattle    chicago     1.7
+           new-york    2.5
+           topeka      1.8
 Name: value, dtype: float64
 """)
 

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -223,10 +223,10 @@ def test_reporter_from_dantzig(test_mp, ureg):
     # ...produces the expected new value
     obs = rep.get(new_key)
     d_ij = rep.get('d:i-j')
-    exp = (d_ij * weights).sum(dim=['j']) / weights.sum(dim=['j'])
-    # FIXME attrs has to be explicitly copied here because math is done which
-    #       returns a pd.Series
-    exp.attrs = d_ij.attrs
+    exp = Quantity(
+        (d_ij * weights).sum(dim=['j']) / weights.sum(dim=['j']),
+        attrs=d_ij.attrs,
+    )
 
     assert_qty_equal(exp, obs)
 

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -86,7 +86,7 @@ def test_reporter_add():
     with pytest.raises(KeyExistsError, match=r"key 'a' already exists"):
         r.add('a', 5, strict=True)
 
-    def gen(other):
+    def gen(other):  # pragma: no cover
         """A generator for apply()."""
         return (lambda a, b: a * b, 'a', other)
 

--- a/ixmp/tests/reporting/test_reporting.py
+++ b/ixmp/tests/reporting/test_reporting.py
@@ -31,6 +31,8 @@ from ixmp.testing import (
 from . import add_test_data
 
 
+pytestmark = pytest.mark.usefixtures('parametrize_quantity_class')
+
 test_args = ('Douglas Adams', 'Hitchhiker')
 
 TS_DF = {'year': [2010, 2020], 'value': [23.7, 23.8]}

--- a/setup.cfg
+++ b/setup.cfg
@@ -20,6 +20,7 @@ install_requires =
     pandas >= 1.0
     pint
     PyYAML
+    sparse >= 0.10
     xarray
     xlrd
     xlsxwriter
@@ -36,7 +37,6 @@ tests =
     pretenders >= 1.4.4
     pytest >= 5
     pytest-cov
-    sparse
 docs =
     numpydoc
     sphinx >= 3.0


### PR DESCRIPTION
We have two internal representations of a reporting Quantity:
- `reporting.attrseries`, which makes a pandas.Series act like a sparse xr.DataArray, e.g. not caring about order of dimensions.
- `reporting.sparsedataarray` (added by this PR) which uses an xr.DataArray backed by pydata/sparse data storage.

The pydata/sparse support via xarray is ~now complete enough that we could use it in `ixmp.reporting`~ still maturing, with some remaining bugs, e.g. pydata/sparse#360. This PR cleans up the code so that the two internal representations of a Quantity are 100% interchangeable. It **does not** actually switch away from `reporting.attrseries`, which remains the default; that switch can be made later.

Some of the code in `sparsedataarray` should be contributed upstream (e.g. pydata/xarray#4007); once they are accepted by xarray, this helper code will shrink and can eventually be eliminated.

## How to review

Note that CI checks all pass.

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.