### PR TITLE
Add `ixmp show-versions`

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,34 @@
+---
+name: Bug report
+about: '`ixmp` does not work as expected'
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+#### Code sample or context
+
+<!-- What did you do? -->
+
+#### Expected result
+
+<!-- What did you expect to happen? -->
+
+#### Problem description
+
+<!-- What happened instead? -->
+
+#### Versions
+
+<details><summary>Output of <tt>ixmp show-versions</tt></summary>
+
+```
+<!--
+  Run one of the following and paste the results here:
+  - 'ixmp show-versions' in a terminal, or
+  - 'import ixmp; ixmp.show_versions()' in a Python interpreter.
+-->
+```
+
+</details>

--- a/.github/ISSUE_TEMPLATE/other.md
+++ b/.github/ISSUE_TEMPLATE/other.md
@@ -1,0 +1,8 @@
+---
+name: Other issue
+about: 'Question, feature request, etc.'
+title: ''
+labels: ''
+assignees: ''
+
+---

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- `#320 <https://github.com/iiasa/ixmp/pull/320>`_: Add CLI command `ixmp show-versions` to print ixmp and dependency versions for debugging.
 - `#312 <https://github.com/iiasa/ixmp/pull/312>`_: Add :meth:`~.computations.apply_units`, :meth:`~computations.select` reporting calculations; expand :meth:`.Reporter.add`.
 - `#310 <https://github.com/iiasa/ixmp/pull/310>`_: :meth:`.Reporter.add_product` accepts a :class:`.Key` with a tag; :func:`~.computations.aggregate` preserves :class:`.Quantity` attributes.
 - `#304 <https://github.com/iiasa/ixmp/pull/304>`_: Add CLI command ``ixmp solve`` to run model solver.

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -187,6 +187,7 @@ So, if ``install.bat`` fails, check if::
 
 are all part of the PATH system variable. If they are not there, add them.
 
+Run `ixmp show-versions` on the command line to check that you have all dependencies installed, or when reporting issues.
 
 .. _`installing MESSAGEix`: https://message.iiasa.ac.at/en/latest/getting_started.html
 .. _`Anaconda`: https://www.continuum.io/downloads

--- a/ixmp/__init__.py
+++ b/ixmp/__init__.py
@@ -1,17 +1,13 @@
+from ._config import config
 from ._version import get_versions
-from ixmp.core import (  # noqa: F401
-    IAMC_IDX,
-    Platform,
-    TimeSeries,
-    Scenario,
-)
-from ._config import config  # noqa: F401
-from .backend import BACKENDS, ItemType  # noqa: F401
+from .backend import BACKENDS, ItemType
 from .backend.jdbc import JDBCBackend
+from .core import IAMC_IDX, Platform, Scenario, TimeSeries
 from .model import MODELS
-from .model.gams import GAMSModel
 from .model.dantzig import DantzigModel
-from ixmp.reporting import Reporter  # noqa: F401
+from .model.gams import GAMSModel
+from .reporting import Reporter
+from .utils import show_versions
 
 __version__ = get_versions()['version']
 del get_versions
@@ -25,3 +21,14 @@ MODELS.update({
     'gams': GAMSModel,
     'dantzig': DantzigModel,
 })
+
+__all__ = [
+    'IAMC_IDX',
+    'ItemType',
+    'Platform',
+    'Reporter',
+    'Scenario',
+    'TimeSeries',
+    'config',
+    'show_versions',
+]

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -95,6 +95,12 @@ def report(context, config, key):
     print(r.get(key))
 
 
+@main.command('show-versions')
+def show_versions_cmd():
+    """Print versions of ixmp and its dependencies."""
+    ixmp.show_versions()
+
+
 @main.command()
 @click.option('--remove-solution', is_flag=True, default=False,
               help='Forces removing solution if exists.')

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -255,6 +255,11 @@ def test_report(ixmp_cli):
     assert result.exit_code == UsageError.exit_code
 
 
+def test_show_versions(ixmp_cli):
+    result = ixmp_cli.invoke(['show-versions'])
+    assert result.exit_code == 0, result.output
+
+
 def test_solve(ixmp_cli, test_mp):
     populate_test_platform(test_mp)
     cmd = [

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -280,22 +280,20 @@ def show_versions(file=sys.stdout):
             return f'\n     {info.rstrip()}'
 
     deps = [
+        None,  # Prints a separator
+
         # ixmp stack
-        'ixmp', 'message_ix', 'message_data', None,  # Separator
+        'ixmp', 'message_ix', 'message_data', None,
 
         # ixmp dependencies
         'click', 'dask', 'graphviz', 'jpype', 'pandas', 'pint', 'xarray',
         'xlrd', 'xlsxwriter', 'yaml', None,
 
         # Optional dependencies, dependencies of message_ix and message_data
-        'iam-units', 'jupyter', 'matplotlib', 'plotnine', 'pyam',
+        'iam_units', 'jupyter', 'matplotlib', 'plotnine', 'pyam', None,
     ]
 
-    # Use xarray to get system & Python information
-    info = [(None, None)]
-    info.extend(get_sys_info()[1:])  # Exclude the commit number
-    info.append((None, None))
-
+    info = []
     for module_name in deps:
         try:
             # Import the module
@@ -315,6 +313,9 @@ def show_versions(file=sys.stdout):
             version = 'installed'
         finally:
             info.append((module_name, version + gl))
+
+    # Use xarray to get system & Python information
+    info.extend(get_sys_info()[1:])  # Exclude the commit number
 
     for k, stat in info:
         if (k, stat) == (None, None):


### PR DESCRIPTION
Add a CLI command `ixmp show-versions` / top-level function `ixmp.show_versions()`—modeled after similar in xarray—that prints out versions of ixmp and its dependencies.

Since we often run these codes from development branches, this version is enhanced to show the current git commit and branch for any repo installed with `pip install --editable`:
```
$ ixmp show-versions

ixmp:        2.0.0.post.dev258
     279d289 (HEAD -> feature/show-versions, khaeru/feature/show-versions) Update install.rst, release notes
message_ix:  2.0.0
     3bbe74f (HEAD -> master, iiasa/master) Exclude JPype1 0.7.3 (iiasa/ixmp#279, iiasa/ixmp#318)
message_data: installed
     9597de3 (HEAD -> CH4_reporting, min/CH4_reporting) Expand docs of reporting.util.collapse

click:       7.0
dask:        2.14.0
graphviz:    0.8.4
jpype:       0.7.3
pandas:      1.0.1
pint:        0.11
xarray:      0.15.1
xlrd:        installed
xlsxwriter:  1.1.7
yaml:        5.1.2

iam_units:   installed
jupyter:     installed
matplotlib:  3.2.1
plotnine:    0.6.0
pyam:        0.5.0+14.g9d0a4ac
     9d0a4ac (HEAD -> issue/368, khaeru/issue/368) Revise release notes per review comment

python:      3.7.5 (default, Apr 19 2020, 20:18:17) 
[GCC 9.2.1 20191008]
python-bits: 64
OS:          Linux
OS-release:  5.3.0-48-generic
machine:     x86_64
processor:   x86_64
byteorder:   little
LC_ALL:      None
LANG:        en_CA.UTF-8
LOCALE:      en_CA.UTF-8
```


Also add GitHub issue templates that prompt users to run this command when reporting a bug.

## How to review

Try it and paste your results!

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.