### PR TITLE
Catch TypeError in `ixmp show-versions`

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :pull:`339`: ``ixmp show-versions`` includes the path to the default JVM used by JDBCBackend/JPype.
 - :pull:`317`: Make :class:`reporting.Quantity` classes interchangeable.
 - :pull:`330`: Use GitHub Actions for continuous testing and integration.
 

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -340,10 +340,11 @@ def show_versions(file=sys.stdout):
 
     def _git_log(mod):
         cmd = ['git', 'log', '--oneline', '--no-color', '--decorate', '-n 1']
-        cwd = Path(mod.__file__).parent
         try:
+            cwd = Path(mod.__file__).parent
             info = check_output(cmd, cwd=cwd, encoding='utf-8', stderr=DEVNULL)
         except Exception:
+            # Occurs if "git log" fails; or if mod.__file__ is None (#338)
             return ''
         else:
             return f'\n     {info.rstrip()}'

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -384,6 +384,9 @@ def show_versions(file=sys.stdout):
         finally:
             info.append((module_name, version + gl))
 
+        if module_name == 'jpype':
+            info.append(('… JVM path', mod.getDefaultJVMPath()))
+
     # Use xarray to get system & Python information
     info.extend(get_sys_info()[1:])  # Exclude the commit number
 


### PR DESCRIPTION
- Closes #338: handle a TypeError in `show-versions`.
- Closes #334: include the output of `jpype.getDefaultJVMPath()` in `show-versions`; this was helpful information when providing tech support during the 2020-06 workshop.

## How to review

Run `ixmp show-versions` or `message-ix show-versions` and confirm that the error observed in #338 does not occur.

## PR checklist

- [x] ~Tests added.~ N/A
- [x] ~Documentation added.~ N/A
- [x] Release notes updated.