### PR TITLE
Correct error in io.s_read_excel for items on multiple sheets

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -8,17 +8,11 @@ All changes
 - :pull:`363`: Expand documentation and revise installation instructions.
 - :pull:`362`: Raise Python exceptions from :class:`.JDBCBackend`.
 - :pull:`354`: Add :meth:`Scenario.items`, :func:`.utils.diff`, and allow using filters in CLI command ``ixmp export``.
-- :pull:`353`: Add meta functionality.
+- :pull:`353`: Add functionality for storing ‘meta’ (annotations of model names, scenario names, versions, and some combinations thereof).
 
-  - :meth:`.Platform.add_model_name` using :meth:`.Backend.add_model_name`
-  - :meth:`.Platform.add_scenario_name` using :meth:`.Backend.add_scenario_name`
-  - :meth:`.Platform.get_model_names` using :meth:`.Backend.get_model_names`
-  - :meth:`.Platform.get_scenario_names` using :meth:`.Backend.get_scenario_names`
-  - :meth:`.Platform.get_meta` using :meth:`.Backend.get_meta`
-  - :meth:`.Platform.set_meta` using :meth:`.Backend.set_meta`
-  - :meth:`.Platform.remove_meta` using :meth:`.Backend.remove_meta`
-  - :meth:`.Scenario.remove_meta` using :meth:`.Backend.remove_meta`
-  - deprecate :meth:`.Scenario.delete_meta`
+  - Add :meth:`.Backend.add_model_name`, :meth:`~.Backend.add_scenario_name`, :meth:`~.Backend.get_model_names`, :meth:`~.Backend.get_scenario_names`, :meth:`~.Backend.get_meta`, :meth:`~.Backend.set_meta`, :meth:`~.Backend.remove_meta`.
+  - Allow these to be called from :class:`.Platform` instances.
+  - Remove :meth:`.Scenario.delete_meta`.
 
 - :pull:`349`: Avoid modifying indexers dictionary in :meth:`.AttrSeries.sel`.
 - :pull:`343`: Add region/unit parameters to :meth:`.Platform.export_timeseries_data`.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :pull:`345`: Fix a bug in :meth:`.read_excel` when parameter data is spread across multiple sheets.
 - :pull:`363`: Expand documentation and revise installation instructions.
 - :pull:`362`: Raise Python exceptions from :class:`.JDBCBackend`.
 - :pull:`354`: Add :meth:`Scenario.items`, :func:`.utils.diff`, and allow using filters in CLI command ``ixmp export``.

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -196,14 +196,14 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
 
     def parse_item_sheets(name):
         """Read data for item *name*, possibly across multiple sheets."""
-        dfs = [xf.parse(name)]
+        dfs = []
 
         # Collect data from repeated sheets due to max_row limit
         for x in filter(lambda n: n.startswith(name + '('), xf.sheet_names):
             dfs.append(xf.parse(x))
 
         # Concatenate once and return
-        return pd.concat(dfs, axis=1)
+        return pd.concat(dfs, axis=0)
 
     # Add sets in two passes:
     # 1. Index sets, required to initialize other sets.

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -196,7 +196,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
 
     def parse_item_sheets(name):
         """Read data for item *name*, possibly across multiple sheets."""
-        dfs = []
+        dfs = [xf.parse(name)]
 
         # Collect data from repeated sheets due to max_row limit
         for x in filter(lambda n: n.startswith(name + '('), xf.sheet_names):

--- a/ixmp/tests/backend/test_io.py
+++ b/ixmp/tests/backend/test_io.py
@@ -1,0 +1,27 @@
+import ixmp
+from ixmp.testing import add_random_model_data, models
+
+
+def test_read_excel_big(test_mp, tmp_path):
+    """Excel files with model items split across sheets can be read.
+
+    https://github.com/iiasa/ixmp/pull/345.
+    """
+    tmp_path /= 'output.xlsx'
+
+    # Write a 25-element parameter with max_row=10 → split across 3 sheets
+    scen = ixmp.Scenario(test_mp, **models['dantzig'], version="new")
+    add_random_model_data(scen, 25)
+    scen.to_excel(tmp_path, items=ixmp.ItemType.MODEL, max_row=10)
+
+    # Initialize target scenario for reading
+    scen_empty = ixmp.Scenario(test_mp, "foo", "bar", version="new")
+    scen_empty.init_set("random_set")
+    scen_empty.init_par(
+        "random_par", scen.idx_sets("random_par"), scen.idx_names("random_par")
+    )
+
+    # File can be read
+    scen_empty.read_excel(tmp_path)
+
+    assert len(scen_empty.par("random_par")) == 25


### PR DESCRIPTION
This PR resolves minor issues that triggers an error when reading data from Excel for parameters with large data that have been saved in multiple sheets (e.g., foo(1), foo(2)). The concatecation of datafrmaes should be done along axis=0.
The reviewer needs to run this over existing tests. Alternatively, a large MESSAGE parameter saved over two or more Excel sheets should be imported without an error.

- [x] Tests already exists. They need to be improved not to pass if concatecation is done along columns.
- [x] Documentation not needed.
- [x] Release notes updated.
