### PR TITLE
Preserve int dtype in data_for_quantity()

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :pull:`347`: Preserve dtypes of index columns in :func:`.data_for_quantity`.
 - :pull:`339`: ``ixmp show-versions`` includes the path to the default JVM used by JDBCBackend/JPype.
 - :pull:`317`: Make :class:`reporting.Quantity` classes interchangeable.
 - :pull:`330`: Use GitHub Actions for continuous testing and integration.

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -174,8 +174,11 @@ def data_for_quantity(ix_type, name, column, scenario, config):
             f'  {repr(filters)}\n  Subsequent computations may fail.'
         )
 
-    # Convert categorical dtype to str
-    data = data.astype({col: str for col in idx_names})
+    # Convert columns with categorical dtype to str
+    data = data.astype({
+        dt[0]: str for dt in data.dtypes.items()
+        if isinstance(dt[1], pd.CategoricalDtype)
+    })
 
     # List of the dimensions
     dims = dims_for_qty(data)


### PR DESCRIPTION
Previously, `data_for_quantity()` converted *all* index columns to `str`; but message_ix returns 'year'-indexed columns as `int`. Convert only columns needing conversion, i.e. those with a specific (categorical) dtype.

## How to review

- Note that the CI checks all pass.

## PR checklist

- [x] ~Tests added.~ Skipped. This would involve writing a Scenario subclass that behaved like message_ix.Scenario, i.e. returned `int` dtype for columns named 'year'.
- [x] ~Documentation added.~ N/A
- [x] Release notes updated.