### PR TITLE
Copy indexers dict in reporting…AttrSeries.sel

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :pull:`349`: Avoid modifying indexers dictionary in :meth:`.AttrSeries.sel`.
 - :pull:`347`: Preserve dtypes of index columns in :func:`.data_for_quantity`.
 - :pull:`339`: ``ixmp show-versions`` includes the path to the default JVM used by JDBCBackend/JPype.
 - :pull:`317`: Make :class:`reporting.Quantity` classes interchangeable.

--- a/ixmp/reporting/attrseries.py
+++ b/ixmp/reporting/attrseries.py
@@ -96,7 +96,7 @@ class AttrSeries(pd.Series):
 
     def sel(self, indexers=None, drop=False, **indexers_kwargs):
         """Like :meth:`xarray.DataArray.sel`."""
-        indexers = indexers or {}
+        indexers = indexers.copy() if indexers else {}
         indexers.update(indexers_kwargs)
         if len(indexers) == 1:
             level, key = list(indexers.items())[0]


### PR DESCRIPTION
`copy()` to avoid modifying a dictionary of indexers passed as the first positional argument to `AttrSeries.sel()`.

## How to review

Confirm that CI checks pass.

## PR checklist

- [x] ~Tests added.~ N/A
- [x] ~Documentation added.~
- [x] Release notes updated.