### PR TITLE
Add read/write TimeSeries.locked attribute

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :pull:`350`: Add read/write :attr:`.locked` attribute to :class:`.TimeSeries`/:class:`.Scenario`.
 - :pull:`345`: Fix a bug in :meth:`.read_excel` when parameter data is spread across multiple sheets.
 - :pull:`363`: Expand documentation and revise installation instructions.
 - :pull:`362`: Raise Python exceptions from :class:`.JDBCBackend`.

--- a/doc/source/api-backend.rst
+++ b/doc/source/api-backend.rst
@@ -147,6 +147,7 @@ Backend API
       get
       get_data
       get_geo
+      get_locked
       init
       is_default
       last_update
@@ -155,6 +156,7 @@ Backend API
       set_data
       set_as_default
       set_geo
+      set_locked
 
    Methods related to :class:`ixmp.Scenario`:
 

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -98,6 +98,11 @@ TimeSeries
       set_as_default
       timeseries
 
+   and the following attribute:
+
+   .. autosummary::
+      locked
+
 
 Scenario
 --------

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -523,6 +523,39 @@ class Backend(ABC):
         """
 
     @abstractmethod
+    def get_locked(self, ts: TimeSeries):
+        """Return the lock state of *ts*.
+
+        Returns
+        -------
+        bool
+            :obj:`True` if *ts* is locked; :obj:`False` otherwise.
+
+        See also
+        --------
+        set_locked
+        """
+
+    @abstractmethod
+    def set_locked(self, ts: TimeSeries, value: bool):
+        """Set the lock state of *ts*.
+
+        Parameters
+        -------
+        value : bool
+            If :obj:`True`, lock *ts*. If :obj:`False`, unlock *ts*.
+
+        Raises
+        ------
+        NotImplementedError
+            if the requested operation is not supported.
+
+        See also
+        --------
+        get_locked
+        """
+
+    @abstractmethod
     def set_as_default(self, ts: TimeSeries):
         """Set the current :attr:`.TimeSeries.version` as the default.
 

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -483,13 +483,8 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def check_out(self, ts: TimeSeries, timeseries_only):
+    def check_out(self, ts: TimeSeries):
         """Check out *ts* for modification.
-
-        Parameters
-        ----------
-        timeseries_only : bool
-            ???
 
         Returns
         -------

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -621,9 +621,9 @@ class JDBCBackend(CachingBackend):
         # Aggressively free memory
         self.gc()
 
-    def check_out(self, ts, timeseries_only):
+    def check_out(self, ts):
         try:
-            self.jindex[ts].checkOut(timeseries_only)
+            self.jindex[ts].checkOut()
         except java.IxException as e:
             _raise_jexception(e)
 

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -642,6 +642,24 @@ class JDBCBackend(CachingBackend):
     def is_default(self, ts):
         return bool(self.jindex[ts].isDefault())
 
+    def get_locked(self, ts):
+        # TimeSeries.state is protected in Java, and ixmp_source does not
+        # provide a method to simply check state
+        try:
+            self.jindex[ts].assertTimeSeriesIsLockedInDB(False)
+        except Exception:
+            # Assertion failed = ts was not locked
+            return False
+        else:
+            # Assertion passed = ts was locked
+            return True
+
+    def set_locked(self, ts, value):
+        if value is True:
+            raise NotImplementedError
+        elif value is False:
+            self.jobj.unlockRunid(self.run_id(ts))
+
     def last_update(self, ts):
         timestamp = self.jindex[ts].getLastUpdateTimestamp()
         if timestamp is not None:

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -499,6 +499,17 @@ class TimeSeries:
         # only Scenario class can have a solution
         return False
 
+    @property
+    def locked(self) -> bool:
+        """:obj:`True` if the TimeSeries is locked. Writeable."""
+        return self._backend('get_locked')
+
+    @locked.setter
+    def locked(self, value: bool):
+        if not isinstance(value, bool):
+            raise TypeError(f"{value}; bool required")
+        self._backend('set_locked', value)
+
     def check_out(self, timeseries_only=False):
         """Check out the TimeSeries.
 

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -306,6 +306,11 @@ def make_dantzig(mp, solve=False):
     scen = Scenario(mp, **models['dantzig'], version='new', annotation=annot,
                     scheme='dantzig', with_data=True)
 
+    # add timeseries data for testing `clone(keep_solution=False)`
+    # and `remove_solution()`
+    scen.add_timeseries(HIST_DF, meta=True)
+    scen.add_timeseries(INP_DF)
+
     # commit the scenario
     scen.commit("Import Dantzig's transport problem for testing.")
 
@@ -315,13 +320,6 @@ def make_dantzig(mp, solve=False):
     if solve:
         # Solve the model using the GAMS code provided in the `tests` folder
         scen.solve(model='dantzig', case='transport_standard')
-
-    # add timeseries data for testing `clone(keep_solution=False)`
-    # and `remove_solution()`
-    scen.check_out(timeseries_only=True)
-    scen.add_timeseries(HIST_DF, meta=True)
-    scen.add_timeseries(INP_DF)
-    scen.commit("Import Dantzig's transport problem for testing.")
 
     return scen
 

--- a/ixmp/tests/backend/test_base.py
+++ b/ixmp/tests/backend/test_base.py
@@ -39,6 +39,7 @@ def test_class():
         get_data = noop
         get_doc = noop
         get_geo = noop
+        get_locked = noop
         get_meta = noop
         get_model_names = noop
         get_nodes = noop
@@ -62,6 +63,7 @@ def test_class():
         set_data = noop
         set_doc = noop
         set_geo = noop
+        set_locked = noop
         set_meta = noop
         set_node = noop
         set_timeslice = noop

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -172,6 +172,33 @@ def test_default(mp, ts):
     assert not ts.is_default()
 
 
+def test_locked(mp, ts):
+    # *ts* fixture is initially checked out and not locked
+    assert not ts.locked
+
+    # Committed and checked in, but still not locked
+    ts.commit("foo")
+    assert not ts.locked
+
+    # With the default JDBCBackend, cannot manually lock a TimeSeries
+    with pytest.raises(NotImplementedError):
+        ts.locked = True
+
+    # Unlock when already unlocked, a no-op
+    ts.locked = False
+    assert not ts.locked
+
+    # TODO force ts to become locked somehow
+
+    # Unlock when locked
+    ts.locked = False
+    assert not ts.locked
+
+    # Invalid type
+    with pytest.raises(TypeError, match="123; bool required"):
+        ts.locked = 123
+
+
 def test_run_id(ts):
     # New, un-committed TimeSeries has run_id of -1
     assert ts.run_id() == -1


### PR DESCRIPTION
@behnam-zakeri mentioned that he and a YSSP student both had an active need to use the Java method `Timeseries.unlockRunid()`, so here's an attempt to tackle what turns out to be our oldest issue, #30. This PR:
- Adds getter and setter methods for an attribute `TimeSeries.locked`.
- Adds the Backend API methods `{get,set}_locked`.
- Implements these methods on JDBCBackend using existing ixmp_source methods.

In https://github.com/iiasa/ixmp/issues/30#issuecomment-584551801 I commented on the complexity of the multiple state options/transitions for TimeSeries on the Java side, and @zikolach have had some discussions circling around how to simplify them. This PR *does not* try to alter them; however, it does create the appearance (to the user) that there are two distinct, boolean states: `checked_out`, and `locked`.

Two things that require input, probably from @zikolach:
- [x] `set_locked(ts, False)` should be prohibited for the shared production databases on gp3.iiasa.ac.at. Options:
  - Only allow unlocking when `driver='hqsldb'`, i.e. someone is working in a local database, and don't allow unlocking for any `driver='oracle'` database. I'm not sure if this rules out @behnam-zakeri's main use-case—could you comment? This can be done entirely in Python.
  - ~Change code on the Java side. Not knowing that code, I don't know how this could be done most simply, or whether the changes would echo back into the Python side. If it involves adding lots of auth machinery to the Python code, I would prefer to avoid that.~ No input, so did not choose this option.
- [ ] There's currently no way to force, from Python, a TimeSeries to become locked, in order to actually test whether the unlocking feature works. Is it possible to add such a method? We can keep it hidden from the Python API.

## How to review

Note that the CI checks all pass.

## PR checklist

- [x] Tests added.
- [x] Documentation added.
- [x] Release notes updated.