### PR TITLE
typo in docstring reporting/computations/select()

### DIFF
--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -349,7 +349,7 @@ def select(qty, indexers, inverse=False):
     Parameters
     ----------
     qty : .Quantity
-    select : dict (str -> list of str)
+    indexers : dict (str -> list of str)
         Elements to be selected from *qty*. Mapping from dimension names to
         labels along each dimension.
     inverse : bool, optional


### PR DESCRIPTION
Small typo in docstring of `ixmp/reporting/computations/select()`.

More typos will be added here in case they will be ecountered.