### PR TITLE
Filter all data from one Scenario by a set element; add utils.diff()

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -47,7 +47,7 @@ jobs:
     - name: Lint with flake8
       run: |
         pip install flake8
-        flake8 --count --max-complexity=29 --show-source --statistics
+        flake8 --count --max-complexity=26 --show-source --statistics
 
     - name: Test package build
       run: |

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :pull:`354`: Add :meth:`Scenario.items`, :func:`.utils.diff`, and allow using filters in CLI command ``ixmp export``.
 - :pull:`353`: Add meta functionality.
 
   - :meth:`.Platform.add_model_name` using :meth:`.Backend.add_model_name`

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -406,11 +406,17 @@ class Backend(ABC):
         --------
         read_file
         """
-        s, filters = self._handle_rw_filters(kwargs.pop('filters', {}))
+        # Use the "scenario" filter to retrieve the Scenario `s` to be written;
+        # reappend any other filters
+        s, kwargs["filters"] = self._handle_rw_filters(
+            kwargs.pop("filters", {})
+        )
+
         xlsx_types = (ItemType.SET | ItemType.PAR, ItemType.MODEL)
         if path.suffix == '.xlsx' and item_type in xlsx_types and s:
             s_write_excel(self, s, path, item_type, **kwargs)
         else:
+            # All other combinations of arguments
             raise NotImplementedError
 
     # Methods for ixmp.TimeSeries

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -3,7 +3,7 @@ import logging
 
 import pandas as pd
 
-from ixmp.utils import as_str_list
+from ixmp.utils import as_str_list, maybe_check_out
 from . import ItemType
 
 
@@ -252,8 +252,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
             raise ValueError(f'no set {repr(name)}; try init_items=True')
 
     if commit_steps:
-        s.commit(f'Loaded sets from {path}')
-        s.check_out()
+        s.commit(f"Loaded sets from {path}")
 
     if add_units:
         # List of existing units for reference
@@ -268,6 +267,8 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
         # Only parameters beyond this point
 
         df = parse_item_sheets(name)
+
+        maybe_check_out(s)
 
         if add_units:
             # New units appearing in this parameter
@@ -304,4 +305,6 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
         if commit_steps:
             # Commit after every parameter
             s.commit(f'Loaded {ix_type} {repr(name)} from {path}')
-            s.check_out()
+
+    if not commit_steps:
+        s.commit(f"Import from {path}")

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -3,7 +3,7 @@ import logging
 
 import pandas as pd
 
-from ixmp.utils import as_str_list, maybe_check_out
+from ixmp.utils import as_str_list, maybe_check_out, maybe_commit
 from . import ItemType
 
 
@@ -263,12 +263,10 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
         except KeyError:
             raise ValueError(f'no set {repr(name)}; try init_items=True')
 
-    if commit_steps:
-        s.commit(f"Loaded sets from {path}")
+    maybe_commit(s, commit_steps, f"Loaded sets from {path}")
 
-    if add_units:
-        # List of existing units for reference
-        units = set(be.get_units())
+    # List of existing units for reference
+    units = set(be.get_units())
 
     # Add equ/par/var data
     for name, ix_type in name_type[name_type != 'set'].items():
@@ -314,9 +312,9 @@ def s_read_excel(be, s, path, add_units=False, init_items=False,
 
         s.add_par(name, df)
 
-        if commit_steps:
-            # Commit after every parameter
-            s.commit(f'Loaded {ix_type} {repr(name)} from {path}')
+        # Commit after every parameter
+        maybe_commit(
+            s, commit_steps, f"Loaded {ix_type} {repr(name)} from {path}"
+        )
 
-    if not commit_steps:
-        s.commit(f"Import from {path}")
+    maybe_commit(s, not commit_steps, f"Import from {path}")

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1688,7 +1688,13 @@ class Scenario(TimeSeries):
                                            self.version)
 
     # Input and output
-    def to_excel(self, path, items=ItemType.SET | ItemType.PAR, max_row=None):
+    def to_excel(
+        self,
+        path,
+        items=ItemType.SET | ItemType.PAR,
+        filters=None,
+        max_row=None
+    ):
         """Write Scenario to a Microsoft Excel file.
 
         Parameters
@@ -1699,6 +1705,9 @@ class Scenario(TimeSeries):
             Types of items to write. Either :attr:`.SET` | :attr:`.PAR` (i.e.
             only sets and parameters), or :attr:`.MODEL` (also variables and
             equations, i.e. model solution data).
+        filters : dict, optional
+            Filters for values along dimensions; same as the `filters` argument
+            to :meth:`par`.
         max_row: int, optional
             Maximum number of rows in each sheet. If the number of elements in
             an item exceeds this number or :data:`.EXCEL_MAX_ROWS`, then an
@@ -1710,9 +1719,16 @@ class Scenario(TimeSeries):
         :ref:`excel-data-format`
         read_excel
         """
-        self.platform._backend.write_file(Path(path), items,
-                                          filters=dict(scenario=self),
-                                          max_row=max_row)
+        # Default filters: empty dict
+        filters = filters or dict()
+
+        # Select the current scenario
+        filters["scenario"] = self
+
+        # Invoke the backend method
+        self.platform._backend.write_file(
+            Path(path), items, filters=filters, max_row=max_row
+        )
 
     def read_excel(self, path, add_units=False, init_items=False,
                    commit_steps=False):

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -284,6 +284,7 @@ class TestScenario:
         # NB could make a more exact comparison of the Scenarios
 
         # Pre-initialize skipped items 'baz_2' and 'baz_3'
+        scen_empty.check_out()
         scen_empty.init_par('baz_2', ['i'], ['i_dim'])
         scen_empty.init_set('baz_3', ['i', 'i'], ['i', 'i_also'])
 
@@ -292,6 +293,7 @@ class TestScenario:
         scen_empty.read_excel(tmp_path)
 
         # Re-initialize an item with different index names
+        scen_empty.check_out()
         scen_empty.remove_par('d')
         scen_empty.init_par('d', idx_sets=['i', 'j'], idx_names=['I', 'J'])
 

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -169,6 +169,35 @@ class TestScenario:
         # Units are as expected
         assert df.loc[0, 'unit'] == 'km'
 
+    def test_items(self, scen):
+        # Without filters
+        iterator = scen.items()
+
+        # next() can be called → an iterator was returned
+        next(iterator)
+
+        # Iterator returns the expected parameter names
+        exp = ["a", "b", "d", "f"]
+        for i, (name, data) in enumerate(scen.items()):
+            # Name is correct in the expected order
+            assert exp[i] == name
+            # Data is one of the return types of .par()
+            assert isinstance(data, (pd.DataFrame, dict))
+
+        # Total number of items was correct
+        assert i == 3
+
+        # With filters
+        iterator = scen.items(filters=dict(i=["seattle"]))
+        exp = [("a", 1), ("d", 3)]
+        for i, (name, data) in enumerate(iterator):
+            # Name is correct in the expected order
+            assert exp[i][0] == name
+            # Number of (filtered) rows is as expected
+            assert exp[i][1] == len(data)
+
+        assert i == 1
+
     def test_var(self, scen):
         df = scen.var('x', filters={'i': ['seattle']})
 

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -187,35 +187,30 @@ def test_excel_io(ixmp_cli, test_mp, tmp_path):
     populate_test_platform(test_mp)
     tmp_path /= 'dantzig.xlsx'
 
+    url = (
+        f"ixmp://{test_mp.name}/{models['dantzig']['model']}/"
+        f"{models['dantzig']['scenario']}"
+    )
+
     # Invoke the CLI to export data to Excel
-    cmd = [
-        '--platform', test_mp.name,
-        '--model', models['dantzig']['model'],
-        '--scenario', models['dantzig']['scenario'],
-        'export', str(tmp_path),
-    ]
+    cmd = ["--url", url, "export", str(tmp_path)]
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 
     # Export with a maximum row limit per sheet
     tmp_path2 = tmp_path.with_name('dantzig2.xlsx')
-    cmd = cmd[:-1] + [str(tmp_path2), '--max-row', 2]
+    cmd = cmd[:-1] + [str(tmp_path2), "--max-row", 2]
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 
     # Fails without platform/scenario info
-    assert ixmp_cli.invoke(cmd[6:]).exit_code == UsageError.exit_code
+    assert ixmp_cli.invoke(cmd[2:]).exit_code == UsageError.exit_code
 
     # Invoke the CLI to read data from Excel
-    cmd = [
-        '--platform', test_mp.name,
-        '--model', models['dantzig']['model'],
-        '--scenario', models['dantzig']['scenario'],
-        'import', 'scenario', str(tmp_path),
-    ]
+    cmd = ["--url", url, "import", "scenario", str(tmp_path)]
 
     # Fails without platform/scenario info
-    assert ixmp_cli.invoke(cmd[6:]).exit_code == UsageError.exit_code
+    assert ixmp_cli.invoke(cmd[2:]).exit_code == UsageError.exit_code
 
     # Fails without --discard-solution
     result = ixmp_cli.invoke(cmd)
@@ -223,28 +218,28 @@ def test_excel_io(ixmp_cli, test_mp, tmp_path):
     assert 'This Scenario has a solution' in result.output
 
     # Succeeds with --discard-solution
-    cmd.insert(-1, '--discard-solution')
+    cmd.insert(-1, "--discard-solution")
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 
-    # Import into a new model name fails without --init-items
+    # Import into a new model name: fails without --init-items
     cmd = [
-        '--platform', test_mp.name,
-        '--model', 'foo model',
-        '--scenario', 'bar scenario',
-        '--version', 'new',
-        'import', 'scenario', str(tmp_path),
+        "--url",
+        f"ixmp://{test_mp.name}/foo model/bar scenario#new",
+        "import",
+        "scenario",
+        str(tmp_path),
     ]
     result = ixmp_cli.invoke(cmd)
-    assert result.exit_code == 1
+    assert result.exit_code == 1, result.output
 
-    # Succeeds
-    cmd.insert(-1, '--init-items')
+    # Succeeds with --init-items
+    cmd.insert(-1, "--init-items")
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 
     # Import from a file that has multiple sheets (due to row limit)
-    cmd[cmd.index(str(tmp_path))] = str(tmp_path2)
+    cmd[-1] = str(tmp_path2)
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 0, result.output
 

--- a/ixmp/tests/test_utils.py
+++ b/ixmp/tests/test_utils.py
@@ -81,10 +81,7 @@ def test_diff(test_mp):
     ], columns="i j value_a unit_a value_b unit_b _merge".split())
 
     # Use the specific categorical produced by pd.merge()
-    merge_cat = pd.Categorical(
-        ["left_only", "right_only", "both"],
-        ["left_only", "right_only", "both"],
-    )
+    merge_cat = pd.CategoricalDtype(["left_only", "right_only", "both"])
     exp_b = exp_b.astype(dict(_merge=merge_cat))
     exp_d = exp_d.astype(dict(_merge=merge_cat))
 

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -66,7 +66,7 @@ def check_year(y, s):
         return True
 
 
-def diff(a, b, filters) -> Iterator[Tuple[str, pd.DataFrame]]:
+def diff(a, b, filters=None) -> Iterator[Tuple[str, pd.DataFrame]]:
     """Compute the difference between Scenarios `a` and `b`.
 
     :func:`diff` combines :func:`pandas.merge` and :meth:`Scenario.items`.

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -131,10 +131,11 @@ def diff(a, b, filters=None) -> Iterator[Tuple[str, pd.DataFrame]]:
                     # data was compared in this iteration; advance
                     name[i], data[i] = next(items[i])
             except StopIteration:
-                # No more data for this iterator
-                name[i], data[i] = "(end)", None
+                # No more data for this iterator.
+                # Use "~" because it sorts after all ASCII characters
+                name[i], data[i] = "~ end", None
 
-        if name[0] == name[1] == "(end)":
+        if name[0] == name[1] == "~ end":
             break
 
 

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -186,7 +186,15 @@ def parse_url(url):
         raise ValueError(f"queries ({components.query}) not supported in URLs")
 
     if len(components.fragment):
-        scenario_info['version'] = int(components.fragment)
+        try:
+            version = int(components.fragment)
+        except ValueError:
+            if components.fragment != "new":
+                raise
+            else:
+                version = "new"
+        finally:
+            scenario_info["version"] = version
 
     return platform_info, scenario_info
 


### PR DESCRIPTION
This PR adds features to get data from every parameter in an `ixmp.Scenario` that matches some filters, e.g. a single value on a single dimension. In message_ix this makes it possible to get all parameter data related to a single `technology`, i.e. iiasa/message_ix#267; but the functionality is generalized here so users can find other applications for it.

## How to review

- Read the new tests, including `test_diff` and ensure they cover easily imaginable use cases.
- Note that CI checks, including new tests, pass.
- Run the new CLI command against some existing, “real world” scenarios, e.g. things like:
  ```
  $ message-ix --url="ixmp://my-platform/my-model/my-scenario" export example.xlsx -- technology=coal_ppl,wind_ppl
  ```

## PR checklist

- [x] Add basic functionality to return data across all parameters.
- [x] Modify `to_excel()` to accept filters.
- [x] Add 2-scenario "diff" utility per https://github.com/iiasa/message_ix/pull/267#issuecomment-623395698.
- [x] Add tests for all of the above.
- [x] Add documentation.
- [x] Update release notes.
- [x] Boost code coverage: test when one param is missing from each scenario passed to `diff()`.