### PR TITLE
Fix broken links to message documentation

### DIFF
--- a/NOTICE.rst
+++ b/NOTICE.rst
@@ -24,7 +24,7 @@ Read and understand the file ``LICENSE``; in particular, clause 7 (“Disclaimer
 
 Cite Huppmann *et al.*—the full citation is given at :cite:`huppmann_messageix_2018`.
 
-In addition, include a hyperlink to the online documentation: https://message.iiasa.ac.at.
+In addition, include a hyperlink to the online documentation: https://docs.messageix.org.
 
 
 3. Use the naming convention for new model instances

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/ixmp.svg)](https://pypi.python.org/pypi/ixmp/)
 [![Anaconda version](https://img.shields.io/conda/vn/conda-forge/ixmp)](https://anaconda.org/conda-forge/ixmp)
-[![Documentation build](https://readthedocs.com/projects/iiasa-energy-program-ixmp/badge/?version=master)](https://message.iiasa.ac.at/projects/ixmp/en/master/)
+[![Documentation build](https://readthedocs.com/projects/iiasa-energy-program-ixmp/badge/?version=master)](https://docs.messageix.org/)
 [![Build status](https://github.com/iiasa/ixmp/workflows/pytest/badge.svg)](https://github.com/iiasa/ixmp/actions?query=workflow:pytest)
 [![Test coverage](https://codecov.io/gh/iiasa/ixmp/branch/master/graph/badge.svg)](https://codecov.io/gh/iiasa/ixmp)
 
@@ -36,12 +36,12 @@ Please refer to the [NOTICE](NOTICE.rst) for details and user guidelines.
 
 Documentation of ixmp and the MESSAGEix framework is available in two forms:
 
-- The [MESSAGEix framework documentation](https://message.iiasa.ac.at/)
+- The [MESSAGEix framework documentation](https://docs.messageix.org/)
   includes documentation of the
-  [ixmp Python API](https://message.iiasa.ac.at/en/stable/api.html), which
+  [ixmp Python API](https://docs.messageix.org/en/stable/api.html), which
   is extended by the framework.
 - The [stand-alone ixmp
-  documentation](https://message.iiasa.ac.at/projects/ixmp/) contains
+  documentation](https://docs.messageix.org/projects/ixmp/) contains
   additional information on installing ixmp from source, the R API, etc.
 
 The online documentation is built automatically from the contents of the
@@ -54,16 +54,16 @@ See [`doc/README.rst`](doc/README.rst) for further details.
 ### Installation
 
 Most users will have ixmp installed automatically as a dependency when
-[installing MESSAGEix](https://message.iiasa.ac.at/en/stable/getting_started.html).
+[installing MESSAGEix](https://docs.messageix.org/en/stable/getting_started.html).
 
 To install the ixmp R API, or to install ixmp from source code, see
-[‘Installation’ in the documentation](https://message.iiasa.ac.at/projects/ixmp/en/stable/install.html).
+[‘Installation’ in the documentation](https://docs.messageix.org/projects/ixmp/en/stable/install.html).
 
 
 ### Tutorials
 
 Introductory tutorials are provided in both Python and R.
-See [‘Tutorials’ in the documentation](https://message.iiasa.ac.at/projects/ixmp/en/stable/tutorials.html) or [`tutorial/README.rst`](tutorial/README.rst).
+See [‘Tutorials’ in the documentation](https://docs.messageix.org/projects/ixmp/en/stable/tutorials.html) or [`tutorial/README.rst`](tutorial/README.rst).
 
 
 ## Scientific reference

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![PyPI version](https://img.shields.io/pypi/v/ixmp.svg)](https://pypi.python.org/pypi/ixmp/)
 [![Anaconda version](https://img.shields.io/conda/vn/conda-forge/ixmp)](https://anaconda.org/conda-forge/ixmp)
-[![Documentation build](https://readthedocs.com/projects/iiasa-energy-program-ixmp/badge/?version=master)](https://docs.messageix.org/)
+[![Documentation build](https://readthedocs.com/projects/iiasa-energy-program-ixmp/badge/?version=master)](https://docs.messageix.org/projects/ixmp/en/master/)
 [![Build status](https://github.com/iiasa/ixmp/workflows/pytest/badge.svg)](https://github.com/iiasa/ixmp/actions?query=workflow:pytest)
 [![Test coverage](https://codecov.io/gh/iiasa/ixmp/branch/master/graph/badge.svg)](https://codecov.io/gh/iiasa/ixmp)
 

--- a/doc/README.rst
+++ b/doc/README.rst
@@ -42,7 +42,7 @@ Read the Docs
 -------------
 
 The official version of the documentation is hosted on Read The Docs (RTD) at
-https://message.iiasa.ac.at/projects/ixmp/. RTD builds the docs using a command
+https://docs.messageix.org/projects/ixmp/. RTD builds the docs using a command
 similar to::
 
     sphinx-build -T -E -d _build/doctrees-readthedocs -D language=en . \

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -185,7 +185,7 @@ For Anaconda users experiencing problems during installation of ixmp, check that
     C:\[YOUR ANACONDA LOCATION]\Anaconda3\Scripts;
     C:\[YOUR ANACONDA LOCATION]\Anaconda3\Library\bin;
 
-.. _`installing MESSAGEix`: https://docs.messageix.org/en/stable/getting_started.html
+.. _`installing MESSAGEix`: https://docs.messageix.org/en/latest/getting_started.html
 .. _`Anaconda`: https://www.continuum.io/downloads
 .. _`GAMS`: http://www.gams.com
 .. _`latest version`: https://www.gams.com/download/

--- a/doc/source/install.rst
+++ b/doc/source/install.rst
@@ -185,7 +185,7 @@ For Anaconda users experiencing problems during installation of ixmp, check that
     C:\[YOUR ANACONDA LOCATION]\Anaconda3\Scripts;
     C:\[YOUR ANACONDA LOCATION]\Anaconda3\Library\bin;
 
-.. _`installing MESSAGEix`: https://message.iiasa.ac.at/en/latest/getting_started.html
+.. _`installing MESSAGEix`: https://docs.messageix.org/en/stable/getting_started.html
 .. _`Anaconda`: https://www.continuum.io/downloads
 .. _`GAMS`: http://www.gams.com
 .. _`latest version`: https://www.gams.com/download/


### PR DESCRIPTION
Fix broken links to message documentation.

## How to review

Check that the adapted links point to the correct location.
Specifically, I'm not sure whether the link of the "Documentation build" badge in the README.md file is correct.


## PR checklist

<!-- The following items are all **required* if the PR results in changes to
the user behaviour, e.g. new features or fixes to existing behaviour. They are
**optional** if the changes are solely to documentation, CI configuration, etc.

In ambiguous cases, strike them out and add a short explanation, e.g.

- [x] ~Tests added.~ No change in behaviour, simply refactoring.
-->
As this PR only adapts the documentation I didn't adapt the release notes.
- [ ] ~~Tests added.~~
- [ ] ~~Documentation added.~~
- [ ] ~~Release notes updated.~~
  <!-- Add a single line at the top of the “Next release” section of
       RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

    - :pull:`999`: Title or single-sentence description from above.
  -->
