### PR TITLE
Avoid usage of R devtools in CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -79,13 +79,6 @@ jobs:
     - name: Install Python package and dependencies
       run: pip install .[docs,tests,tutorial]
 
-    - name: Install system R dependencies (Linux only)
-      # This is faster than allowing remotes::install_deps() to do the
-      # installation, below. However, not all packages are available in 18.04.
-      # TODO install more of the Linux dependencies in this way to speed up.
-      if: ${{ contains(matrix.os, 'ubuntu') }}
-      run: sudo apt install -q libcurl4-openssl-dev r-cran-devtools
-
     - name: Set RETICULATE_PYTHON (Windows only)
       # Without this, reticulate tries to use Python 2.7 in the next step
       if: ${{ contains(matrix.os, 'windows') }}
@@ -94,20 +87,18 @@ jobs:
 
     - name: Install R package and dependencies
       run: |
-        install.packages(c("devtools", "remotes", "IRkernel"))
-        remotes::install_cran("rcmdcheck")
+        install.packages("remotes")
+        remotes::install_cran(c("rcmdcheck", "IRkernel"))
         remotes::install_deps("rixmp", dependencies = TRUE)
-
-        # Set up R Jupyter kernel for tutorial notebooks
-        IRkernel::installspec()
 
         # commented: for debugging
         # print(reticulate::py_config())
         # reticulate::py_run_string("import os; print(os.environ)")
 
-        # --no-multiarch here (and below) avoids cross-compiling arch=i386 on
-        # Windows, which is not needed and causes errors
-        devtools::install("rixmp", args = "--no-multiarch")
+        # For R tutorial notebooks, run via the pytest suite: set up R kernel;
+        # actually install the R package
+        IRkernel::installspec()
+        remotes::install_local("rixmp")
       shell: Rscript {0}
 
     - name: Run test suite using pytest


### PR DESCRIPTION
Continuous integration failures were observed in #356 due to trying to install the R `devtools` package, in particular the Ubuntu system version.

Per the [official example](https://github.com/r-lib/actions/tree/master/examples#standard-ci-workflow), this PR adjusts the CI workflow to use `remotes::install_local` instead of `devtools::install`, removing any need for devtools and its many dependencies.

## How to review

Note that CI checks pass on Ubuntu.

## PR checklist
- ~Tests added.~ N/A, CI changes only
- ~Documentation added.~
- ~Release notes updated.~