### PR TITLE
Use --no-multiarch when installing R package on Windows CI

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -98,7 +98,7 @@ jobs:
         # For R tutorial notebooks, run via the pytest suite: set up R kernel;
         # actually install the R package
         IRkernel::installspec()
-        remotes::install_local("rixmp")
+        remotes::install_local("rixmp", INSTALL_opts = c("--no-multiarch"))
       shell: Rscript {0}
 
     - name: Run test suite using pytest


### PR DESCRIPTION
r-lib/actions#151 was fixed. The next CI run, [number 172](https://github.com/iiasa/ixmp/runs/958501623#check-step-13), errored on Windows in the step where `rixmp` is installed, because cross-compiling is attempted. This PR disables multiarch build.

## How to review

Note that CI checks all pass.

## PR checklist

- ~Tests added.~ CI changes only.
- ~Documentation added.~
- ~Release notes updated.~