### PR TITLE
Run CI checks on Python 3.6

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -37,6 +37,9 @@ jobs:
       run: git fetch --tags --depth=${{ env.depth }}
 
     - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
     - uses: r-lib/actions/setup-r@master
 
     - name: Use OpenJDK 14 (macOS only)

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -20,8 +20,15 @@ jobs:
         - ubuntu-latest
         - windows-latest
         python-version:
-        - '3.6' # Earliest supported by ixmp
-        - '3.8' # Latest available
+        - '3.6'        # Earliest supported by ixmp
+        - '3.8'        # Latest release
+        # Currently disabled: compiled binary packages are not available for
+        # some dependencies, e.g. llvmlite, numpy, pandas. Compiling these on
+        # the job runner requires a more elaborate build environment, currently
+        # out of scope.
+        # TODO enable once Python 3.9 is released and binary packages are
+        #      availalable.
+        # - '3.9.0-rc.1' # Development version
 
       fail-fast: false
 

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -30,6 +30,11 @@ jobs:
         #      availalable.
         # - '3.9.0-rc.1' # Development version
 
+        exclude:
+        # See https://github.com/iiasa/ixmp/issues/360
+        - os: windows-latest
+          python-version: '3.6'
+
       fail-fast: false
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -104,7 +104,7 @@ jobs:
       run: |
         install.packages("remotes")
         remotes::install_cran(c("rcmdcheck", "IRkernel"))
-        remotes::install_deps("rixmp", dependencies = TRUE)
+        remotes::install_deps("rixmp", upgrade = "never", dependencies = TRUE)
 
         # commented: for debugging
         # print(reticulate::py_config())
@@ -113,7 +113,11 @@ jobs:
         # For R tutorial notebooks, run via the pytest suite: set up R kernel;
         # actually install the R package
         IRkernel::installspec()
-        remotes::install_local("rixmp", INSTALL_opts = c("--no-multiarch"))
+        remotes::install_local(
+          "rixmp",
+          force = TRUE,
+          INSTALL_opts = c("--no-multiarch"),
+          )
       shell: Rscript {0}
 
     - name: Run test suite using pytest


### PR DESCRIPTION
@OFR-IIASA flagged that TeamCity builds began to fail (e.g. [#870](https://ene-builds.iiasa.ac.at/buildConfiguration/message_data/5552?buildTab=log&focusLine=685&linesState=134)) after the merge of iiasa/message_ix#286.

The issue here was that the message_ix GitHub Actions configuration did not correctly install Python 3.6 for the job that is supposed to use it. Syntax not compatible with Python 3.8 appeared to pass checks, when they should have failed. TeamCity uses Python 3.7, so TC builds began to fail when using the new code.

The same problem affects ixmp; see e.g. [this log](https://github.com/iiasa/ixmp/runs/961648311), supposedly for a py36 job, which contains:
```
Successfully setup CPython (3.8.5)
```

This PR fixes this issue.

I attempted to add Python 3.9-dev, but this fails because some dependencies, e.g. pandas, numpy, and llvmlite, are not available as precompiled binaries from PyPI for this as-yet-unreleased version of Python. `pip` on the job runner tries to compile them from source, but this requires a lot of dependencies that we don't have the resources to decipher. For now, the config for this Python version is commented out; but it should be enabled as soon as Python 3.9 is released, expected [2020-10-05](https://www.python.org/dev/peps/pep-0596/).

iiasa/message_ix#381 will be expanded to include similar changes.

## How to review

- Confirm CI checks pass.
- View the logs and confirm the intended version of Python is being installed for each job.

## PR checklist

- ~Tests added.~ N/A; CI changes only
- ~Documentation added.~
- ~Release notes updated.~