### PR TITLE
Don't error on missing dim= kwarg in reporting…concat()

### DIFF
--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -286,8 +286,9 @@ def concat(*objs, **kwargs):
     Reporter.
     """
     objs = filter_concat_args(objs)
-    if Quantity.CLASS == 'AttrSeries':
-        kwargs.pop('dim')
+    if Quantity.CLASS == "AttrSeries":
+        # Silently discard any "dim" keyword argument
+        kwargs.pop("dim", None)
         return pd.concat(objs, **kwargs)
     else:
         # Correct fill-values


### PR DESCRIPTION
`reporting.computations.concat()` needs a dim= keyword argument for xarray, but not for pandas; don't raise an exception if it is missing.

Discovered with @francescolovat during work on iiasa/message_data#120.

## How to review

Note that CI checks all pass.

## PR checklist

- ~Tests added.~
- ~Documentation added.~
- ~Release notes updated.~