### PR TITLE
Demote missing annotation warning to info in TimeSeries.__init__()

### DIFF
--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -446,9 +446,9 @@ class TimeSeries:
         elif version and not (version == 'new' or isinstance(version, int)):
             raise ValueError(f'version={repr(version)}')
         elif version == 'new' and annotation is None:
-            log.warning(
-                f'Missing annotation for new {self.__class__.__name__}'
-                f' {model}/{scenario}'
+            log.info(
+                f"Missing annotation for new {self.__class__.__name__}"
+                f" {model}/{scenario}"
             )
             annotation = ''
 


### PR DESCRIPTION
The warning-level log message is displayed prominently in a Jupyter notebook, and can be confused for a fatal error.

Closes iiasa/message_ix#383.

## How to review

- Confirm CI checks all pass.

## PR checklist
- ~Add or expand tests.~ N/A
- ~Add, expand, or update documentation.~
- ~Update release notes.~ Minor change that doesn't need to be advertised to users.