### PR TITLE
Use nbclient instead in ixmp.testing.run_notebook()

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,16 @@
+codecov:
+  notify:
+    wait_for_ci: false
+
+coverage:
+  precision: 1
+  # PRs can result in small changes of e.g. 0.04 percent; don't let these
+  # prevent a passing check
+  status:
+    project:
+      default:
+        threshold: 0.2%
+
+comment:
+  # Don't display the large graph
+  layout: "diff, files"

--- a/ci/codecov.yml
+++ b/ci/codecov.yml
@@ -1,1 +1,0 @@
-comment: off

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -359,6 +359,15 @@ def run_notebook(nb_path, tmp_path, env=None, kernel=None, allow_errors=False):
     import nbformat
     from nbclient import NotebookClient
 
+    # Workaround for https://github.com/jupyter/nbclient/issues/85
+    if (
+        sys.version_info[0] == 3
+        and sys.version_info[1] >= 8
+        and sys.platform.startswith("win")
+    ):
+        import asyncio
+        asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
+
     # Read the notebook
     with open(nb_path) as f:
         nb = nbformat.read(f, as_version=4)

--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -36,7 +36,6 @@ from collections import namedtuple
 import contextlib
 from contextlib import contextmanager
 from copy import deepcopy
-import io
 from itertools import chain, product
 import logging
 from math import ceil
@@ -48,7 +47,6 @@ except ImportError:
     # Windows
     has_resource_module = False
 import shutil
-import subprocess
 import sys
 
 from click.testing import CliRunner
@@ -332,10 +330,7 @@ nbformat = pytest.importorskip('nbformat')
 
 
 def run_notebook(nb_path, tmp_path, env=None, kernel=None, allow_errors=False):
-    """Execute a Jupyter notebook via ``nbconvert`` and collect output.
-
-    Modified from
-    https://blog.thedataincubator.com/2016/06/testing-jupyter-notebooks/
+    """Execute a Jupyter notebook via :mod:`nbclient` and collect output.
 
     Parameters
     ----------
@@ -361,30 +356,31 @@ def run_notebook(nb_path, tmp_path, env=None, kernel=None, allow_errors=False):
     errors : list
         Any execution errors.
     """
-    # Process arguments
-    env = env or os.environ
-    major_version = sys.version_info[0]
-    kernel = kernel or 'python{}'.format(major_version)
+    import nbformat
+    from nbclient import NotebookClient
 
-    os.chdir(nb_path.parent)
-    fname = tmp_path / 'test.ipynb'
-    args = [
-        "jupyter", "nbconvert", "--to", "notebook", "--execute",
-        "--allow-errors" if allow_errors else "",
-        "--ExecutePreprocessor.timeout=60",
-        "--ExecutePreprocessor.kernel_name={}".format(kernel),
-        "--output", str(fname), str(nb_path)]
-    subprocess.check_call(args, env=env)
+    # Read the notebook
+    with open(nb_path) as f:
+        nb = nbformat.read(f, as_version=4)
 
-    nb = nbformat.read(io.open(fname, encoding='utf-8'),
-                       nbformat.current_nbformat)
+    # Create a client and use it to execute the notebook
+    client = NotebookClient(
+        nb,
+        timeout=60,
+        kernel_name=kernel or f"python{sys.version_info[0]}",
+        allow_errors=allow_errors,
+        resources=dict(metadata=dict(path=tmp_path))
+    )
 
+    # Execute the notebook.
+    # `env` is passed from nbclient to jupyter_client.launcher.launch_kernel()
+    client.execute(env=env or os.environ.copy())
+
+    # Retrieve error information from cells
     errors = [
         output for cell in nb.cells if "outputs" in cell
         for output in cell["outputs"] if output.output_type == "error"
     ]
-
-    fname.unlink()
 
     return nb, errors
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -33,7 +33,7 @@ tests =
     codecov
     jupyter
     memory_profiler
-    nbformat >= 5.0
+    nbclient >= 0.5
     pretenders >= 1.4.4
     pytest >= 5
     pytest-cov


### PR DESCRIPTION
`run_notebook()` used the built-in Python `subprocess` module to run tutorial and test notebooks, write the results to a file, and then read the finished notebook. This process recently began to cause test & CI failures, e.g. in #370.

The Jupyter ecosystem now has a first-class package `nbclient` that executes notebooks programmatically; this PR:

- adjusts the function to use this package.
- replaces `nbformat` with `nbclient` as a requirement for the 'tests' extra set. (`nbclient` itself depends on `nbformat`.)
- moves and update codecov.yml; in the `ci/` directory, it was not being detected by the Codecov CLI tool.

## How to review

- Note that the CI checks all pass.

## PR checklist

- ~Add or expand tests.~ N/A
- [x] Add, expand, or update documentation.
- ~Update release notes.~ N/A