### PR TITLE
Always read notebooks as UTF-8 in ixmp.testing.run_notebook()

### DIFF
--- a/ixmp/testing.py
+++ b/ixmp/testing.py
@@ -369,7 +369,7 @@ def run_notebook(nb_path, tmp_path, env=None, kernel=None, allow_errors=False):
         asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
 
     # Read the notebook
-    with open(nb_path) as f:
+    with open(nb_path, encoding="utf-8") as f:
         nb = nbformat.read(f, as_version=4)
 
     # Create a client and use it to execute the notebook


### PR DESCRIPTION
Some message_ix notebooks (see iiasa/message_ix#402) are in UTF-8; this ensures they are read as such, even on Windows.

## How to review

Note that the CI checks all pass.

## PR checklist

Hotfix; N/A.