### PR TITLE
Add tests of add_par() with empty DataFrames

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :pull:`374`: Raise clearer exceptions from :meth:`.add_par` for incorrect parameters; silently handle empty data.
 - :pull:`389`: Depend on :mod:`openpyxl` instead of :mod:`xlrd` and :mod:`xlsxwriter` for Excel I/O; :mod:`xlrd` versions 2.0.0 and later do not support :file:`.xlsx`.
 - :pull:`367`: Add a parameter for exporting all model+scenario run versions to :meth:`.Platform.export_timeseries_data`, and fix a bug where exporting all runs happens uninteneded.
 - :pull:`378`: Silence noisy output from ignored exceptions on JDBCBackend/JVM shutdown.

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -2,7 +2,7 @@ import logging
 from functools import partial
 from itertools import repeat, zip_longest
 from pathlib import Path
-from typing import Optional, List, Union
+from typing import List, Union
 from warnings import warn
 from weakref import ProxyType, proxy
 

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -2,7 +2,7 @@ import logging
 from functools import partial
 from itertools import repeat, zip_longest
 from pathlib import Path
-from typing import List, Union
+from typing import Optional, List, Union
 from warnings import warn
 from weakref import ProxyType, proxy
 
@@ -1265,7 +1265,14 @@ class Scenario(TimeSeries):
                 name, filters={k: v for k, v in filters.items() if k in idx_names}
             )
 
-    def add_par(self, name, key_or_data=None, value=None, unit=None, comment=None):
+    def add_par(
+        self,
+        name: str,
+        key_or_data=None,
+        value=None,
+        unit: str = None,
+        comment: str = None,
+    ):
         """Set the values of a parameter.
 
         Parameters

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -1299,8 +1299,11 @@ class Scenario(TimeSeries):
             data = pd.DataFrame.from_dict(key_or_data, orient="columns")
         elif isinstance(key_or_data, pd.DataFrame):
             data = key_or_data.copy()
-            if "value" in data.columns and value is not None:
-                raise ValueError("both key_or_data.value and value supplied")
+            if value is not None:
+                if "value" in data.columns:
+                    raise ValueError("both key_or_data.value and value supplied")
+                else:
+                    data["value"] = value
         else:
             # One or more keys; convert to a list of strings
             if isinstance(key_or_data, range):
@@ -1337,12 +1340,15 @@ class Scenario(TimeSeries):
         # Further handle each column
         if "key" not in data.columns:
             # Form the 'key' column from other columns
-            if N_dim > 1:
+            if N_dim > 1 and len(data):
                 data["key"] = data.apply(
                     partial(as_str_list, idx_names=idx_names), axis=1
                 )
             else:
                 data["key"] = data[idx_names[0]]
+
+        if "value" not in data.columns:
+            raise ValueError("no parameter values supplied")
 
         if "unit" not in data.columns:
             # Broadcast single unit across all values. pandas raises ValueError
@@ -1360,8 +1366,9 @@ class Scenario(TimeSeries):
                 types.pop("comment")
 
         # Convert types, generate tuples
-        elements = (
-            (e.key, e.value, e.unit, e.comment) for e in data.astype(types).itertuples()
+        elements = map(
+            lambda e: (e.key, e.value, e.unit, e.comment),
+            data.astype(types).itertuples(),
         )
 
         # Store

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -171,11 +171,19 @@ class TestScenario:
         assert scen.scalar("f") == {"unit": "USD/km", "value": 90}
 
     # Store data
-    def test_add_par(self, scen):
-        # add_par() broadcasts scalar values/units across multiple keys
+    @pytest.mark.parametrize(
+        "args, kwargs",
+        (
+            # Scalar values/units are broadcast across multiple keys
+            (("b", ["new-york", "chicago"]), dict(value=100, unit="cases")),
+            # Empty DataFrame can be added without error
+            (("b", pd.DataFrame(columns=["i", "j", "value", "unit"])), dict()),
+        ),
+    )
+    def test_add_par(self, scen, args, kwargs):
         scen = scen.clone(keep_solution=False)
         scen.check_out()
-        scen.add_par("b", ["new-york", "chicago"], value=100, unit="cases")
+        scen.add_par(*args, **kwargs)
 
     # Retrieve data
     def test_idx(self, scen):

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -185,6 +185,13 @@ class TestScenario:
         scen.check_out()
         scen.add_par(*args, **kwargs)
 
+    def test_add_par2(self, scen):
+        scen = scen.clone(keep_solution=False)
+        scen.check_out()
+        # Create a parameter with duplicate indices
+        scen.init_par("foo", idx_sets=["i", "i", "j"], idx_names=["i0", "i1", "j"])
+        scen.add_par("foo", pd.DataFrame(columns=["i0", "i1", "j"]))
+
     # Retrieve data
     def test_idx(self, scen):
         assert scen.idx_sets("d") == ["i", "j"]

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -178,6 +178,12 @@ class TestScenario:
             (("b", ["new-york", "chicago"]), dict(value=100, unit="cases")),
             # Empty DataFrame can be added without error
             (("b", pd.DataFrame(columns=["i", "j", "value", "unit"])), dict()),
+            # Empty DataFrame can be added without error
+            pytest.param(
+                ("b", pd.DataFrame(columns=["i", "j", "unit"])),
+                dict(),
+                marks=pytest.mark.xfail(raises=ValueError, match="no parameter values"),
+            ),
         ),
     )
     def test_add_par(self, scen, args, kwargs):
@@ -190,7 +196,7 @@ class TestScenario:
         scen.check_out()
         # Create a parameter with duplicate indices
         scen.init_par("foo", idx_sets=["i", "i", "j"], idx_names=["i0", "i1", "j"])
-        scen.add_par("foo", pd.DataFrame(columns=["i0", "i1", "j"]))
+        scen.add_par("foo", pd.DataFrame(columns=["i0", "i1", "j"]), value=1.0)
 
     # Retrieve data
     def test_idx(self, scen):

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -178,7 +178,14 @@ class TestScenario:
             (("b", ["new-york", "chicago"]), dict(value=100, unit="cases")),
             # Empty DataFrame can be added without error
             (("b", pd.DataFrame(columns=["i", "j", "value", "unit"])), dict()),
-            # Empty DataFrame can be added without error
+            # Exceptions
+            pytest.param(
+                ("b", pd.DataFrame(columns=["i", "j", "value", "unit"])),
+                dict(value=1.0),
+                marks=pytest.mark.xfail(
+                    raises=ValueError, match="both key_or_data.value and value supplied"
+                ),
+            ),
             pytest.param(
                 ("b", pd.DataFrame(columns=["i", "j", "unit"])),
                 dict(),


### PR DESCRIPTION
## How to review

Note that CI checks pass, in particular newly added tests/parametrizations of `test_add_par` and `test_add_par2`.

## PR checklist

- [x] Add or expand tests.
  - [x] Test of an empty dataframe with correct columns.
  - [x] Test of an empty dataframe for a parameter with different idx_names/idx_sets, per https://github.com/iiasa/ixmp/issues/373#issuecomment-712056459
- ~Add, expand, or update documentation.~ N/A, bug fix
- [x] Update release notes.