### PR TITLE
Run pytest CI jobs nightly

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -31,6 +31,10 @@ jobs:
       run: git fetch --tags --depth=${{ env.depth }}
 
     - uses: actions/setup-python@v2
+      with:
+        # This should match the "Latest version testable on GitHub Actions"
+        # in pytest.yml
+        python-version: "3.8"
 
     - name: Cache Python packages
       uses: actions/cache@v2

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -46,7 +46,7 @@ jobs:
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }} py${{ matrix.python-version }}
+    name: ${{ matrix.os }}-py${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v2
@@ -59,6 +59,11 @@ jobs:
     - uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
+    - name: Set RETICULATE_PYTHON
+      # Use the environment variable set by the setup-python action, above.
+      run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
+      shell: bash
 
     - uses: r-lib/actions/setup-r@master
 
@@ -101,13 +106,6 @@ jobs:
 
     - name: Install Python package and dependencies
       run: pip install .[docs,tests,tutorial]
-
-    - name: Set RETICULATE_PYTHON (Windows only)
-      # Without this, reticulate tries to use Python 2.7 in the next step
-      if: ${{ contains(matrix.os, 'windows') }}
-      run: |
-        echo "RETICULATE_PYTHON=${{ env.PYTHONLOCATION }}\python.exe" >> $GITHUB_ENV
-      shell: bash
 
     - name: Install R package and dependencies
       run: |

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -23,15 +23,20 @@ jobs:
         - ubuntu-latest
         - windows-latest
         python-version:
-        - '3.6'        # Earliest supported by ixmp
-        - '3.8'        # Latest release
-        # Currently disabled: compiled binary packages are not available for
-        # some dependencies, e.g. llvmlite, numpy, pandas. Compiling these on
-        # the job runner requires a more elaborate build environment, currently
-        # out of scope.
-        # TODO enable once Python 3.9 is released and binary packages are
-        #      availalable.
-        # - '3.9.0-rc.1' # Development version
+        - "3.6"  # Earliest version supported by ixmp
+        - "3.8"  # Latest version testable on GitHub Actions
+
+        # Commented: binary wheels also not available (as of 2020-10-22) for
+        # recently-released Python 3.9.
+        # TODO monitor https://pypi.org/project/[PKG]/#files for the packages
+        #      mentioned below; enable once wheels for "cp39" are available.
+        # - '3.9'  # Latest version / latest supported by ixmp
+
+        # For development versions of Python, compiled binary wheels are not
+        # available for some dependencies, e.g. llvmlite, numba, numpy, and/or
+        # pandas. Compiling these on the job runner requires a more elaborate
+        # build environment, currently out of scope for the ixmp project.
+        # - '3.10.0-alpha.1'  # Development version
 
         exclude:
         # See https://github.com/iiasa/ixmp/issues/360

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -5,6 +5,9 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
+  schedule:
+  - cron: "0 5 * * *"
+
 
 env:
   GAMS_VERSION: 25.1.1

--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -106,7 +106,8 @@ jobs:
       # Without this, reticulate tries to use Python 2.7 in the next step
       if: ${{ contains(matrix.os, 'windows') }}
       run: |
-        Write-Host "::set-env name=RETICULATE_PYTHON::${{ env.PYTHONLOCATION }}\python.exe"
+        echo "RETICULATE_PYTHON=${{ env.PYTHONLOCATION }}\python.exe" >> $GITHUB_ENV
+      shell: bash
 
     - name: Install R package and dependencies
       run: |

--- a/ci/install-gams.sh
+++ b/ci/install-gams.sh
@@ -60,7 +60,7 @@ fi
 export PATH=$BASE/$DEST:$PATH
 
 # For GitHub Actions
-echo "::add-path::$BASE/$DEST"
+echo "$BASE/$DEST" >> $GITHUB_PATH
 
 # Show location
 which gams


### PR DESCRIPTION
This PR:

- Adds configuration to run the 'pytest' GitHub Actions CI workflow/jobs daily/nightly. message_ix already has a separate 'nightly' workflow. This will serve as a 'canary' test, i.e. to identify when changes in dependencies or the CI environment break the code or the CI configuration.
- Adds a detailed comment about CI using Python 3.9. Although Python 3.9 is released, binary wheels are not yet available for some ixmp dependencies, so this version cannot be enabled. Related to iiasa/message_ix#413.
- Sets RETICULATE_PYTHON on all operating systems (rather than only Windows) to ensure reticulate uses the specified version of Python.

## How to review

Note that the CI checks all pass.

## PR checklist

- ~Add or expand tests.~ N/A, CI changes only.
- ~Add, expand, or update documentation.~
- ~Update release notes.~