### PR TITLE
Improve ixmp.model internals

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,10 @@ Next release
 All changes
 -----------
 
+- :pull:`376`: Add a utility method, :func:`.gams_version`, to check the installed version of GAMS.
+  The result is displayed by the ``ixmp show-versions`` CLI command/:func:`.show_versions`.
+- :pull:`376`: :meth:`.init_par` and related methods accept any sequence (not merely :class:`list`) of :class:`str` for the `idx_sets` and `idx_names` arguments.
+
 
 v3.1.0 (2020-08-28)
 ===================

--- a/doc/source/api-model.rst
+++ b/doc/source/api-model.rst
@@ -17,10 +17,8 @@ Provided models
 
 .. currentmodule:: ixmp.model.gams
 
-.. autoclass:: ixmp.model.gams.GAMSModel
+.. automodule:: ixmp.model.gams
    :members:
-
-.. automethod:: ixmp.model.gams.gams_version
 
 .. currentmodule:: ixmp.model.dantzig
 

--- a/doc/source/api-model.rst
+++ b/doc/source/api-model.rst
@@ -20,6 +20,8 @@ Provided models
 .. autoclass:: ixmp.model.gams.GAMSModel
    :members:
 
+.. automethod:: ixmp.model.gams.gams_version
+
 .. currentmodule:: ixmp.model.dantzig
 
 .. autoclass:: ixmp.model.dantzig.DantzigModel

--- a/doc/source/api.rst
+++ b/doc/source/api.rst
@@ -237,7 +237,7 @@ Utilities
 .. currentmodule:: ixmp.utils
 
 .. automodule:: ixmp.utils
-   :members: format_scenario_list, maybe_check_out, maybe_commit, parse_url, update_par
+   :members: format_scenario_list, maybe_check_out, maybe_commit, parse_url, show_versions, update_par
 
 
 Testing utilities

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -789,10 +789,10 @@ class Backend(ABC):
         type : 'set' or 'par' or 'equ' or 'var'
         name : str
             Name for the new item.
-        idx_sets : list of str
+        idx_sets : sequence of str
             If empty, a 0-dimensional/scalar item is initialized. Otherwise, a
             1+-dimensional item is initialized.
-        idx_names : list of str or None
+        idx_names : sequence of str or None
             Optional names for the dimensions. If not supplied, the names of
             the *idx_sets* (if any) are used. If supplied, *idx_names* and
             *idx_sets* must be the same length.

--- a/ixmp/core.py
+++ b/ixmp/core.py
@@ -981,9 +981,9 @@ class Scenario(TimeSeries):
         ----------
         name : str
             Name of the set.
-        idx_sets : list of str or str, optional
+        idx_sets : sequence of str or str, optional
             Names of other sets that index this set.
-        idx_names : list of str or str, optional
+        idx_names : sequence of str or str, optional
             Names of the dimensions indexed by `idx_sets`.
 
         Raises
@@ -1157,9 +1157,9 @@ class Scenario(TimeSeries):
         ----------
         name : str
             Name of the parameter.
-        idx_sets : list of str or str, optional
+        idx_sets : sequence of str or str, optional
             Names of sets that index this parameter.
-        idx_names : list of str or str, optional
+        idx_names : sequence of str or str, optional
             Names of the dimensions indexed by `idx_sets`.
         """
         idx_sets = as_str_list(idx_sets) or []
@@ -1398,9 +1398,9 @@ class Scenario(TimeSeries):
         ----------
         name : str
             Name of the variable.
-        idx_sets : list of str or str, optional
+        idx_sets : sequence of str or str, optional
             Name(s) of index sets for a 1+-dimensional variable.
-        idx_names : list of str or str, optional
+        idx_names : sequence of str or str, optional
             Names of the dimensions indexed by `idx_sets`.
         """
         idx_sets = as_str_list(idx_sets) or []
@@ -1430,9 +1430,9 @@ class Scenario(TimeSeries):
         ----------
         name : str
             Name of the equation.
-        idx_sets : list of str or str, optional
+        idx_sets : sequence of str or str, optional
             Name(s) of index sets for a 1+-dimensional variable.
-        idx_names : list of str or str, optional
+        idx_names : sequence of str or str, optional
             Names of the dimensions indexed by `idx_sets`.
         """
         idx_sets = as_str_list(idx_sets) or []

--- a/ixmp/model/base.py
+++ b/ixmp/model/base.py
@@ -109,7 +109,7 @@ class Model(ABC):
                 for key, values in item_info.items():
                     values = values or []
                     existing = getattr(scenario, key)(name)
-                    if existing != values:
+                    if existing != list(values):
                         # The existing index sets or names do not match
                         log.warning(
                             f"Existing index {key.split('_')[-1]} of "

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -130,7 +130,7 @@ class TestScenario:
             scen.init_set('foo')
 
     def test_init_par(self, scen):
-        scen.remove_solution()
+        scen = scen.clone(keep_solution=False)
         scen.check_out()
 
         # Parameter can be initialized with a tuple (not list) of idx_sets

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -344,7 +344,7 @@ class TestScenario:
         exp = test_dict['test_string']
         assert obs == exp
 
-        scen.delete_meta(['test_int', 'test_bool'])
+        scen.remove_meta(['test_int', 'test_bool'])
         obs = scen.get_meta()
         assert len(obs) == 4
         assert set(obs.keys()) == {'test_string', 'test_number',

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -129,6 +129,16 @@ class TestScenario:
         with pytest.raises(ValueError, match="'foo' already exists"):
             scen.init_set('foo')
 
+    def test_init_par(self, scen):
+        scen.remove_solution()
+        scen.check_out()
+
+        # Parameter can be initialized with a tuple (not list) of idx_sets
+        scen.init_par("foo", idx_sets=("i", "j"))
+
+        # Return type of idx_sets is still list
+        assert scen.idx_sets("foo") == ["i", "j"]
+
     def test_init_scalar(self, scen):
         scen2 = scen.clone(keep_solution=False)
         scen2.check_out()

--- a/ixmp/tests/test_model.py
+++ b/ixmp/tests/test_model.py
@@ -5,6 +5,7 @@ import pytest
 from ixmp import Scenario
 from ixmp.testing import assert_logs, make_dantzig
 from ixmp.model.base import Model
+from ixmp.model.gams import gams_version
 from ixmp.model.dantzig import DantzigModel
 
 
@@ -86,3 +87,8 @@ def test_model_initialize(test_mp, caplog):
     with assert_logs(caplog,
                      "Existing index sets of 'b' ['i'] do not match ['j']"):
         DantzigModel.initialize(s)
+
+
+def test_gams_version():
+    # Returns a version string like X.Y.Z
+    assert len(gams_version().split(".")) == 3

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -442,6 +442,8 @@ def show_versions(file=sys.stdout):
 
     from xarray.util.print_versions import get_sys_info
 
+    from ixmp.model.gams import gams_version
+
     def _git_log(mod):
         cmd = ['git', 'log', '--oneline', '--no-color', '--decorate', '-n 1']
         try:
@@ -490,6 +492,14 @@ def show_versions(file=sys.stdout):
 
         if module_name == 'jpype':
             info.append(('… JVM path', mod.getDefaultJVMPath()))
+
+    # Also display GAMS version, if any
+    try:
+        version = gams_version()
+    except FileNotFoundError:
+        version = "'gams' executable not in PATH"
+    finally:
+        info.extend([("GAMS", version), (None, None)])
 
     # Use xarray to get system & Python information
     info.extend(get_sys_info()[1:])  # Exclude the commit number

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from functools import partial
 from inspect import Parameter, signature
 from pathlib import Path
@@ -35,7 +35,7 @@ def as_str_list(arg, idx_names=None):
     Several types of arguments are handled:
     - None: returned as None.
     - str: returned as a length-1 list of str.
-    - list of values: returned as a list with each value converted to str
+    - sequence of values: returned as a list with each value converted to str
     - dict, with list of idx_names: the idx_names are used to look up values
       in the dict, the resulting list has the corresponding values in the same
       order.
@@ -45,7 +45,7 @@ def as_str_list(arg, idx_names=None):
         return None
     elif idx_names is None:
         # arg must be iterable
-        if isinstance(arg, Iterable) and not isinstance(arg, str):
+        if isinstance(arg, Sequence) and not isinstance(arg, str):
             return list(map(str, arg))
         else:
             return [str(arg)]

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -1,4 +1,4 @@
-from collections.abc import Iterable, Sequence
+from collections.abc import Iterable
 from functools import partial
 from inspect import Parameter, signature
 from pathlib import Path
@@ -35,7 +35,7 @@ def as_str_list(arg, idx_names=None):
     Several types of arguments are handled:
     - None: returned as None.
     - str: returned as a length-1 list of str.
-    - sequence of values: returned as a list with each value converted to str
+    - iterable of values: returned as a list with each value converted to str
     - dict, with list of idx_names: the idx_names are used to look up values
       in the dict, the resulting list has the corresponding values in the same
       order.
@@ -45,7 +45,9 @@ def as_str_list(arg, idx_names=None):
         return None
     elif idx_names is None:
         # arg must be iterable
-        if isinstance(arg, Sequence) and not isinstance(arg, str):
+        # NB narrower ABC Sequence does not work here; e.g. test_excel_io()
+        #    fails via Scenario.add_set().
+        if isinstance(arg, Iterable) and not isinstance(arg, str):
             return list(map(str, arg))
         else:
             return [str(arg)]

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -440,7 +440,7 @@ def format_scenario_list(platform, model=None, scenario=None, match=None,
 def show_versions(file=sys.stdout):
     """Print information about ixmp and its dependencies to *file*."""
     import importlib
-    from subprocess import DEVNULL, check_output
+    from subprocess import DEVNULL, CalledProcessError, check_output
 
     from xarray.util.print_versions import get_sys_info
 
@@ -498,7 +498,7 @@ def show_versions(file=sys.stdout):
     # Also display GAMS version, if any
     try:
         version = gams_version()
-    except FileNotFoundError:
+    except (CalledProcessError, FileNotFoundError):
         version = "'gams' executable not in PATH"
     finally:
         info.extend([("GAMS", version), (None, None)])


### PR DESCRIPTION
- Move the `gams_version()` utility function into ixmp (was in message_ix):
  https://github.com/iiasa/message_ix/blob/aa02d8c545aec4466fb98290cafbba598a9e56b8/message_ix/models.py#L192-L194
- Allow `Backend.init_item()` (and thus `Model.initialize_items()`) to accept tuples/other sequences of strings for the `idx_sets` and `idx_names` parameters—rather than only lists.

## How to review

Note that the CI checks all pass.

## PR checklist

- [x] Add or expand tests.
- [x] Add, expand, or update documentation.
- [x] Update release notes.
