### PR TITLE
Force graphviz version 2.38 from chocolatey on Windows CI

### DIFF
--- a/ci/install-graphviz.sh
+++ b/ci/install-graphviz.sh
@@ -9,7 +9,8 @@ case $CI_OS in
     brew install graphviz
     ;;
   windows*)
-    choco install --no-progress graphviz
+    # Temporary; see https://github.com/iiasa/ixmp/pull/387
+    choco install --no-progress --version 2.38.0.20190211 graphviz
     ;;
 esac
 


### PR DESCRIPTION
CI jobs for Windows began to fail recently. [Example](https://github.com/iiasa/ixmp/runs/1496999302?check_suite_focus=true#step:14:389):
```
graphviz.backend.CalledProcessError: Command '['dot', '-Tpng']' returned non-zero exit status 1. [stderr: b'Format: "png" not recognized. Use one of:\r\n']
```

On the GitHub Actions runner for Windows, this package is installed using Chocolatey: https://github.com/iiasa/ixmp/blob/689bbe44ff7735184979160bbf4c8d29adb8cee7/ci/install-graphviz.sh#L1-L17

The package appears to be installed successfully (`dot -V` works) but the Python traceback shows that no Graphviz output plugin is available. Another user [reports the same error](https://chocolatey.org/packages/Graphviz#comment-5172544720). The fix is to temporarily force installation of an older version, 2.38.

## How to review

Note the Windows CI check passes.

## PR checklist

- ~Add or expand tests.~ N/A, CI changes only
- ~Add, expand, or update documentation.~
- ~Update release notes.~