### PR TITLE
Add Zenodo badge & update citation instructions

### DIFF
--- a/NOTICE.rst
+++ b/NOTICE.rst
@@ -1,51 +1,18 @@
-User Guidelines and Notice
+User guidelines and notice
 ==========================
 
-We ask that you take the following four actions whenever you:
+The :doc:`user guidelines and notice for MESSAGEix <message_ix:notice>` also apply to ixmp in their entirety.
+We ask that you read the notice and take the actions whenever you:
 
-- **use** the |ixmp|, the |MESSAGEix| framework, or any model(s) you have built using these tools
+- **use** the |ixmp|, or any model(s) you have built using this tool
 - to **produce** any scientific publication, technical report, website, or other **publicly-available material**.
 
-The aim of this request is to ensure good scientific practice and collaborative development of the platform.
+The guidelines include the *optional* step to cite the code via Zenodo (in addition to the *required* step to cite the peer-reviewed publication).
+You must decide which records to cite:
 
-1. Understand the code license
-------------------------------
+- If you are using both :mod:`message_ix` *and* :mod:`ixmp`, then cite the MESSAGEix records.
+- If you are using *only* :mod:`ixmp` *without* :mod:`message_ix`, then cite the ixmp records.
+  ixmp has its own Zenodo records that are distinct from message_ix:
 
-Use the most recent version of the *ixmp* from the Github repository.
-Specify clearly which version (e.g. release tag, such as ``v1.1.0``, or commit hash, such as ``26cc08f``) you have used, and whether you have made any modifications to the code.
-
-Read and understand the file ``LICENSE``; in particular, clause 7 (“Disclaimer of Warranty”), which states:
-
-    Unless required by applicable law or agreed to in writing, Licensor provides the Work (and each Contributor provides its Contributions) on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied, including, without limitation, any warranties or conditions of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are solely responsible for determining the appropriateness of using or redistributing the Work and assume any risks associated with Your exercise of permissions under this License.
-
-
-2. Cite the scientific publication
-----------------------------------
-
-Cite Huppmann *et al.*—the full citation is given at :cite:`huppmann_messageix_2018`.
-
-In addition, include a hyperlink to the online documentation: https://docs.messageix.org.
-
-
-3. Use the naming convention for new model instances
-----------------------------------------------------
-
-For any new model instance under the |MESSAGEix| framework, choose a name of
-the form "MESSAGEix [xxx]" or "MESSAGEix-[xxx]", where [xxx] is replaced by:
-
-- the institution or organization developing the model,
-- the name of a country/region represented in the model, or
-- a similar identifier.
-
-For example, the national model for South Africa developed by Orthofer *et al.* :cite:`orthofer-2019` is named "MESSAGEix South Africa".
-
-For models built on the |ixmp| but unrelated to |MESSAGEix|, we recommend using a name of the form "[NAME]ix".
-
-Ensure there is no naming conflict with existing versions of the *ixmp*/|MESSAGEix| model family.
-When in doubt, contact the IIASA Energy Program at <message_ix@iiasa.ac.at> for a list of existing model instances.
-
-
-4. Give notice of publication
------------------------------
-
-E-mail <message_ix@iiasa.ac.at> with notice of notice of any new or pending publication.
+  - The DOI `10.5281/zenodo.4005665 <https://doi.org/10.5281/zenodo.4005665>`_ represents *all* versions of the :mod:`ixmp` code, and will always resolve to the latest version.
+  - At that page, you can also choose a different DOI in order to cite one specific version; for instance, `10.5281/zenodo.4005666 <https://doi.org/10.5281/zenodo.4005666>`_ to cite v3.1.0.

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ examples for a generic model instance based on Dantzig's transport problem.
 
 ## License
 
-Copyright © 2017–2020 IIASA Energy Program
+Copyright © 2017–2021 IIASA Energy, Climate, and Environment (ECE) program
 
 The platform package is licensed under the Apache License, Version 2.0 (the
 "License"); you may not use the files in this repository except in compliance

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # The ix modeling platform (ixmp)
 
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4005665.svg)](https://doi.org/10.5281/zenodo.4005665)
 [![PyPI version](https://img.shields.io/pypi/v/ixmp.svg)](https://pypi.python.org/pypi/ixmp/)
 [![Anaconda version](https://img.shields.io/conda/vn/conda-forge/ixmp)](https://anaconda.org/conda-forge/ixmp)
 [![Documentation build](https://readthedocs.com/projects/iiasa-energy-program-ixmp/badge/?version=master)](https://docs.messageix.org/projects/ixmp/en/master/)

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,7 @@ import ixmp.testing
 # -- Project information ---------------------------------------------------------------
 
 project = "ix modeling platform"
-copyright = "2020, IIASA Energy Program"
+copyright = "2017–2021, IIASA Energy, Climate, and Environment (ECE) program"
 author = "ixmp Developers"
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = ixmp
-author = IIASA Energy Program
+author = IIASA IIASA Energy, Climate, and Environment (ECE) program
 author_email = message_ix@iiasa.ac.at
 license = Apache
 description = ix modeling platform


### PR DESCRIPTION
Closes #369.

The ixmp NOTICE file repeated a lot of content from the MESSAGEix NOTICE file, but the two had been edited and not been kept in sync. In order to avoid further work of this sort, this PR changes the file to (a) incorporate the other by reference, and (b) only include details particular to ixmp.

## How to review

View the new NOTICE and ensure that it correctly describes how to cite ixmp.

## PR checklist

- ~Add or expand tests.~ No change to code
- [x] Add, expand, or update documentation.
- ~Update release notes.~