### PR TITLE
Add a user-friendly message when no JVM is found

### DIFF
--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -1114,7 +1114,15 @@ def start_jvm(jvmargs=None):
     log.debug(f"jpype.getDefaultJVMPath: {jpype.getDefaultJVMPath()}")
     log.debug(f"args to startJVM: {args} {kwargs}")
 
-    jpype.startJVM(*args, **kwargs)
+    try:
+        jpype.startJVM(*args, **kwargs)
+    except FileNotFoundError as e:  # pragma: no cover
+        # Not covered by tests. jpype.getDefaultJVMPath() tries an extensive set of
+        # methods to find the JVM; it would require excessive effort to defeat these.
+        raise FileNotFoundError(
+            "This error may occur because you have not installed or configured a Java"
+            "Runtime Environment. See the install documentation."
+        ) from e
 
     # define auxiliary references to Java classes
     global java


### PR DESCRIPTION
Closes #249.

<!-- Optional: write a longer description here to help a reviewer understand the PR in 3–5 minutes. -->

## How to review

Note that the CI checks all pass.

## PR checklist

- ~Add or expand tests.~ As noted in the comment, to test that this message is returned would require an elaborate set up: either a new CI environment *without* any JVM, or lots of code to defeat the sophisticated checks in `jpype.getDefaultJVMPath()`. Both are beyond scope.
- ~Add, expand, or update documentation.~
- ~Update release notes.~