### PR TITLE
Minor reporting fixes

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,7 +4,7 @@ Next release
 All changes
 -----------
 
-
+- :pull:`396`: Fix two minor bugs in reporting.
 
 v3.2.0 (2021-01-24)
 ===================

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -338,7 +338,12 @@ def ratio(numerator, denominator):
     u_num, u_denom = collect_units(numerator, denominator)
 
     result = numerator / denominator
-    result.attrs["_unit"] = u_num / u_denom
+
+    # This shouldn't be necessary; would instead prefer:
+    # result.attrs["_unit"] = u_num / u_denom
+    # … but is necessary to avoid an issue when the operands are different Unit classes
+    ureg = pint.get_application_registry()
+    result.attrs["_unit"] = ureg.Unit(u_num) / ureg.Unit(u_denom)
 
     if Quantity.CLASS == "AttrSeries":
         result.dropna(inplace=True)

--- a/ixmp/reporting/utils.py
+++ b/ixmp/reporting/utils.py
@@ -41,16 +41,19 @@ def collect_units(*args):
     """Return an list of '_unit' attributes for *args*."""
     registry = pint.get_application_registry()
 
+    result = []
     for arg in args:
-        if "_unit" in arg.attrs:
-            # Convert units if necessary
-            if isinstance(arg.attrs["_unit"], str):
-                arg.attrs["_unit"] = registry.parse_units(arg.attrs["_unit"])
-        else:
+        # Ensure units are from the same, application registry
+        unit = arg.attrs.get("_unit")
+        if not unit:
             log.debug("assuming {} is unitless".format(arg))
-            arg.attrs["_unit"] = registry.parse_units("")
+            unit = registry.dimensionless
 
-    return [arg.attrs["_unit"] for arg in args]
+        # Store the value (possibly converted from str, possibly new) on the Quantity
+        arg.attrs["_unit"] = registry.Unit(unit)
+        result.append(unit)
+
+    return result
 
 
 def dims_for_qty(data):


### PR DESCRIPTION
Two small issues spotted while working on MESSAGEix-Transport:

1. Dask behaviour has changed; see the commit message.
2. Units handling in `computations.ratio()` was triggering some odd behaviour in pint:
```
  File "/home/khaeru/vc/iiasa/ixmp/ixmp/reporting/computations.py", line 344, in ratio
    result.attrs["_unit"] = u_num / u_denom
  File "/home/khaeru/.local/lib/python3.8/site-packages/pint/unit.py", line 198, in __truediv__
    return qself / other
  File "/home/khaeru/.local/lib/python3.8/site-packages/pint/quantity.py", line 1270, in __truediv__
    return self._mul_div(other, operator.truediv)
  File "/home/khaeru/.local/lib/python3.8/site-packages/pint/quantity.py", line 115, in wrapped
    return f(self, *args, **kwargs)
  File "/home/khaeru/.local/lib/python3.8/site-packages/pint/quantity.py", line 95, in wrapped
    result = f(self, *args, **kwargs)
  File "/home/khaeru/.local/lib/python3.8/site-packages/pint/quantity.py", line 1231, in _mul_div
    no_offset_units_other = len(other._get_non_multiplicative_units())
AttributeError: 'Unit' object has no attribute '_get_non_multiplicative_units'
```

Despite the effort of `collect_units()` to ensure units are from the same registry, things like this would happen:
```
kilometer <class 'pint.unit.build_unit_class.<locals>.Unit'>          
megapassenger <class 'pint.unit.Unit'>    
```
Note the different classes. The explicit re-instantiation prevents this.

## How to review

Note that the CI checks all pass.

## PR checklist

- ~Add or expand tests.~ Not needed here, this code will be moved upstream shortly.
- ~Add, expand, or update documentation.~ No change in behaviour.
- [x] Update release notes.