### PR TITLE
Work around r-lib/actions#250

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -61,25 +61,6 @@ jobs:
     - name: Fetch tags (for setuptools-scm)
       run: git fetch --tags --depth=${{ env.depth }}
 
-    - uses: actions/setup-python@v2
-      with:
-        python-version: ${{ matrix.python-version }}
-
-    - name: Set RETICULATE_PYTHON
-      # Use the environment variable set by the setup-python action, above.
-      run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
-      shell: bash
-
-    - uses: r-lib/actions/setup-r@master
-
-    - name: Use OpenJDK 14 (macOS only)
-      # Using the default OpenJDK 1.8 on the macos-latest runner produces
-      # "Abort trap: 6" when JPype1 starts the JVM
-      if: ${{ startsWith(matrix.os, 'macos') }}
-      uses: actions/setup-java@v1
-      with:
-        java-version: '14'
-
     - name: Cache GAMS installer, Python packages, and R packages
       uses: actions/cache@v2
       with:
@@ -102,9 +83,24 @@ jobs:
         ci/install-graphviz.sh
       shell: bash
 
-    - name: Check GAMS
-      run: gams
+    - uses: r-lib/actions/setup-r@master
+
+    - uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+
+    - name: Set RETICULATE_PYTHON
+      # Use the environment variable set by the setup-python action, above.
+      run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
       shell: bash
+
+    - name: Use OpenJDK 14 (macOS only)
+      # Using the default OpenJDK 1.8 on the macos-latest runner produces
+      # "Abort trap: 6" when JPype1 starts the JVM
+      if: ${{ startsWith(matrix.os, 'macos') }}
+      uses: actions/setup-java@v1
+      with:
+        java-version: '14'
 
     - name: Upgrade pip, wheel, setuptools-scm
       run: python -m pip install --upgrade pip wheel setuptools-scm


### PR DESCRIPTION
Runs like https://github.com/iiasa/ixmp/runs/1976377711?check_suite_focus=true are failing on macOS for the last few days with:
```
Run python -m pip install --upgrade pip wheel setuptools-scm
/System/Library/Frameworks/Python.framework/Versions/2.7/Resources/Python.app/Contents/MacOS/Python: No module named pip
Error: Process completed with exit code 1.
```

"2.7" here is erroneous, because `actions/setup-python` was used earlier to install Python 3.8.

The cause:
- ~May be related to actions/setup-python#191 or actions/setup-python#22.~
- Turns out to be r-lib/actions#250.

## How to review

No review: CI changes only.

## PR checklist

- [x] Continuous integration checks all ✅
- ~Add or expand tests; coverage checks both ✅~ N/A; CI changes only.
- ~Add, expand, or update documentation.~ N/A; CI changes only.
- ~Update release notes.~ N/A; CI changes only.