### PR TITLE
Sanitize GAMSModel "case" name

### DIFF
--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -248,7 +248,7 @@ class GAMSModel(Model):
         # Determine working directory for the GAMS call, possibly a temporary directory
         self.cwd = Path(tempfile.mkdtemp()) if self.use_temp_dir else model_file.parent
         # The "case" name
-        self.case = self.format_option("case").replace(" ", "_")
+        self.case = self.clean_path(self.format_option("case").replace(" ", "_"))
         # Input and output file names
         self.in_file = Path(self.format_option("in_file"))
         self.out_file = Path(self.format_option("out_file"))

--- a/setup.cfg
+++ b/setup.cfg
@@ -31,6 +31,8 @@ docs =
     sphinx >= 3.0
     sphinx_rtd_theme
     sphinxcontrib-bibtex
+report =
+    genno[compat]
 tutorial =
     jupyter
 tests =

--- a/setup.cfg
+++ b/setup.cfg
@@ -14,7 +14,7 @@ zip_safe = True
 include_package_data = True
 install_requires =
     click
-    genno >= 1.1.0
+    genno >= 1.3.0
     JPype1 >= 1.2.1
     openpyxl
     pandas >= 1.0


### PR DESCRIPTION
This PR follows #398. Tests for message-ix-models (e.g. [here](https://github.com/iiasa/message-ix-models/pull/9/checks?check_run_id=2168843171#step:13:1797)) show:
```
>           self.jindex[ts].toGDX(str(path.parent), path.name, False)
E           com.gams.api.com.gams.api.GAMSException: com.gams.api.GAMSException: Permission denied: C:\hostedtoolcache\windows\Python\3.8.8\x64\Lib\site-packages\message_ix\model\data\MsgData_MESSAGEix-GLOBIOM_R14_2010:10:2110_baseline.gdx
```

This is because, while #398 sanitized the model name by replacing characters that Windows cannot handle, it did not sanitize "case", which is used by message-ix to format e.g. `infile = f"MsgData_{case}.gdx"`. This is the invalid file name that triggers the exception.

To resolve, `clean_path()` is applied to this value as well.

## How to review

Note that checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update release notes.~
