### PR TITLE
Add "publish" CI workflow

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -65,9 +65,3 @@ jobs:
         # Also install packages that contain type stubs
         pip install pytest genno xarray
         mypy .
-
-    - name: Test package build
-      run: |
-        pip install twine wheel
-        python3 setup.py bdist_wheel sdist
-        twine check dist/*

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -2,9 +2,9 @@ name: Lint
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
 
 env:
   # For setuptools-scm. With fetch --tags below, this ensures that

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -6,16 +6,6 @@ on:
   pull_request:
     branches: [ main ]
 
-env:
-  # For setuptools-scm. With fetch --tags below, this ensures that
-  # enough history is fetched to contain the latest tag, so that
-  # setuptools-scm can generate the version number. Update:
-  # - See https://github.com/iiasa/ixmp/releases, at "NN commits to
-  #   master since this release". The value should be at least equal to
-  #   NN + the number of commits on any PR branch.
-  # - Reset to a lower value, e.g. 100, after a new release.
-  depth: 100
-
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -24,11 +14,6 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-      with:
-        fetch-depth: ${{ env.depth }}
-
-    - name: Fetch tags (for setuptools-scm)
-      run: git fetch --tags --depth=${{ env.depth }}
 
     - uses: actions/setup-python@v2
       with:

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,0 +1,51 @@
+name: Publish
+
+on:
+  push:
+    branches: [ main ]
+    tags: [ "v*" ]
+  release:
+    types: [ published ]
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+
+    - uses: actions/setup-python@v2
+      with:
+        # This should match the "Latest version testable on GitHub Actions"
+        # in pytest.yaml
+        python-version: "3.8"
+
+    - name: Cache Python packages
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.cache/pip
+        key: publish-${{ runner.os }}
+
+    - name: Upgrade pip, wheel, setuptools-scm
+      run: python -m pip install --upgrade pip wheel setuptools-scm twine
+
+    - name: Build package
+      run: |
+        python3 setup.py bdist_wheel sdist
+        twine check dist/*
+
+    - name: Publish to TestPyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags')
+      with:
+        user: __token__
+        password: ${{ secrets.TESTPYPI_TOKEN }}
+        repository_url: https://test.pypi.org/legacy/
+
+    - name: Publish to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.4.1
+      if: github.event_name == 'release'
+      with:
+        user: __token__
+        password: ${{ secrets.PYPI_TOKEN }}

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,4 +1,4 @@
-name: Publish
+name: Build package / publish
 
 on:
   push:
@@ -6,6 +6,10 @@ on:
     tags: [ "v*" ]
   release:
     types: [ published ]
+  # Check that package can be built even on PRs
+  pull_request:
+    branches: [ main ]
+
 
 jobs:
   publish:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -2,9 +2,9 @@ name: Test
 
 on:
   push:
-    branches: [ master ]
+    branches: [ main ]
   pull_request:
-    branches: [ master ]
+    branches: [ main ]
   schedule:
   - cron: "0 5 * * *"
 


### PR DESCRIPTION
This PR adds .github/workflows/publish.yaml, which automates building an uploading the package to TestPyPI (on tags) and PyPI (on tags and GitHub releases).

## How to review

No review; packaging only.

## PR checklist

- [x] Continuous integration checks all ✅
- ~Add or expand tests; coverage checks both ✅~
- [x] Add, expand, or update documentation.
- ~Update release notes.~