### PR TITLE
Disable Sphinx builds on GHA under Python 3.6

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,7 +8,6 @@ on:
   schedule:
   - cron: "0 5 * * *"
 
-
 env:
   # See description in lint.yml
   depth: 100
@@ -23,19 +22,14 @@ jobs:
         - windows-latest
         python-version:
         - "3.6"  # Earliest version supported by ixmp
-        - "3.8"  # Latest version testable on GitHub Actions
-
-        # Commented: binary wheels also not available (as of 2020-10-22) for
-        # recently-released Python 3.9.
-        # TODO monitor https://pypi.org/project/[PKG]/#files for the packages
-        #      mentioned below; enable once wheels for "cp39" are available.
-        # - '3.9'  # Latest version / latest supported by ixmp
+        - "3.8"
+        - "3.9"  # Latest release / latest supported by ixmp
 
         # For development versions of Python, compiled binary wheels are not
         # available for some dependencies, e.g. llvmlite, numba, numpy, and/or
         # pandas. Compiling these on the job runner requires a more elaborate
         # build environment, currently out of scope for the ixmp project.
-        # - '3.10.0-alpha.1'  # Development version
+        # - "3.10.0-alpha.1"  # Development version
 
         exclude:
         # See https://github.com/iiasa/ixmp/issues/360

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -40,7 +40,7 @@ jobs:
         exclude:
         # See https://github.com/iiasa/ixmp/issues/360
         - os: windows-latest
-          python-version: '3.6'
+          python-version: "3.6"
 
       fail-fast: false
 
@@ -141,6 +141,7 @@ jobs:
       shell: Rscript {0}
 
     - name: Test documentation build using Sphinx
+      if: matrix.python-version != '3.6'
       run: make --directory=doc html
 
     - name: Upload test coverage to Codecov.io


### PR DESCRIPTION
Closes #413.

Also:
- Re-enable Python 3.9 builds.

## How to review

No review: CI adjustments only.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~
- ~Update release notes.~
