### PR TITLE
🚧 Add PyomoModel class

### DIFF
--- a/ixmp/__init__.py
+++ b/ixmp/__init__.py
@@ -8,7 +8,7 @@ from .backend.jdbc import JDBCBackend
 from .core import IAMC_IDX, Platform, Scenario, TimeSeries
 from .model import MODELS
 from .model.base import ModelError
-from .model.dantzig import DantzigModel
+from .model.dantzig import DantzigGAMSModel, DantzigPyomoModel
 from .model.gams import GAMSModel
 from .reporting import Reporter
 from .utils import show_versions
@@ -40,7 +40,9 @@ MODELS.update(
     {
         "default": GAMSModel,
         "gams": GAMSModel,
-        "dantzig": DantzigModel,
+        "dantzig": DantzigGAMSModel,
+        "dantzig-gams": DantzigGAMSModel,
+        "dantzig-pyomo": DantzigPyomoModel,
     }
 )
 

--- a/ixmp/model/pyomo.py
+++ b/ixmp/model/pyomo.py
@@ -1,0 +1,134 @@
+from inspect import signature
+
+try:
+    from pyomo import environ as pyo, opt
+    has_pyomo = True
+except ImportError:
+    has_pyomo = False
+
+from ixmp.model.base import Model
+
+
+COMPONENT = dict(
+    par=pyo.Param,
+    set=pyo.Set,
+    var=pyo.Var,
+    equ=pyo.Constraint,
+)
+
+
+def get_sets(model, names):
+    return [model.component(idx_set) for idx_set in names]
+
+
+class PyomoModel(Model):
+    """General class for ixmp models using :mod:`pyomo`."""
+    name = 'pyomo'
+
+    items = {}
+    constraints = {}
+    objective = None
+    _partials = {}
+
+    def __init__(self, name=None, solver='glpk'):
+        if not has_pyomo:
+            raise ImportError('pyomo must be installed')
+
+        self.opt = opt.SolverFactory(solver)
+
+        m = pyo.AbstractModel()
+
+        for name, info in self.items.items():
+            if name == self.objective:
+                # Handle the objective separately
+                continue
+
+            Component = COMPONENT[info['ix_type']]
+
+            kwargs = {}
+
+            if info['ix_type'] == 'equ':
+                func = self.equation[name]
+                params = signature(func).parameters
+                idx_sets = list(params.keys())[1:]
+                kwargs = dict(rule=func)
+            else:
+                idx_sets = info.get('idx_sets', None) or []
+
+                # NB would like to do this, but pyomo doesn't recognize partial
+                #    objects as callable
+                # if info['ix_type'] != 'var':
+                #     kwarg = dict(
+                #         initialize=partial(self.to_pyomo, name)
+                # )
+
+            kwargs.update(self.component_kwargs.get(name, {}))
+
+            component = Component(*get_sets(m, idx_sets), **kwargs)
+            m.add_component(name, component)
+
+        obj_func = self.equation[self.objective]
+        obj = pyo.Objective(rule=obj_func, sense=pyo.minimize)
+        m.add_component(self.objective, obj)
+
+        # Store
+        self.model = m
+
+    def to_pyomo(self, name):
+        info = self.items[name]
+        ix_type = info['ix_type']
+
+        if ix_type == 'par':
+            item = self.scenario.par(name)
+
+            idx_sets = info.get('idx_sets', []) or []
+            if len(idx_sets):
+                series = item.set_index(idx_sets)['value']
+                series.index = series.index.to_flat_index()
+                return series.to_dict()
+            else:
+                return {None: item['value']}
+        elif ix_type == 'set':
+            return {None: self.scenario.set(name).tolist()}
+
+    def all_to_pyomo(self):
+        return {None: dict(
+            filter(
+                lambda name_data: name_data[1],
+                [(name, self.to_pyomo(name)) for name in self.items]
+            )
+        )}
+
+    def all_from_pyomo(self, model):
+        for name, info in self.items.items():
+            if info['ix_type'] not in ('equ', 'var'):
+                continue
+            self.from_pyomo(model, name)
+
+    def from_pyomo(self, model, name):
+        component = model.component(name)
+        component.display()
+        try:
+            data = component.get_values()
+        except Exception as exc:
+            print(exc)
+            return
+
+        # TODO add to Scenario; currently not possible because ixmp_source does
+        # not allow setting elements of 'equ' and 'var'
+        del data
+
+    def run(self, scenario):
+        self.scenario = scenario
+
+        data = self.all_to_pyomo()
+
+        m = self.model.create_instance(data=data)
+
+        assert m.is_constructed()
+
+        results = self.opt.solve(m)
+
+        self.all_from_pyomo(m)
+
+        delattr(self, 'scenario')

--- a/ixmp/testing/data.py
+++ b/ixmp/testing/data.py
@@ -154,7 +154,9 @@ def add_test_data(scen: Scenario):
     return t, t_foo, t_bar, x
 
 
-def make_dantzig(mp: Platform, solve: bool = False, quiet: bool = False) -> Scenario:
+def make_dantzig(
+    mp: Platform, solve: bool = False, quiet: bool = False, scheme="dantzig-gams"
+) -> Scenario:
     """Return :class:`ixmp.Scenario` of Dantzig's canning/transport problem.
 
     Parameters
@@ -190,7 +192,7 @@ def make_dantzig(mp: Platform, solve: bool = False, quiet: bool = False) -> Scen
         **models["dantzig"],  # type: ignore [arg-type]
         version="new",
         annotation=annot,
-        scheme="dantzig",
+        scheme=scheme,
         with_data=True,
     )
 

--- a/ixmp/tests/test_model.py
+++ b/ixmp/tests/test_model.py
@@ -21,6 +21,26 @@ def test_base_model():
         M1()
 
 
+@pytest.mark.parametrize(
+    "kwargs",
+    [
+        dict(comment=None),
+        dict(equ_list=None, var_list=["x"]),
+        dict(equ_list=["demand", "supply"], var_list=[]),
+    ],
+    ids=["null-comment", "null-list", "empty-list"],
+)
+def test_GAMSModel(test_mp, test_data_path, kwargs):
+    s = make_dantzig(test_mp)
+    s.solve(model="dantzig", **kwargs)
+
+
+def test_PyomoModel(test_mp):
+    """Pyomo version of the Dantzig model builds and solves."""
+    s = make_dantzig(test_mp, scheme="dantzig-pyomo")
+    s.solve(model="dantzig-pyomo")
+
+
 def test_model_initialize(test_mp, caplog):
     # Model.initialize runs on an empty Scenario
     s = make_dantzig(test_mp)


### PR DESCRIPTION
**Do not merge**; development code.

This PR adds `ixmp.model.pyomo.PyomoModel`, a class that solves models via [Pyomo](https://pyomo.readthedocs.io/en/stable/index.html). Pyomo offers the option of using open-source solvers supported by Pyomo.

This is possible because Pyomo uses a similar data/information model (‘schema’) to AMPL and GAMS. (The Pyomo docs use the term “algebraic modeling language”, AML), and so aligns well with ixmp.

## How to review

To be added.

## PR checklist

- [ ] Complete the code.
- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.