### PR TITLE
Only reset_index() in format_scenario_list() when there are >0 results

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -48,5 +48,5 @@ jobs:
       run: |
         pip install mypy
         # Also install packages that contain type stubs
-        pip install pytest genno xarray
+        pip install pytest genno xarray types-setuptools
         mypy .

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -390,10 +390,11 @@ def format_scenario_list(
         platform.scenario_list(model=model, scen=scenario, default=default_only)
         .groupby(["model", "scenario"])
         .apply(describe)
-        .reset_index()
     )
 
-    if not len(info):
+    if len(info):
+        info = info.reset_index()
+    else:
         # No results; re-create a minimal empty data frame
         info = pd.DataFrame([], columns=["model", "scenario", "default", "N"])
 


### PR DESCRIPTION
With the upgrade of pandas to 1.3.0 `format_scenario_list()` should only `reset_index()` when there are >0 results. 
To satisfy the workflow Lint the package `types-setuptools` needed to be installed.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Update release notes. ✅
