### PR TITLE
🚧 Implement clone() in Python

### DIFF
--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -786,7 +786,7 @@ class Backend(ABC):
         scenario: str,
         annotation: str,
         keep_solution: bool,
-        first_model_year: int = None,
+        first_model_year: Optional[int],
     ) -> Union[TimeSeries, Scenario]:
         """Clone `ts`.
 

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -817,18 +817,29 @@ class JDBCBackend(CachingBackend):
         first_model_year=None,
     ):
         # Raise exceptions for limitations of JDBCBackend
-        if not isinstance(platform_dest._backend, self.__class__):
-            raise NotImplementedError(  # pragma: no cover
-                f"Clone between {self.__class__} and"
-                f"{platform_dest._backend.__class__}"
-            )
-        elif platform_dest._backend is not self:
+        if platform_dest._backend is not self:
             package = s.__class__.__module__.split(".")[0]
             msg = f"Cross-platform clone of {package}.Scenario with"
             if keep_solution is False:
                 raise NotImplementedError(f"{msg} `keep_solution=False`")
             elif "message_ix" in msg and first_model_year is not None:
                 raise NotImplementedError(f"{msg} first_model_year != None")
+
+        # # This condition replicates existing behaviour
+        # if not isinstance(platform_dest._backend, self.__class__):
+        # This condition is what is desired; see the PR
+        if True:
+            return super().clone(
+                s,
+                platform_dest,
+                model,
+                scenario,
+                annotation,
+                keep_solution,
+                first_model_year,
+            )
+
+        # Remaining code can be deleted once the PR is complete
 
         # Prepare arguments
         args = [platform_dest._backend.jobj, model, scenario, annotation, keep_solution]

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -1122,8 +1122,10 @@ class JDBCBackend(CachingBackend):
             return getattr(self.jindex[s], f"get{ix_type.title()}")(*args)
         except java.IxException as e:
             # Regex for similar but not consistent messages from Java code
-            msg = f"No (item|{ix_type.title()}) '?{name}'? exists in this " "Scenario!"
-            if re.match(msg, e.args[0]):
+            if re.match(
+                f"No (item|{ix_type.title()}) '?{name}'? exists in this Scenario!",
+                e.args[0],
+            ):
                 # Re-raise as a Python KeyError
                 raise KeyError(name) from None
             else:  # pragma: no cover

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -40,6 +40,9 @@ class Platform:
         Keyword arguments to specific to the `backend`. See :class:`.JDBCBackend`.
     """
 
+    #: Name of the platform.
+    name: str
+
     # Storage back end for the platform
     _backend: "Backend"
 
@@ -74,6 +77,8 @@ class Platform:
         if name:
             # Using a named platform config; retrieve it
             self.name, kwargs = config.get_platform_info(name)
+        else:
+            self.name = "(anonymous)"
 
         # Overwrite any platform config with explicit keyword arguments
         kwargs.update(backend_args)

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -716,19 +716,24 @@ class Scenario(TimeSeries):
             Platform to clone to (default: current platform)
         """
         if shift_first_model_year is not None:
+            if not isinstance(shift_first_model_year, int):
+                raise TypeError(
+                    "shift_first_model_year must be int; got "
+                    + str(type(shift_first_model_year))
+                )
             if keep_solution:
                 log.warning("Override keep_solution=True for shift_first_model_year")
                 keep_solution = False
 
-        platform = platform or self.platform
-        model = model or self.model
-        scenario = scenario or self.scenario
-
-        args = [platform, model, scenario, annotation, keep_solution]
-        if check_year(shift_first_model_year, "first_model_year"):
-            args.append(shift_first_model_year)
-
-        return self._backend("clone", *args)
+        return self._backend(
+            "clone",
+            platform or self.platform,
+            model or self.model,
+            scenario or self.scenario,
+            annotation,
+            keep_solution,
+            shift_first_model_year,
+        )
 
     def has_solution(self) -> bool:
         """Return :obj:`True` if the Scenario contains model solution data."""


### PR DESCRIPTION
**Do not merge**; development code.

This PR is a sketch of how to (re-)implement `clone()` in Python, to address #423, iiasa/message_ix#254, and other issues.

Some of the requirements:
- clone() must not only work across 2 Platforms sharing the same Backend class (e.g. both JDBCBackend), but across different Backend classes, e.g. between a JDBCBacken and #400 in either direction.

Things to check:
- That `ixmp_source` supports initializing and setting elements of 'variable' and 'equation'-type items.

  We've run into trouble with this in the past, e.g. working on #212, #315.

## How to review

To be added.

## PR checklist

- [ ] Complete the code.
  - [ ] Extend `item_set_elements()` to cover variables and equations.
  - [ ] Complete the TODOs in `clone()`.
- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.