### PR TITLE
Extend R installation dependencies

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -97,7 +97,7 @@ jobs:
 
     - name: Install R dependencies and tutorial requirements
       run: |
-        install.packages("remotes")
+        install.packages(c("remotes", "Rcpp"))
         remotes::install_cran(
           c("IRkernel", "reticulate"),
           dependencies = TRUE,


### PR DESCRIPTION
This PR extends the R installation dependencies with the installation of the package `Rcpp`. Merging this PR closes issue #426 

## How to review

No review; CI changes only.

## PR checklist

- [x] Continuous integration checks all ✅

