### PR TITLE
Address type hint errors

### DIFF
--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -160,7 +160,7 @@ class GAMSModel(Model):
     name = "default"
 
     #: Default values and format strings for options.
-    defaults: Mapping[str, object] = {
+    defaults: MutableMapping[str, Any] = {
         "model_file": "{model_name}.gms",
         "case": "{scenario.model}_{scenario.scenario}",
         "in_file": str(Path("{cwd}", "{model_name}_in.gdx")),

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -6,7 +6,7 @@ import tempfile
 from copy import copy
 from pathlib import Path
 from subprocess import CalledProcessError, check_call
-from typing import Mapping
+from typing import MutableMapping
 
 from ixmp.backend import ItemType
 from ixmp.model.base import Model, ModelError

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -6,7 +6,7 @@ import tempfile
 from copy import copy
 from pathlib import Path
 from subprocess import CalledProcessError, check_call
-from typing import MutableMapping
+from typing import Any, MutableMapping
 
 from ixmp.backend import ItemType
 from ixmp.model.base import Model, ModelError


### PR DESCRIPTION
This PR aims to address the type hint errors in gams.py and supports to close https://github.com/iiasa/ixmp/issues/429 and https://github.com/iiasa/message_ix/issues/538. To close the issue in message_ix and the failing lint workflow in message-ix-models (see PR https://github.com/iiasa/message-ix-models/pull/41), ixmp needs to be released once this PR is merged.

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅