### PR TITLE
Extend extras_require for report

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -32,7 +32,7 @@ docs =
     sphinx_rtd_theme
     sphinxcontrib-bibtex
 report =
-    genno[compat]
+    genno[compat,graphviz]
 tutorial =
     jupyter
 tests =


### PR DESCRIPTION
This PR extends the `extras_require` for `report` with `graphviz` and `plotnine`. See ToDos in `message_ix` [here](https://github.com/iiasa/message_ix/blob/main/setup.cfg#L58) and `message_data` [here](https://github.com/iiasa/message_data/blob/master/setup.cfg#L17).

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
