### PR TITLE
Simplify & improve configuration

### DIFF
--- a/doc/api.rst
+++ b/doc/api.rst
@@ -164,7 +164,7 @@ When imported, :mod:`ixmp` reads configuration from the first file named
 .. tip::
    For most users, #2 or #3 is a sensible default; platform information for many local and remote databases can be stored in ``config.json`` and retrieved by name.
 
-   Advanced users wishing to use a project-specific ``config.json`` can set ``IXMP_DATA`` to the directory containing this file.
+   Advanced users wishing to use a project-specific ``config.json`` can set ``IXMP_DATA`` to the path for any directory containing a file with this name.
 
 To manipulate the configuration file, use the ``platform`` command in the ixmp command-line interface::
 
@@ -178,7 +178,7 @@ To manipulate the configuration file, use the ``platform`` command in the ixmp c
   # Make 'p2' the default Platform
   $ ixmp platform add default p2
 
-…or, use the methods of :obj:`ixmp.config`.
+…or, use the methods of :data:`.ixmp.config`.
 
 .. currentmodule:: ixmp
 

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -73,7 +73,7 @@ def test_main(ixmp_cli, test_mp, tmp_path):
 def test_config(ixmp_cli):
     # ixmp has no string keys by default, so we insert a fake one
     ixmp.config.register("test key", str)
-    ixmp.config.values["test key"] = "foo"
+    ixmp.config.set("test key", "foo")
 
     # show() works
     assert ixmp_cli.invoke(["config", "show"]).output.startswith("Configuration path: ")
@@ -89,6 +89,9 @@ def test_config(ixmp_cli):
     # get() with a value is an invalid call
     result = ixmp_cli.invoke(["config", "get", "test key", "BADVALUE"])
     assert result.exit_code != 0
+
+    # Tidy up for other tests
+    ixmp.config.unregister("test key")
 
 
 def test_list(ixmp_cli, test_mp):

--- a/ixmp/tests/test_compat.py
+++ b/ixmp/tests/test_compat.py
@@ -3,7 +3,7 @@ from pathlib import Path
 
 import pytest
 
-from ixmp import _config, config
+from ixmp import config
 
 
 @pytest.fixture()
@@ -48,4 +48,4 @@ def test_message_model_dir(ixmp_cli, tmp_env, tmp_path):
 
     # Clean for remainder of tests
     config.unregister(key)
-    assert key not in _config.KEYS
+    assert key not in config.keys()


### PR DESCRIPTION
- Closes #434, #428.
- Since we thus now require Python 3.7, use [`dataclasses`](https://docs.python.org/3/library/dataclasses.html) from the standard library to streamline and simplify the `Config` class.
- Fix configuration bugs including #415.
- Support iiasa/message_ix#557.

## How to review

TBA.

## PR checklist

- [ ] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [ ] Update release notes.