### PR TITLE
Improve performance in add_par()

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -1,5 +1,5 @@
 Contributing to development
-===========================
+***************************
 
 The |MESSAGEix| software stack, including :mod:`ixmp` and :mod:`message_ix`, is developed by a single group of contributors in an integrated process.
 The MESSAGEix documentation contains :doc:`complete guidelines <message_ix:contributing>` for contributing to the code base, at: https://docs.messageix.org/en/latest/contributing.html.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- Improve performance in :meth:`.add_par` (:pull:`441`).
 - Minimum requirements are increased for dependencies (:pull:`435`):
 
   - Python 3.7 or greater. Python 3.6 reached end-of-life on 2021-12-31.

--- a/doc/contributing.rst
+++ b/doc/contributing.rst
@@ -1,1 +1,9 @@
 .. include:: ../CONTRIBUTING.rst
+
+Performance tests
+=================
+
+The test suite contains performance tests, which are disabled by the default options given in :file:`setup.cfg`.
+To run these, use::
+
+    pytest … --benchmark-only …

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -209,7 +209,7 @@ def s_read_excel(be, s, path, add_units=False, init_items=False, commit_steps=Fa
         except IndexError:
             break  # Finished
 
-        log.info(name)
+        # log.debug(name)
 
         first_pass = data is None
         if first_pass:

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -1213,25 +1213,19 @@ def to_jlist(arg, convert=None):
     -------
     java.LinkedList
     """
-    jlist = java.LinkedList()
-
     # Previously JPype1 (prior to 1.0) could take single argument in addAll method of
     # Java collection. As string implements Sequence contract in Python we need to
     # convert it explicitly to list here.
     if isinstance(arg, str):
         arg = [arg]
 
-    if convert:
-        arg = map(convert, arg)
-
-    if isinstance(arg, Sequence):
+    if convert is not None:
+        return java.LinkedList(list(map(convert, arg)))
+    elif isinstance(arg, Sequence):
         # Sized collection can be used directly
-        jlist.addAll(arg)
-
+        return java.LinkedList(arg)
     elif isinstance(arg, Iterable):
         # Transfer items from an iterable, generator, etc. to the LinkedList
-        [jlist.add(value) for value in arg]
+        return java.LinkedList(list(arg))
     else:
         raise ValueError(arg)
-
-    return jlist

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -502,8 +502,8 @@ class Scenario(TimeSeries):
         if "key" not in data.columns:
             # Form the 'key' column from other columns
             if N_dim > 1 and len(data):
-                data["key"] = data.apply(
-                    partial(as_str_list, idx_names=idx_names), axis=1
+                data["key"] = (
+                    data[idx_names].astype(str).agg(lambda s: s.tolist(), axis=1)
                 )
             else:
                 data["key"] = data[idx_names[0]]

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -1,5 +1,4 @@
 import logging
-from functools import partial
 from itertools import repeat, zip_longest
 from numbers import Real
 from os import PathLike

--- a/ixmp/tests/test_perf.py
+++ b/ixmp/tests/test_perf.py
@@ -8,17 +8,17 @@ from ixmp.testing import models
 from ixmp.testing.data import add_random_model_data
 
 
-def add_par_setup(mp, length):
+def add_par_setup(mp, length):  # pragma: no cover
     return (Scenario(mp, **models["dantzig"], version="new"), length), dict()
 
 
-def add_par(scen, length):
+def add_par(scen, length):  # pragma: no cover
     with scen.transact():
         add_random_model_data(scen, length)
 
 
 @pytest.mark.parametrize("length", [1e2, 1e3, 1e4, 1e6])
-def test_add_par(benchmark, test_mp, length):
+def test_add_par(benchmark, test_mp, length):  # pragma: no cover
     """Test performance of :meth:`.add_par`."""
     benchmark.pedantic(
         add_par,

--- a/ixmp/tests/test_perf.py
+++ b/ixmp/tests/test_perf.py
@@ -1,0 +1,26 @@
+"""Performance tests."""
+from functools import partial
+
+import pytest
+
+from ixmp import Scenario
+from ixmp.testing import models
+from ixmp.testing.data import add_random_model_data
+
+
+def add_par_setup(mp, length):
+    return (Scenario(mp, **models["dantzig"], version="new"), length), dict()
+
+
+def add_par(scen, length):
+    with scen.transact():
+        add_random_model_data(scen, length)
+
+
+@pytest.mark.parametrize("length", [1e2, 1e3, 1e4, 1e6])
+def test_add_par(benchmark, test_mp, length):
+    """Test performance of :meth:`.add_par`."""
+    benchmark.pedantic(
+        add_par,
+        setup=partial(add_par_setup, test_mp, length),
+    )

--- a/setup.cfg
+++ b/setup.cfg
@@ -59,6 +59,7 @@ tests =
     nbclient >= 0.5
     pretenders >= 1.4.4
     pytest >= 5
+    pytest-benchmark
     pytest-cov
 
 [options.entry_points]

--- a/setup.cfg
+++ b/setup.cfg
@@ -71,9 +71,10 @@ console_scripts =
 # - https://github.com/jpype-project/jpype/issues/561
 # - https://github.com/iiasa/ixmp/issues/229
 # - https://github.com/iiasa/ixmp/issues/247
-addopts = --cov=ixmp --cov-report=
-    -m "not rixmp and not performance"
+addopts = -m "not rixmp and not performance"
     -p no:faulthandler
+    --benchmark-skip
+    --cov=ixmp --cov-report=
 markers =
     rixmp: test of the ixmp R interface.
     performance: ixmp performance test.


### PR DESCRIPTION
This applies some simple optimizations in `Scenario.add_par()` and underlying backend code by using pandas' (fast) internals rather than (slower) utilities/code in `ixmp.utils`.

Anecdotally (using pytest-profiling) there is about a 50% speed-up in `message_data` test cases where the runtime is dominated by `add_par()`.

The branch also adds `.tests.test_perf.test_add_par()` using pytest-benchmark; these are invoked with `pytest -k perf --benchmark-only`. While I am not experienced with performance profiling, these results seem to show consistently better performance.
- I am not sure if the first two cases are erroneously displayed out of order.
- For adding 10⁶ data points, the improvement is about 20%.

```
## Code on `main`

-------------------------------------------------------------------------------------------- benchmark: 4 tests -------------------------------------------------------------------------------------------
Name (time in ms)                   Min                    Max                   Mean            StdDev                 Median               IQR            Outliers      OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_add_par[1000.0]            73.9765 (1.0)          73.9765 (1.0)          73.9765 (1.0)      0.0000 (1.0)          73.9765 (1.0)      0.0000 (1.0)           0;0  13.5178 (1.0)           1           1
test_add_par[100.0]            150.6392 (2.04)        150.6392 (2.04)        150.6392 (2.04)     0.0000 (1.0)         150.6392 (2.04)     0.0000 (1.0)           0;0   6.6384 (0.49)          1           1
test_add_par[10000.0]          432.8315 (5.85)        432.8315 (5.85)        432.8315 (5.85)     0.0000 (1.0)         432.8315 (5.85)     0.0000 (1.0)           0;0   2.3104 (0.17)          1           1
test_add_par[1000000.0]     39,330.8795 (531.67)   39,330.8795 (531.67)   39,330.8795 (531.67)   0.0000 (1.0)      39,330.8795 (531.67)   0.0000 (1.0)           0;0   0.0254 (0.00)          1           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

## This branch

-------------------------------------------------------------------------------------------- benchmark: 4 tests -------------------------------------------------------------------------------------------
Name (time in ms)                   Min                    Max                   Mean            StdDev                 Median               IQR            Outliers      OPS            Rounds  Iterations
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
test_add_par[1000.0]            66.0219 (1.0)          66.0219 (1.0)          66.0219 (1.0)      0.0000 (1.0)          66.0219 (1.0)      0.0000 (1.0)           0;0  15.1465 (1.0)           1           1
test_add_par[100.0]             67.3930 (1.02)         67.3930 (1.02)         67.3930 (1.02)     0.0000 (1.0)          67.3930 (1.02)     0.0000 (1.0)           0;0  14.8383 (0.98)          1           1
test_add_par[10000.0]          326.6322 (4.95)        326.6322 (4.95)        326.6322 (4.95)     0.0000 (1.0)         326.6322 (4.95)     0.0000 (1.0)           0;0   3.0615 (0.20)          1           1
test_add_par[1000000.0]     32,624.5220 (494.15)   32,624.5220 (494.15)   32,624.5220 (494.15)   0.0000 (1.0)      32,624.5220 (494.15)   0.0000 (1.0)           0;0   0.0307 (0.00)          1           1
-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------

Legend:
  Outliers: 1 Standard Deviation from Mean; 1.5 IQR (InterQuartile Range) from 1st Quartile and 3rd Quartile.
  OPS: Operations Per Second, computed as 1 / Mean
```

## How to review

- Read the diff of the following files:
  - ixmp/core/scenario.py
  - ixmp/backend/jdbc.py
- Optional:
  - Check out/install the branch.
  - Run code that is heavy on adding data to scenarios; e.g. in message_data `pytest -k "transport and build_bare"`.
  - Note the runtime/performance versus `main` or the last release.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.