### PR TITLE
Handle ±∞ in TimeSeries.add_timeseries()

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.4005665.svg)](https://doi.org/10.5281/zenodo.4005665)
 [![PyPI version](https://img.shields.io/pypi/v/ixmp.svg)](https://pypi.python.org/pypi/ixmp/)
 [![Anaconda version](https://img.shields.io/conda/vn/conda-forge/ixmp)](https://anaconda.org/conda-forge/ixmp)
-[![Documentation build](https://readthedocs.com/projects/iiasa-energy-program-ixmp/badge/?version=master)](https://docs.messageix.org/projects/ixmp/en/master/)
+[![Documentation build](https://readthedocs.com/projects/iiasa-energy-program-ixmp/badge/?version=latest)](https://docs.messageix.org/projects/ixmp/en/latest/)
 [![Build status](https://github.com/iiasa/ixmp/actions/workflows/pytest.yaml/badge.svg)](https://github.com/iiasa/ixmp/actions/workflows/pytest.yaml)
 [![Test coverage](https://codecov.io/gh/iiasa/ixmp/branch/master/graph/badge.svg)](https://codecov.io/gh/iiasa/ixmp)
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [`doc/README.rst`](doc/README.rst) for further details.
 
 ## License
 
-Copyright © 2017–2021 IIASA Energy, Climate, and Environment (ECE) program
+Copyright © 2017–2022 IIASA Energy, Climate, and Environment (ECE) program
 
 `ixmp` is licensed under the Apache License, Version 2.0 (the "License"); you
 may not use the files in this repository except in compliance with the License.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- Raise an informative :class:`ValueError` when adding infinite values with :meth:`.add_timeseries`; this is unsupported on :class:`.JDBCBackend` when connected to an Oracle database (:pull:`443`, :issue:`442`).
 - New attribute :attr:`.url` for convenience in constructing :class:`.TimeSeries`/:class:`.Scenario` URLS (:pull:`444`).
 - New :func:`.store_ts` reporting computation for storing time-series data on a :class:`.TimeSeries`/:class:`.Scenario` (:pull:`444`).
 - Improve performance in :meth:`.add_par` (:pull:`441`).

--- a/doc/api-backend.rst
+++ b/doc/api-backend.rst
@@ -49,7 +49,8 @@ Provided backends
 
    JDBCBackend has the following **limitations**:
 
-   - The `comment` argument to :meth:`Platform.add_unit` is limited to 64 characters.
+   - The `comment` argument to :meth:`.Platform.add_unit` is limited to 64 characters.
+   - Infinite floating-point values (:data:`numpy.inf`, :data:`math.inf`) cannot be stored using :meth:`.TimeSeries.add_timeseries` when using an Oracle database via ``driver='oracle'``.
 
    JDBCBackend's implementation allows the following kinds of file input and output:
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -21,7 +21,7 @@ import ixmp.testing
 # -- Project information ---------------------------------------------------------------
 
 project = "ix modeling platform"
-copyright = "2017–2021, IIASA Energy, Climate, and Environment (ECE) program"
+copyright = "2017–2022, IIASA Energy, Climate, and Environment (ECE) program"
 author = "ixmp Developers"
 
 

--- a/ixmp/core/timeseries.py
+++ b/ixmp/core/timeseries.py
@@ -353,7 +353,9 @@ class TimeSeries:
         # Add one time series per row
         for (r, v, u, sa), data in df.iterrows():
             # Values as float; exclude NA
-            self._backend("set_data", r, v, data.astype(float).dropna(), u, sa, meta)
+            self._backend(
+                "set_data", r, v, data.astype(float).dropna().to_dict(), u, sa, meta
+            )
 
     def timeseries(
         self,

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -10,7 +10,7 @@ from pytest import raises
 
 import ixmp
 import ixmp.backend.jdbc
-from ixmp.backend.jdbc import java
+from ixmp.backend.jdbc import DRIVER_CLASS, java
 from ixmp.testing import DATA, add_random_model_data, bool_param_id, make_dantzig
 from ixmp.testing.resource import memory_usage
 
@@ -123,15 +123,19 @@ class TestJDBCBackend:
 
         assert dict(driver="hsqldb", path=tmp_path) == klass.handle_config(args, kwargs)
 
-    def test_add_timeseries_inf(self, mp):
+    def test_set_data_inf(self, mp):
         """:meth:`JDBCBackend.set_data` errors on :data:`numpy.inf` values."""
-        ts = ixmp.TimeSeries(mp, "model name", "scenario name", version="new")
+        # Make `mp` think it is connected to an Oracle database
+        mp._backend._properties["jdbc.driver"] = DRIVER_CLASS["oracle"]
 
+        # TimeSeries object and data to add
+        ts = ixmp.TimeSeries(mp, "model name", "scenario name", version="new")
         data = DATA[0].assign(value=[np.inf, -np.inf])
 
-        with pytest.raises(FileNotFoundError):  # Not the actual exception
-            ts.add_timeseries(data)
-            ts.commit("")
+        with pytest.raises(
+            ValueError, match=r"infinity \(at region=World, variable=Testing\)"
+        ):
+            ts.add_timeseries(data)  # Calls JDBCBackend.set_data
 
     def test_read_file(self, tmp_path, be):
         """Cannot read CSV files."""


### PR DESCRIPTION
#442 appears to be related to handling ±`numpy.inf` in input to `TimeSeries.add_timeseries()`—possibly on Oracle databases.

This PR adds test and fixes the issue by:
- Store the DB properties when the JDBCBackend is first created.
- Check the driver and for infinite values in input data.
- Raise an informative exception.

## How to review

- View test_set_data_inf() in the diff.
- Try calling `.add_timeseries()` with infinite value when connected to a Oracle database via JDBCBackend gives the same kind of exception.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.