### PR TITLE
Add `store_ts` reporting computation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -31,15 +31,15 @@ For example, one or more of:
 
 <!-- This item is always required. -->
 - [ ] Continuous integration checks all ✅
-<!--
-The following items are all *required* if the PR results in changes to user-
-facing behaviour, e.g. new features or fixes to existing behaviour. They are
-*optional* if the changes are solely to documentation, CI configuration, etc.
-
-In ambiguous cases, strike them out and add a short explanation, e.g.
-
-- ~Add or expand tests.~ No change in behaviour, simply refactoring.
--->
+  <!--
+  The following items are all *required* if the PR results in changes to user-
+  facing behaviour, e.g. new features or fixes to existing behaviour. They are
+  *optional* if the changes are solely to documentation, CI configuration, etc.
+  
+  In ambiguous cases, strike them out and add a short explanation, e.g.
+  
+  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
+  -->
 - [ ] Add or expand tests; coverage checks both ✅
 - [ ] Add, expand, or update documentation.
 - [ ] Update release notes.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- New :func:`.store_ts` reporting computation for storing time-series data on a :class:`.TimeSeries`/:class:`.Scenario` (:pull:`444`).
 - Improve performance in :meth:`.add_par` (:pull:`441`).
 - Minimum requirements are increased for dependencies (:pull:`435`):
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -30,10 +30,10 @@ Code should use :func:`numpy.isscalar`.
 All changes
 -----------
 
-- :pull:`422`: Add :meth:`.TimeSeries.transact`, for wrapping data manipulations in :meth:`~.TimeSeries.check_out` and :meth:`~.TimeSeries.commit` operations.
-- :pull:`422`: Add :doc:`data-model`, a documentation page giving a complete description of the :mod:`ixmp` data model.
-- :pull:`422`: Add the :command:`pytest --user-config` command-line option, to use user's local configuration when testing.
-- :pull:`421`: Adjust :func:`.format_scenario_list` for changes in :mod:`pandas` 1.3.0.
+- Add :meth:`.TimeSeries.transact`, for wrapping data manipulations in :meth:`~.TimeSeries.check_out` and :meth:`~.TimeSeries.commit` operations (:pull:`422`).
+- Add :doc:`data-model`, a documentation page giving a complete description of the :mod:`ixmp` data model (:pull:`422`).
+- Add the :command:`pytest --user-config` command-line option, to use user's local configuration when testing (:pull:`422`).
+- Adjust :func:`.format_scenario_list` for changes in :mod:`pandas` 1.3.0 (:pull:`421`).
 
 
 .. _v3.3.0:
@@ -59,8 +59,8 @@ All changes
 - Add a `quiet` option to :meth:`.GAMSModel.solve` and use in testing (:pull:`399`).
 - Fix :class:`.GAMSModel` would try to write GDX data to filenames containing invalid characters on Windows (:pull:`398`).
 - Format user-friendly exceptions when GAMSModel errors (:issue:`383`, :pull:`398`).
-- Adjust :mod:`ixmp.reporting` to use :mod:`genno` (:pull:`397`:).
-- Fix two minor bugs in reporting (:pull:`396`:).
+- Adjust :mod:`ixmp.reporting` to use :mod:`genno` (:pull:`397`).
+- Fix two minor bugs in reporting (:pull:`396`).
 
 v3.2.0 (2021-01-24)
 ===================
@@ -68,15 +68,15 @@ v3.2.0 (2021-01-24)
 All changes
 -----------
 
-- :pull:`394`: Increase JPype minimum version to 1.2.1.
-- :pull:`391`: Adjust test suite for pandas v1.2.0.
-- :pull:`374`: Raise clearer exceptions from :meth:`.add_par` for incorrect parameters; silently handle empty data.
-- :pull:`389`: Depend on :mod:`openpyxl` instead of :mod:`xlrd` and :mod:`xlsxwriter` for Excel I/O; :mod:`xlrd` versions 2.0.0 and later do not support :file:`.xlsx`.
-- :pull:`367`: Add a parameter for exporting all model+scenario run versions to :meth:`.Platform.export_timeseries_data`, and fix a bug where exporting all runs happens uninteneded.
-- :pull:`378`: Silence noisy output from ignored exceptions on JDBCBackend/JVM shutdown.
-- :pull:`376`: Add a utility method, :func:`.gams_version`, to check the installed version of GAMS.
+- Increase JPype minimum version to 1.2.1 (:pull:`394`).
+- Adjust test suite for pandas v1.2.0 (:pull:`391`).
+- Raise clearer exceptions from :meth:`.add_par` for incorrect parameters; silently handle empty data (:pull:`374`).
+- Depend on :mod:`openpyxl` instead of :mod:`xlrd` and :mod:`xlsxwriter` for Excel I/O; :mod:`xlrd` versions 2.0.0 and later do not support :file:`.xlsx` (:pull:`389`).
+- Add a parameter for exporting all model+scenario run versions to :meth:`.Platform.export_timeseries_data`, and fix a bug where exporting all runs happens uninteneded (:pull:`367`).
+- Silence noisy output from ignored exceptions on JDBCBackend/JVM shutdown (:pull:`378`).
+- Add a utility method, :func:`.gams_version`, to check the installed version of GAMS (:pull:`376`).
   The result is displayed by the ``ixmp show-versions`` CLI command/:func:`.show_versions`.
-- :pull:`376`: :meth:`.init_par` and related methods accept any sequence (not merely :class:`list`) of :class:`str` for the `idx_sets` and `idx_names` arguments.
+- :meth:`.init_par` and related methods accept any sequence (not merely :class:`list`) of :class:`str` for the `idx_sets` and `idx_names` arguments (:pull:`376`).
 
 
 v3.1.0 (2020-08-28)
@@ -87,22 +87,22 @@ All changes
 
 ixmp v3.1.0 coincides with message_ix v3.1.0.
 
-- :pull:`345`: Fix a bug in :meth:`.read_excel` when parameter data is spread across multiple sheets.
-- :pull:`363`: Expand documentation and revise installation instructions.
-- :pull:`362`: Raise Python exceptions from :class:`.JDBCBackend`.
-- :pull:`354`: Add :meth:`Scenario.items`, :func:`.utils.diff`, and allow using filters in CLI command ``ixmp export``.
-- :pull:`353`: Add functionality for storing ‘meta’ (annotations of model names, scenario names, versions, and some combinations thereof).
+- Fix a bug in :meth:`.read_excel` when parameter data is spread across multiple sheets (:pull:`345`).
+- Expand documentation and revise installation instructions (:pull:`363`).
+- Raise Python exceptions from :class:`.JDBCBackend` (:pull:`362`).
+- Add :meth:`Scenario.items`, :func:`.utils.diff`, and allow using filters in CLI command ``ixmp export`` (:pull:`354`).
+- Add functionality for storing ‘meta’ (annotations of model names, scenario names, versions, and some combinations thereof) (:pull:`353`).
 
   - Add :meth:`.Backend.add_model_name`, :meth:`~.Backend.add_scenario_name`, :meth:`~.Backend.get_model_names`, :meth:`~.Backend.get_scenario_names`, :meth:`~.Backend.get_meta`, :meth:`~.Backend.set_meta`, :meth:`~.Backend.remove_meta`.
   - Allow these to be called from :class:`.Platform` instances.
   - Remove :meth:`.Scenario.delete_meta`.
 
-- :pull:`349`: Avoid modifying indexers dictionary in :meth:`.AttrSeries.sel`.
-- :pull:`343`: Add region/unit parameters to :meth:`.Platform.export_timeseries_data`.
-- :pull:`347`: Preserve dtypes of index columns in :func:`.data_for_quantity`.
-- :pull:`339`: ``ixmp show-versions`` includes the path to the default JVM used by JDBCBackend/JPype.
-- :pull:`317`: Make :class:`reporting.Quantity` classes interchangeable.
-- :pull:`330`: Use GitHub Actions for continuous testing and integration.
+- Avoid modifying indexers dictionary in :meth:`.AttrSeries.sel` (:pull:`349`).
+- Add region/unit parameters to :meth:`.Platform.export_timeseries_data` (:pull:`343`).
+- Preserve dtypes of index columns in :func:`.data_for_quantity` (:pull:`347`).
+- ``ixmp show-versions`` includes the path to the default JVM used by JDBCBackend/JPype (:pull:`339`).
+- Make :class:`reporting.Quantity` classes interchangeable (:pull:`317`).
+- Use GitHub Actions for continuous testing and integration (:pull:`330`).
 
 
 v3.0.0 (2020-06-05)
@@ -149,26 +149,24 @@ Deprecations and deprecation policy
 All changes
 -----------
 
-- :pull:`327`: Bump JPype dependency to 0.7.5.
-- :pull:`298`: Improve memory management in :class:`.JDBCBackend`.
-- :pull:`316`: Raise user-friendly exceptions from :meth:`.Reporter.get` in Jupyter notebooks and other read–evaluate–print loops (REPLs).
-- :pull:`315`: Ensure :meth:`.Model.initialize` is always called for new *and* cloned objects.
-- :pull:`320`: Add CLI command `ixmp show-versions` to print ixmp and dependency versions for debugging.
-- :pull:`314`: Bulk saving for metadata and exposing documentation API
-- :pull:`312`: Add :meth:`~.computations.apply_units`, :meth:`~computations.select` reporting calculations; expand :meth:`.Reporter.add`.
-- :pull:`310`: :meth:`.Reporter.add_product` accepts a :class:`.Key` with a tag; :func:`~.computations.aggregate` preserves :class:`.Quantity` attributes.
-- :pull:`304`: Add CLI command ``ixmp solve`` to run model solver.
-- :pull:`303`: Add `dims` and `units` arguments to :meth:`Reporter.add_file`; remove :meth:`Reporter.read_config` (redundant with :meth:`Reporter.configure`).
-- :pull:`295`: Add option to include `subannual` column in dataframe returned by :meth:`.TimeSeries.timeseries`.
-- :pull:`286`,
-  :pull:`297`,
-  :pull:`309`: Add :meth:`.Scenario.to_excel` and :meth:`.read_excel`; this functionality is transferred to ixmp from :mod:`message_ix` and enhanced for dealing with maximum row limits in Excel.
-- :pull:`270`: Include all tests in the ixmp package.
-- :pull:`212`: Add :meth:`Model.initialize` API to help populate new Scenarios according to a model scheme.
-- :pull:`267`: Apply units to reported quantities.
-- :pull:`261`: Increase minimum pandas version to 1.0; adjust for `API changes and deprecations <https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html#backwards-incompatible-api-changes>`_.
-- :pull:`243`: Add :meth:`.export_timeseries_data` to write data for multiple scenarios to CSV.
-- :pull:`264`: Implement methods to get and create new subannual timeslices.
+- Bump JPype dependency to 0.7.5 (:pull:`327`).
+- Improve memory management in :class:`.JDBCBackend` (:pull:`298`).
+- Raise user-friendly exceptions from :meth:`.Reporter.get` in Jupyter notebooks and other read–evaluate–print loops (REPLs) (:pull:`316`).
+- Ensure :meth:`.Model.initialize` is always called for new *and* cloned objects (:pull:`315`).
+- Add CLI command `ixmp show-versions` to print ixmp and dependency versions for debugging (:pull:`320`).
+- Bulk saving for metadata and exposing documentation AP (:pull:`314`)I
+- Add :meth:`~.computations.apply_units`, :meth:`~computations.select` reporting calculations; expand :meth:`.Reporter.add` (:pull:`312`).
+- :meth:`.Reporter.add_product` accepts a :class:`.Key` with a tag; :func:`~.computations.aggregate` preserves :class:`.Quantity` attributes (:pull:`310`).
+- Add CLI command ``ixmp solve`` to run model solver (:pull:`304`).
+- Add `dims` and `units` arguments to :meth:`Reporter.add_file`; remove :meth:`Reporter.read_config` (redundant with :meth:`Reporter.configure`) (:pull:`303`).
+- Add option to include `subannual` column in dataframe returned by :meth:`.TimeSeries.timeseries` (:pull:`295`).
+- Add :meth:`.Scenario.to_excel` and :meth:`.read_excel`; this functionality is transferred to ixmp from :mod:`message_ix` and enhanced for dealing with maximum row limits in Excel (:pull:`286`, :pull:`297`, :pull:`309`).
+- Include all tests in the ixmp package (:pull:`270`).
+- Add :meth:`Model.initialize` API to help populate new Scenarios according to a model scheme (:pull:`212`).
+- Apply units to reported quantities (:pull:`267`).
+- Increase minimum pandas version to 1.0; adjust for `API changes and deprecations <https://pandas.pydata.org/pandas-docs/version/1.0.0/whatsnew/v1.0.0.html#backwards-incompatible-api-changes>`_ (:pull:`261`).
+- Add :meth:`.export_timeseries_data` to write data for multiple scenarios to CSV (:pull:`243`).
+- Implement methods to get and create new subannual timeslices (:pull:`264`).
 
 
 v2.0.0 (2020-01-14)

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- New attribute :attr:`.url` for convenience in constructing :class:`.TimeSeries`/:class:`.Scenario` URLS (:pull:`444`).
 - New :func:`.store_ts` reporting computation for storing time-series data on a :class:`.TimeSeries`/:class:`.Scenario` (:pull:`444`).
 - Improve performance in :meth:`.add_par` (:pull:`441`).
 - Minimum requirements are increased for dependencies (:pull:`435`):

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -63,7 +63,7 @@ TimeSeries
    - Instantiating a new TimeSeries with the same `model` and `scenario` as an existing TimeSeries.
    - Calling :meth:`Scenario.clone`.
 
-   TimeSeries objects have the following methods:
+   TimeSeries objects have the following methods and attributes:
 
    .. autosummary::
       add_geodata
@@ -82,6 +82,7 @@ TimeSeries
       set_as_default
       timeseries
       transact
+      url
 
 
 Scenario

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -210,6 +210,7 @@ Utilities
       parse_url
       show_versions
       update_par
+      to_iamc_layout
 
 Testing utilities
 -----------------

--- a/doc/reporting.rst
+++ b/doc/reporting.rst
@@ -148,9 +148,15 @@ Computations
       ~genno.computations.combine
       ~genno.computations.concat
       ~genno.computations.disaggregate_shares
+      ~genno.computations.div
       ~genno.computations.group_sum
+      ~genno.computations.interpolate
       ~genno.computations.load_file
+      ~genno.computations.mul
+      ~genno.computations.pow
       ~genno.computations.product
+      ~genno.computations.relabel
+      ~genno.computations.rename_dims
       ~genno.computations.ratio
       ~genno.computations.select
       ~genno.computations.sum

--- a/doc/reporting.rst
+++ b/doc/reporting.rst
@@ -134,6 +134,7 @@ Computations
       data_for_quantity
       map_as_qty
       update_scenario
+      store_ts
 
    Basic computations are defined by :mod:`genno.computation`; and its compatibility modules; see there for details:
 

--- a/ixmp/core/timeseries.py
+++ b/ixmp/core/timeseries.py
@@ -244,6 +244,11 @@ class TimeSeries:
         """Get the run id of this TimeSeries."""
         return self._backend("run_id")
 
+    @property
+    def url(self) -> str:
+        """URL fragment for the TimeSeries."""
+        return f"{self.model}/{self.scenario}#{self.version}"
+
     # Time series data
 
     def preload_timeseries(self) -> None:

--- a/ixmp/core/timeseries.py
+++ b/ixmp/core/timeseries.py
@@ -246,7 +246,28 @@ class TimeSeries:
 
     @property
     def url(self) -> str:
-        """URL fragment for the TimeSeries."""
+        """URL fragment for the TimeSeries.
+
+        This has the format ``{model name}/{scenario name}#{version}``, with the same
+        values passed when creating the TimeSeries instance.
+
+        Examples
+        --------
+        To form a complete URL (e.g. to use with :meth:`.from_url`), use a configured
+        :class:`Platform` name:
+
+        >>> platform_name = "my-ixmp-platform"
+        >>> mp = Platform(platform_name)
+        >>> ts = TimeSeries(mp, "foo", "bar", 34)
+        >>> ts.url
+        "foo/bar#34"
+        >>> f"ixmp://{platform_name}/{ts.url}"
+        "ixmp://platform_name/foo/bar#34"
+
+        .. note:: Use caution: because Platform configuration is system-specific, other
+           systems must have the same configuration for `platform_name` in order for
+           the URL to refer to the same TimeSeries/Scenario.
+        """
         return f"{self.model}/{self.scenario}#{self.version}"
 
     # Time series data

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -181,6 +181,9 @@ def store_ts(scenario, *data):
         1 or more objects containing data to store. If :class:`pandas.DataFrame`, the
         data are passed through :func:`to_iamc_layout`.
     """
+    # TODO tolerate invalid types/errors on elements of `data`, logging exceptions on
+    #      level ERROR, then continue and commit anyway; add an optional parameter like
+    #      continue_on_error=True to control this behaviour
     import pyam
 
     log.info(f"Store time series data on '{scenario.url}'")

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -168,7 +168,19 @@ def map_as_qty(set_df: pd.DataFrame, full_set):
 
 
 def store_ts(scenario, *data):
-    """Store time series data on `scenario`."""
+    """Store time series `data` on `scenario`.
+
+    The data is stored using :meth:`.add_timeseries`; `scenario` is checked out and then
+    committed.
+
+    Parameters
+    ----------
+    scenario :
+        Scenario on which to store data.
+    data : pandas.DataFrame or pyam.IamDataFrame
+        1 or more objects containing data to store. If :class:`pandas.DataFrame`, the
+        data are passed through :func:`to_iamc_layout`.
+    """
     import pyam
 
     log.info(f"Store time series data on '{scenario.url}'")

--- a/ixmp/reporting/reporter.py
+++ b/ixmp/reporting/reporter.py
@@ -59,11 +59,11 @@ class Reporter(Computer):
             comps = keys_for_quantity(ix_type, name, scenario)
 
             # Add to the graph and index, including sums
-            rep.add(*comps[0], strict=True, index=True, sums=True)
+            rep.add(*comps[0], strict=True, sums=True)
 
             try:
                 # Add any marginals, but without sums
-                rep.add(*comps[1], strict=True, index=True)
+                rep.add(*comps[1], strict=True)
             except IndexError:
                 pass  # Not an equ/var with marginals
 

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -369,6 +369,10 @@ def test_solve(ixmp_cli, test_mp):
     assert result.exit_code == 1, result.output
     assert "Error: model='non-existing'" in result.output
 
+    result = ixmp_cli.invoke([f"--url=ixmp://{test_mp.name}/foo/bar", "solve"])
+    assert UsageError.exit_code == result.exit_code, result.output
+    assert "Error: not found" in result.output
+
     # no platform/scenario provided
     cmd = ["solve"]
     result = ixmp_cli.invoke(cmd)

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -318,13 +318,13 @@ def parse_url(url):
 
 
 def to_iamc_layout(df: pd.DataFrame) -> pd.DataFrame:
-    """Transform *df* to a standard IAMC layout.
+    """Transform `df` to the IAMC structure/layout.
 
     The returned object has:
 
     - Any (Multi)Index levels reset as columns.
     - Lower-case column names 'region', 'variable', 'subannual', and 'unit'.
-    - If not present in *df*, the value 'Year' in the 'subannual' column.
+    - If not present in `df`, the value 'Year' in the 'subannual' column.
 
     Parameters
     ----------

--- a/ixmp/utils.py
+++ b/ixmp/utils.py
@@ -456,7 +456,7 @@ def format_scenario_list(
     lines = []
 
     if as_url:
-        info["url"] = "ixmp://{}".format(platform.name)
+        info["url"] = f"ixmp://{platform.name}"
         urls = info["url"].str.cat([info["model"], info["scenario"]], sep="/")
         lines = urls.tolist()
     else:

--- a/setup.cfg
+++ b/setup.cfg
@@ -112,6 +112,8 @@ ignore_missing_imports = True
 ignore_missing_imports = True
 [mypy-pint.*]
 ignore_missing_imports = True
+[mypy-pyam.*]
+ignore_missing_imports = True
 [mypy-pretenders.*]
 ignore_missing_imports = True
 [mypy-requests_cache.*]

--- a/setup.cfg
+++ b/setup.cfg
@@ -53,6 +53,7 @@ tutorial =
     jupyter
 tests =
     %(docs)s
+    %(report)s
     %(tutorial)s
     codecov
     memory_profiler

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ zip_safe = True
 include_package_data = True
 install_requires =
     click
-    genno >= 1.6.0
+    genno >= 1.11.0
     JPype1 >= 1.2.1
     openpyxl
     pandas >= 1.2


### PR DESCRIPTION
`store_ts` accepts pd.DataFrame or pyam.IamDataFrame as input and stores the contents using `TimeSeries.add_timeseries()`.

Also:
- `TimeSeries.url` (`Scenario.url`) is a shorthand for constructing the URL of an object.
- Cleaner output from `ixmp solve` CLI when the target Scenario is not found.

## How to review

- Read the diff for computations.py and the added tests.
- Note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
  <!--
  The following items are all *required* if the PR results in changes to user-
  facing behaviour, e.g. new features or fixes to existing behaviour. They are
  *optional* if the changes are solely to documentation, CI configuration, etc.

  In ambiguous cases, strike them out and add a short explanation, e.g.

  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
  -->
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - :pull:`999`: Title or single-sentence description from above.

  Commit with a message like “Add #999 to release notes”
  -->
