### PR TITLE
Enable windows-latest-py3.10 job using JPype 1.4.0 binaries from PyPI

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,11 +33,6 @@ jobs:
         # for the ixmp project.
         # - "3.11.0-alpha.1"  # Development version
 
-        exclude:
-        # JPype1 binary wheels are not available for this combination
-        - os: windows-latest
-          python-version: "3.10"
-
       fail-fast: false
 
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- ~Add or expand tests; coverage checks both ✅~ N/A, CI only
- ~Add, expand, or update documentation.~
- ~Update release notes.~