### PR TITLE
Adjust typing for mypy 0.960 & other minor fixes

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,8 +1,10 @@
-.. Next release
-.. ============
+Next release
+============
 
-.. All changes
-.. -----------
+All changes
+-----------
+
+- Add :meth:`.enforce` to the :class:`~.base.Model` API for enforcing structure/data consistency before :meth:`.Model.solve` (:pull:`450`).
 
 .. _v3.5.0:
 

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -300,14 +300,14 @@ class Scenario(TimeSeries):
 
         # Combine iterators to tuples. If the lengths are mismatched, the sentinel
         # value 'False' is filled in
-        to_add = list(zip_longest(keys, comments, fillvalue=False))
+        to_add = list(zip_longest(keys, comments, fillvalue=(False,)))
 
         # Check processed arguments
         for e, c in to_add:
             # Check for sentinel values
-            if e is False:
+            if e == (False,):
                 raise ValueError(f"Comment {repr(c)} without matching key")
-            elif c is False:
+            elif c == (False,):
                 raise ValueError(f"Key {repr(e)} without matching comment")
             elif len(idx_names) and len(idx_names) != len(e):
                 raise ValueError(

--- a/ixmp/model/base.py
+++ b/ixmp/model/base.py
@@ -34,6 +34,26 @@ class Model(ABC):
         chars = r'<>"/\|?*' + (":" if os.name == "nt" else "")
         return re.sub("[{}]+".format(re.escape(chars)), "_", value)
 
+    @staticmethod
+    def enforce(scenario):
+        """Enforce data consistency in `scenario`.
+
+        Optional. Implementations of :meth:`enforce`:
+
+        - **should** modify the contents of sets and parameters so that `scenario`
+          contains structure and data that is consistent with the underlying model.
+        - **must not** add or remove sets or parameters; for that, use
+          :meth:`initiatize`.
+
+        :meth:`enforce` is always called by :meth:`run` before the model is run or
+        solved; it **may** be called manually at other times.
+
+        Parameters
+        ----------
+        scenario : .Scenario
+            Object on which to enforce data consistency.
+        """
+
     @classmethod
     def initialize(cls, scenario):
         """Set up *scenario* with required items.
@@ -160,6 +180,10 @@ class Model(ABC):
     @abstractmethod
     def run(self, scenario):
         """Execute the model.
+
+        Implementations of :meth:`run`:
+
+        - **must** call :meth:`enforce`.
 
         Parameters
         ----------

--- a/ixmp/model/base.py
+++ b/ixmp/model/base.py
@@ -62,8 +62,8 @@ class Model(ABC):
 
         - **may** add sets, set elements, and/or parameter values.
         - **may** accept any number of keyword arguments to control behaviour.
-        - **must not** modify existing parameter data in *scenario*, either by
-          deleting or overwriting values.
+        - **must not** modify existing parameter data in *scenario*, either by deleting
+          or overwriting values; for that, use :meth:`enforce`.
 
         Parameters
         ----------
@@ -80,12 +80,12 @@ class Model(ABC):
     def initialize_items(cls, scenario, items):
         """Helper for :meth:`initialize`.
 
-        All of the `items` are added to `scenario`. Existing items are not
-        modified. Errors are logged if the description in `items` conflicts
-        with the index set(s) and/or index name(s) of existing items.
+        All of the `items` are added to `scenario`. Existing items are not modified.
+        Errors are logged if the description in `items` conflicts with the index set(s)
+        and/or index name(s) of existing items.
 
-        initialize_items may perform one commit. `scenario` is in the same
-        state (checked in, or checked out) after initialize_items is complete.
+        initialize_items may perform one commit. `scenario` is in the same state
+        (checked in, or checked out) after initialize_items is complete.
 
         Parameters
         ----------
@@ -93,15 +93,15 @@ class Model(ABC):
             Object to initialize.
         items : dict of (str -> dict)
             Each key is the name of an ixmp item (set, parameter, equation, or
-            variable) to initialize. Each dict **must** have the key 'ix_type';
-            one of 'set', 'par', 'equ', or 'var'; any other entries are keyword
-            arguments to the methods :meth:`.init_set` etc.
+            variable) to initialize. Each dict **must** have the key 'ix_type'; one of
+            'set', 'par', 'equ', or 'var'; any other entries are keyword arguments to
+            the methods :meth:`.init_set` etc.
 
         Raises
         ------
         ValueError
-            if `scenario` has a solution, i.e. :meth:`~.Scenario.has_solution`
-            is :obj:`True`.
+            if `scenario` has a solution, i.e. :meth:`~.Scenario.has_solution` is
+            :obj:`True`.
 
         See also
         --------
@@ -155,10 +155,9 @@ class Model(ABC):
             try:
                 checkout = maybe_check_out(scenario, checkout)
             except ValueError as exc:  # pragma: no cover
-                # The Scenario has a solution. This indicates an inconsistent
-                # situation: the Scenario lacks the item *name*, but somehow it
-                # was successfully solved without it, and the solution stored.
-                # Can't proceed further.
+                # The Scenario has a solution. This indicates an inconsistent situation:
+                # the Scenario lacks the item *name*, but somehow it was successfully
+                # solved without it, and the solution stored. Can't proceed further.
                 log.error(str(exc))
                 return
 

--- a/ixmp/reporting/reporter.py
+++ b/ixmp/reporting/reporter.py
@@ -6,16 +6,25 @@ import pandas as pd
 from genno.core.computer import Computer, Key
 
 from ixmp.core.scenario import Scenario
-from ixmp.reporting import computations
 from ixmp.reporting.util import RENAME_DIMS, keys_for_quantity
 
 
 class Reporter(Computer):
     """Class for describing and executing computations."""
 
-    # Append ixmp.reporting.computations to the modules in which the Computer will look
-    # up computations names.
-    modules = list(Computer.modules) + [computations]
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+
+        # Append ixmp.reporting.computations to the modules in which the Computer will
+        # look up computations names.
+        # genno <= 1.11
+        from ixmp.reporting import computations
+
+        if computations not in self.modules:
+            self.modules.append(computations)
+
+        # TODO use this once genno >= 1.12.0 is released
+        # self.require_compat("ixmp.reporting.computations")
 
     @classmethod
     def from_scenario(cls, scenario: Scenario, **kwargs) -> "Reporter":


### PR DESCRIPTION
- Closes #449
- In `.reporting`, uses the improved functionality of `Computer.require_compat()` from genno 1.11 to ensure `ixmp.reporting.computations` are available for use.
- Add and document the `Model.enforce()` method for adjusting scenario contents to be consistent with model representations; introduced downstream in iiasa/message_ix#561, also used in iiasa/message_ix#514.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.