### PR TITLE
Miscellaneous improvements for 2022-W30

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,10 @@ Next release
 All changes
 -----------
 
+- Optionally tolerate failures to add individual items in :func:`.store_ts` reporting computation (:pull:`451`); use ``timeseries_only=True`` in check-out to function with :class:`.Scenario` with solution data stored.
+- Bugfix: :class:`.Config` squashed configuration values read from :file:`config.json`, if the respective keys were registered in downstream packages, e.g. :mod:`message_ix`.
+  Allow the values loaded from file to persist (:pull:`451`).
+- Adjust to genno 1.12 and set this as the minimum required version (:pull:`451`).
 - Add :meth:`.enforce` to the :class:`~.base.Model` API for enforcing structure/data consistency before :meth:`.Model.solve` (:pull:`450`).
 
 .. _v3.5.0:

--- a/doc/api-model.rst
+++ b/doc/api-model.rst
@@ -32,16 +32,22 @@ Model API
 .. currentmodule:: ixmp.model.base
 
 .. autoclass:: ixmp.model.base.Model
-   :members: name, __init__, initialize, initialize_items, run
+   :members: name, __init__, run, initialize, initialize_items, enforce
 
    In the following, the words **required**, **optional**, etc. have specific meanings as described in `IETF RFC 2119 <https://tools.ietf.org/html/rfc2119>`_.
 
-   Model is an **abstract** class; this means it MUST be subclassed.
-   It has two REQURIED methods that MUST be overridden by subclasses:
+   Model is an *abstract* class; this means it **must** be subclassed.
+   It has two **required** methods that **must** be overridden by subclasses:
 
    .. autosummary::
-      name
       __init__
+      run
+
+   The following attributes and methods are **optional** in subclasses.
+   The default implementations are either empty or implement reasonable default behaviour.
+
+   .. autosummary::
+      enforce
       initialize
       initialize_items
-      run
+      name

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -805,7 +805,16 @@ class JDBCBackend(CachingBackend):
         # Integer so JPype does not produce invalid java.lang.Long.
         jdata = java.LinkedHashMap({java.Integer(k): v for k, v in data.items()})
 
-        self.jindex[ts].addTimeseries(region, variable, subannual, jdata, unit, meta)
+        try:
+            self.jindex[ts].addTimeseries(
+                region, variable, subannual, jdata, unit, meta
+            )
+        except java.IxException as e:
+            match = re.search("node '([^']*)' does not exist in the database", str(e))
+            if match:
+                raise ValueError(f"region = {match.group(1)}") from None
+            else:
+                raise
 
     def set_geo(self, ts, region, variable, subannual, year, value, unit, meta):
         self.jindex[ts].addGeoData(

--- a/ixmp/model/base.py
+++ b/ixmp/model/base.py
@@ -14,11 +14,13 @@ class ModelError(Exception):
 
 class Model(ABC):
     #: Name of the model.
-    name = "base"
+    name: str = "base"
 
     @abstractmethod
     def __init__(self, name, **kwargs):
         """Constructor.
+
+        **Required.**
 
         Parameters
         ----------
@@ -38,12 +40,13 @@ class Model(ABC):
     def enforce(scenario):
         """Enforce data consistency in `scenario`.
 
-        Optional. Implementations of :meth:`enforce`:
+        **Optional**; the default implementation does nothing. Subclass implementations
+        of :meth:`enforce`:
 
         - **should** modify the contents of sets and parameters so that `scenario`
           contains structure and data that is consistent with the underlying model.
         - **must not** add or remove sets or parameters; for that, use
-          :meth:`initiatize`.
+          :meth:`initialize`.
 
         :meth:`enforce` is always called by :meth:`run` before the model is run or
         solved; it **may** be called manually at other times.
@@ -58,7 +61,8 @@ class Model(ABC):
     def initialize(cls, scenario):
         """Set up *scenario* with required items.
 
-        Implementations of :meth:`initialize`:
+        **Optional**; the default implementation does nothing. Subclass implementations
+        of :meth:`initialize`:
 
         - **may** add sets, set elements, and/or parameter values.
         - **may** accept any number of keyword arguments to control behaviour.
@@ -180,9 +184,10 @@ class Model(ABC):
     def run(self, scenario):
         """Execute the model.
 
-        Implementations of :meth:`run`:
+        **Required.** Implementations of :meth:`run`:
 
         - **must** call :meth:`enforce`.
+
 
         Parameters
         ----------

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -222,9 +222,12 @@ def update_scenario(scenario, *quantities, params=[]):
         if not isinstance(qty, pd.DataFrame):
             # Convert a Quantity to a DataFrame
             par_name = qty.name
-            new = qty.to_series().reset_index().rename(columns={par_name: "value"})
-            new["unit"] = "{:~}".format(qty.attrs["_unit"])  # type: ignore [str-format]
-            qty = new
+            qty = (
+                qty.to_series()
+                .reset_index()
+                .rename(columns={par_name: "value"})
+                .assign(unit=f"{qty.units:~}")
+            )
 
         # Add the data
         log.info(f"  {repr(par_name)} ← {len(qty)} rows")

--- a/ixmp/reporting/computations.py
+++ b/ixmp/reporting/computations.py
@@ -187,7 +187,7 @@ def store_ts(scenario, *data):
     import pyam
 
     log.info(f"Store time series data on '{scenario.url}'")
-    scenario.check_out()
+    scenario.check_out(timeseries_only=True)
 
     for order, df in enumerate(data):
         df = (

--- a/ixmp/reporting/reporter.py
+++ b/ixmp/reporting/reporter.py
@@ -17,14 +17,7 @@ class Reporter(Computer):
 
         # Append ixmp.reporting.computations to the modules in which the Computer will
         # look up computations names.
-        # genno <= 1.11
-        from ixmp.reporting import computations
-
-        if computations not in self.modules:
-            self.modules.append(computations)
-
-        # TODO use this once genno >= 1.12.0 is released
-        # self.require_compat("ixmp.reporting.computations")
+        self.require_compat("ixmp.reporting.computations")
 
     @classmethod
     def from_scenario(cls, scenario: Scenario, **kwargs) -> "Reporter":

--- a/ixmp/tests/reporting/test_computations.py
+++ b/ixmp/tests/reporting/test_computations.py
@@ -4,7 +4,7 @@ from functools import partial
 import pandas as pd
 import pyam
 import pytest
-from genno import Computer, Quantity
+from genno import ComputationError, Computer, Quantity
 from genno.testing import assert_qty_equal
 from pandas.testing import assert_frame_equal
 
@@ -135,3 +135,11 @@ def test_store_ts(request, caplog, test_mp):
     # Input is stored exactly
     assert_frame_equal(expected_1, scen.timeseries(variable="Foo"))
     assert_frame_equal(expected_2, scen.timeseries(variable="Bar"))
+
+    # Data with an unregistered region name
+    c.add("input 3", test_data[0].assign(variable="Foo", region="Moon"))
+    c.add("test 2", store_ts, "target", "input 3")
+
+    # The computation fails
+    with pytest.raises(ComputationError, match="baz"):
+        c.get("test 2")

--- a/ixmp/tests/reporting/test_reporter.py
+++ b/ixmp/tests/reporting/test_reporter.py
@@ -166,7 +166,6 @@ def test_cli(ixmp_cli, test_mp, test_data_path):
     # TODO warning should be logged
 
     # Reporting produces the expected command-line output
-
     assert re.match(
         "i          j       "  # Trailing whitespace
         r"""
@@ -176,8 +175,7 @@ san-diego  chicago     1\.8
 seattle    chicago     1\.7
            new-york    2\.5
            topeka      1\.8
-(Name: value, )?dtype: float64
-""",
+(Name: value, )?dtype: float64(, units: dimensionsless)?""",
         result.output,
     )
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -30,7 +30,7 @@ zip_safe = True
 include_package_data = True
 install_requires =
     click
-    genno >= 1.11.0
+    genno >= 1.12.0
     JPype1 >= 1.2.1
     openpyxl
     pandas >= 1.2


### PR DESCRIPTION
- Adjust to genno 1.12 and set this as the minimum required version.
- Handle a ValueError in `TimeSeries.add_timeseries()` / `JDBCBackend.set_data()`; partly addresses #296.
- Bugfix in `ixmp._config.Config`: config values loaded from file were squashed with defaults, if (and only if) those defaults were set downstream, e.g. in message-ix, message-ix-models, or message-data. Preserve the values, as expected.
- Improve `.reporting.computations.update_ts()`:
  - Use `TimeSeries.check_out(…, timeseries_only=True)`.
  - Tolerate failure to add each individual item, add optional strict argument.
- Simplify units handling in `.reporting.computations.update_scenario()`

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.