### PR TITLE
Confirm compatibility with pandas 2.0.0rc0

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,6 @@ jobs:
   lint:
     uses: iiasa/actions/.github/workflows/lint.yaml@main
     with:
-      max-complexity: 26
       # If the "Latest version testable on GitHub Actions" in pytest.yaml
       # is not the latest 3.x stable version, adjust here to match:
       python-version: "3.10"

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,14 +29,15 @@ jobs:
         - "3.7"  # Earliest version supported by ixmp
         - "3.8"
         - "3.9"
-        - "3.10"  # Latest release / latest supported by ixmp
+        - "3.10"  # Latest supported by ixmp
 
         # For fresh releases and development versions of Python, compiled
         # binary wheels are not available for some dependencies, e.g. llvmlite,
         # numba, numpy, and/or pandas. Compiling these on the job runner
         # requires a more elaborate build environment, currently out of scope
         # for the ixmp project.
-        # - "3.11.0-alpha.1"  # Development version
+        # - "3.11"  # Latest release; pending numba/numba#8304
+        # - "3.12.0-alpha.1"  # Development version
 
         # commented: force a specific version of pandas, for e.g. pre-release
         # testing

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -32,9 +32,14 @@ jobs:
         # requires a more elaborate build environment, currently out of scope
         # for the ixmp project.
         # - "3.11.0-alpha.1"  # Development version
+
         pandas-version:
         - ""
         - "==2.0.0rc0"
+
+        exclude:
+        - python-version: "3.7"
+          pandas-version: "==2.0.0rc0"
 
       fail-fast: false
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -8,6 +8,11 @@ on:
   schedule:
   - cron: "0 5 * * *"
 
+# Cancel previous runs that have not completed
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 env:
   # See description in lint.yml
   depth: 100
@@ -47,11 +52,6 @@ jobs:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}
 
     steps:
-    - name: Cancel previous runs that have not completed
-      uses: styfle/cancel-workflow-action@0.11.0
-      with:
-        access_token: ${{ github.token }}
-
     - uses: actions/checkout@v3
       with:
         fetch-depth: ${{ env.depth }}

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -32,11 +32,14 @@ jobs:
         # requires a more elaborate build environment, currently out of scope
         # for the ixmp project.
         # - "3.11.0-alpha.1"  # Development version
+        pandas-version:
+        - ""
+        - "==2.0.0rc0"
 
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}-py${{ matrix.python-version }}
+    name: ${{ matrix.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}
 
     steps:
     - name: Cancel previous runs that have not completed
@@ -89,6 +92,7 @@ jobs:
     - name: Install Python package and dependencies
       run: |
         pip install .[tests]
+        pip install --upgrade pandas${{ matrix.pandas-version }}
         # TEMPORARY work around iiasa/ixmp#463
         pip install "JPype1 != 1.4.1"
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -38,18 +38,24 @@ jobs:
         # for the ixmp project.
         # - "3.11.0-alpha.1"  # Development version
 
-        pandas-version:
-        - ""
-        - "==2.0.0rc0"
+        # commented: force a specific version of pandas, for e.g. pre-release
+        # testing
+        # pandas-version:
+        # - ""
+        # - "==2.0.0rc0"
 
-        exclude:
-        - python-version: "3.7"
-          pandas-version: "==2.0.0rc0"
+        exclude: [ ]
+        # # Specific version combinations that are invalid, e.g. pandas 2.0
+        # # requires Python >= 3.8
+        # - python-version: "3.7"
+        #   pandas-version: "==2.0.0rc0"
 
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}
+    name: ${{ matrix.os }}-py${{ matrix.python-version }}
+    # commented: use with "pandas-version" in the matrix, above
+    # name: ${{ matrix.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}
 
     steps:
     - uses: actions/checkout@v3
@@ -97,7 +103,8 @@ jobs:
     - name: Install Python package and dependencies
       run: |
         pip install .[tests]
-        pip install --upgrade pandas${{ matrix.pandas-version }}
+        # commented: use with "pandas-version" in the matrix, above
+        # pip install --upgrade pandas${{ matrix.pandas-version }}
         # TEMPORARY work around iiasa/ixmp#463
         pip install "JPype1 != 1.4.1"
 

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,9 @@ Next release
 All changes
 -----------
 
+- :mod:`ixmp` is tested and compatible with `pandas 2.0.0 <https://pandas.pydata.org/pandas-docs/version/2.0/whatsnew/v2.0.0.html>`__ (:pull:`471`).
+  Note that `pandas 1.4.0 dropped support for Python 3.7 <https://pandas.pydata.org/docs/whatsnew/v1.4.0.html#increased-minimum-version-for-python>`__: thus while :mod:`ixmp` still supports Python 3.7 this is achieved with pandas 1.3.x, which may not receive further updates (the last patch release was in December 2021).
+  Support for Python 3.7 will be dropped in a future version of :mod:`ixmp`, and users are encouraged to upgrade to a newer version of Python.
 - Bugfix: `year` argument to :meth:`.TimeSeries.timeseries` accepts :class:`int` or :class:`list` of :class:`int` (:issue:`440`, :pull:`469`).
 - Adjust to pandas 1.5.0 (:pull:`458`).
 - New module :mod:`.util.sphinx_linkcode_github` to link documentation to source code on GitHub (:pull:`459`).

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -172,9 +172,10 @@ def maybe_init_item(scenario, ix_type, name, new_idx, path):
             raise ValueError from None
 
 
-# FIXME reduce complexity. Currently 26; next highest is JDBCBackend.item_get_elements
-#       at 19
-def s_read_excel(be, s, path, add_units=False, init_items=False, commit_steps=False):
+# FIXME reduce complexity from 26 to <=15
+def s_read_excel(  # noqa: C901
+    be, s, path, add_units=False, init_items=False, commit_steps=False
+):
     """Read data from a Microsoft Excel file at *path* into *s*.
 
     See also

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -917,7 +917,8 @@ class JDBCBackend(CachingBackend):
         jitem = self._get_item(s, "item", name, load=False)
         return list(getattr(jitem, f"getIdx{sets_or_names.title()}")())
 
-    def item_get_elements(self, s, type, name, filters=None):
+    # FIXME reduce complexity from 19 to <=15
+    def item_get_elements(self, s, type, name, filters=None):  # noqa: C901
         if filters:
             # Convert filter elements to strings
             filters = {dim: as_str_list(ele) for dim, ele in filters.items()}

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -208,7 +208,8 @@ class Scenario(TimeSeries):
         """
         return self._backend("item_get_elements", "set", name, filters)
 
-    def add_set(
+    # FIXME reduce complexity from 17 to <=15
+    def add_set(  # noqa: C901
         self,
         name: str,
         key: Union[str, Sequence[str], Dict, pd.DataFrame],

--- a/setup.cfg
+++ b/setup.cfg
@@ -67,4 +67,9 @@ console_scripts =
     ixmp = ixmp.cli:main
 
 [flake8]
+# FIXME the following exceed this limit
+# .backend.io.s_read_excel: 26
+# .backend.jdbc.JDBCBackend.item_get_elements: 19
+# .core.scenario.Scenario.add_set: 17
+max-complexity = 15
 max-line-length = 88


### PR DESCRIPTION
This PR:
- Was used to temporarily run the test suite against the pandas 2.0.0rc0 pre-release and confirm all tests pass [see here](https://github.com/iiasa/ixmp/actions/runs/4322403190/jobs/7544782246).
- Updates the release notes with details about pandas and Python versions.

Closes #470.

## How to review

Read the additions to the release notes and confirm they are clear.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- [x] Update release notes.