### PR TITLE
Adjust for genno 1.16

### DIFF
--- a/ixmp/tests/reporting/test_reporter.py
+++ b/ixmp/tests/reporting/test_reporter.py
@@ -75,7 +75,8 @@ def test_platform_units(test_mp, caplog, ureg):
     bad_units = [
         ("-", "-", "-"),
         ("???", r"\?\?\?", r"\?\?\?"),
-        ("E$", r"E\$", r"\$"),
+        # Disabled pending https://github.com/hgrecco/pint/issues/1766
+        # ("E$", r"E\$", r"\$"),
     ]
     for unit, expr, chars in bad_units:
         # Add the unit

--- a/ixmp/tests/reporting/test_reporter.py
+++ b/ixmp/tests/reporting/test_reporter.py
@@ -69,12 +69,12 @@ def test_platform_units(test_mp, caplog, ureg):
     x = x.to_series().rename("value").reset_index()
 
     # Exception message, formatted as a regular expression
-    msg = r"unit '{}' cannot be parsed; contains invalid character\(s\) '{}'"
+    msg = r"unit '{}' cannot be parsed; contains invalid character\(s\) '{}+'"
 
     # Unit and components for the regex
     bad_units = [
         ("-", "-", "-"),
-        ("???", r"\?\?\?", r"\?\?\?"),
+        ("???", r"\?\?\?", r"\?"),
         # Disabled pending https://github.com/hgrecco/pint/issues/1766
         # ("E$", r"E\$", r"\$"),
     ]

--- a/ixmp/tests/reporting/test_reporter.py
+++ b/ixmp/tests/reporting/test_reporter.py
@@ -72,7 +72,11 @@ def test_platform_units(test_mp, caplog, ureg):
     msg = r"unit '{}' cannot be parsed; contains invalid character\(s\) '{}'"
 
     # Unit and components for the regex
-    bad_units = [("-", "-", "-"), ("???", r"\?\?\?", r"\?"), ("E$", r"E\$", r"\$")]
+    bad_units = [
+        ("-", "-", "-"),
+        ("???", r"\?\?\?", r"\?\?\?"),
+        ("E$", r"E\$", r"\$"),
+    ]
     for unit, expr, chars in bad_units:
         # Add the unit
         test_mp.add_unit(unit)


### PR DESCRIPTION
genno 1.16 slightly changed the messages on unparseable pint units, to be more informative. This PR adjusts one test to check for the newer message.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update release notes.~