### PR TITLE
Support Python 3.11

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,7 +10,10 @@ jobs:
   lint:
     uses: iiasa/actions/.github/workflows/lint.yaml@main
     with:
-      # If the "Latest version testable on GitHub Actions" in pytest.yaml
-      # is not the latest 3.x stable version, adjust here to match:
-      python-version: "3.10"
-      type-hint-packages: pytest genno GitPython nbclient nbformat xarray sphinx
+      type-hint-packages: >-
+        genno
+        GitPython
+        nbclient
+        pytest
+        sphinx
+        xarray

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -96,10 +96,13 @@ jobs:
     - name: Install Python package and dependencies
       run: |
         pip install .[tests]
+
         # commented: use with "pandas-version" in the matrix, above
         # pip install --upgrade pandas${{ matrix.pandas-version }}
-        # TEMPORARY work around iiasa/ixmp#463
-        pip install "JPype1 != 1.4.1"
+
+    - name: TEMPORARY Work around iiasa/ixmp#463
+      if: matrix.python-version != '3.11'
+      run: pip install "JPype1 != 1.4.1"
 
     - name: Install R dependencies and tutorial requirements
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -29,15 +29,8 @@ jobs:
         - "3.7"  # Earliest version supported by ixmp
         - "3.8"
         - "3.9"
-        - "3.10"  # Latest supported by ixmp
-
-        # For fresh releases and development versions of Python, compiled
-        # binary wheels are not available for some dependencies, e.g. llvmlite,
-        # numba, numpy, and/or pandas. Compiling these on the job runner
-        # requires a more elaborate build environment, currently out of scope
-        # for the ixmp project.
-        # - "3.11"  # Latest release; pending numba/numba#8304
-        # - "3.12.0-alpha.1"  # Development version
+        - "3.10"
+        - "3.11"  # Latest supported by ixmp
 
         # commented: force a specific version of pandas, for e.g. pre-release
         # testing

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- :mod:`ixmp` is tested and compatible with `Python 3.11 <https://www.python.org/downloads/release/python-3110/>`__ (:pull:`481`).
 - :mod:`ixmp` is tested and compatible with `pandas 2.0.0 <https://pandas.pydata.org/pandas-docs/version/2.0/whatsnew/v2.0.0.html>`__ (:pull:`471`).
   Note that `pandas 1.4.0 dropped support for Python 3.7 <https://pandas.pydata.org/docs/whatsnew/v1.4.0.html#increased-minimum-version-for-python>`__: thus while :mod:`ixmp` still supports Python 3.7 this is achieved with pandas 1.3.x, which may not receive further updates (the last patch release was in December 2021).
   Support for Python 3.7 will be dropped in a future version of :mod:`ixmp`, and users are encouraged to upgrade to a newer version of Python.

--- a/doc/references.bib
+++ b/doc/references.bib
@@ -1,8 +1,5 @@
 @article{huppmann_messageix_2018,
-   author = {Huppmann, Daniel and Gidden, Matthew and Fricko, Oliver and
-             Kolp, Peter and Orthofer, Clara and Pimmer, Michael and
-             Kushin, Nikolay and Vinca, Adriano and Mastrucci, Alessio and
-             Riahi, Keywan and Krey, Volker},
+   author = {Huppmann, Daniel and Gidden, Matthew and Fricko, Oliver and Kolp, Peter and Orthofer, Clara and Pimmer, Michael and Kushin, Nikolay and Vinca, Adriano and Mastrucci, Alessio and Riahi, Keywan and Krey, Volker},
    title = {{The MESSAGEix Integrated Assessment Model and the ix modeling platform (ixmp): An open framework for integrated and cross-cutting analysis of energy, climate, the environment, and sustainable development}},
    journal = {Environmental Modelling \& Software},
    volume = {112},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,9 @@ classifiers = [
 ]
 dependencies = [
   "click",
-  "genno >= 1.12.0",
-  'importlib_metadata; python_version < "3.8"',
+  "genno <= 1.13; python_version < '3.8'",
+  "genno >= 1.16; python_version >= '3.8'",
+  "importlib_metadata; python_version < '3.8'",
   "JPype1 >= 1.2.1",
   "openpyxl",
   "pandas >= 1.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ classifiers = [
   "Programming Language :: Python :: 3.8",
   "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
   "Programming Language :: R",
   "Topic :: Scientific/Engineering",
   "Topic :: Scientific/Engineering :: Information Analysis",


### PR DESCRIPTION
Take advantage of `genno` >= 1.16, in which `sparse` is an optional/extra dependency.

Previously, via genno → sparse → numba → llvmlite, it was not possible to install/test ixmp with the latest Python; for example, Python 3.11 was released 2022-10-24, but numba 0.57 supporting Python 3.11 was not released until 2023-05-03, a lag of ~6 months.

Notes:
- For #463, we forced a downgrade of JPype1 to < 1.4.1. But JPype1 <= 1.4.0 is not available as binary wheels for Python 3.11. This PR _does not_ force this downgrade for Python 3.11—and the tests seem to pass!
- However, an experiment (see [this run](https://github.com/iiasa/ixmp/actions/runs/4934670781/jobs/8820003482)) confirms that the test failures still occur for Python 3.10, so we retain the workaround.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- [x] Update release notes.