### PR TITLE
Update RTD config

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,4 +4,4 @@ python:
   install:
   - method: pip
     path: .
-    extra_requirements: [tests]
+    extra_requirements: [docs]


### PR DESCRIPTION
As noted by Xiaoyang on Slack, it's not intuitive to choose `[tests]` as the extra requirement for building the docs when we also have `[docs]`. This PR replaces the selection hoping it works out of the box. In the same process, it renames the config file to comply with current recommendations.  

## How to review

- Read the diff and note that the CI checks all pass.
- Build the documentation and check that it works as usual.

## PR checklist

- [x] ~Continuous integration checks all ✅~
  Except for `macos-latest-py3.7` per iiasa/ixmp#484.
