### PR TITLE
Update RTD config

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -94,8 +94,9 @@ jobs:
       shell: bash
 
     - name: Install Python package and dependencies
+      # [docs] contains [tests], which contains [report,tutorial]
       run: |
-        pip install .[tests]
+        pip install .[docs]
 
         # commented: use with "pandas-version" in the matrix, above
         # pip install --upgrade pandas${{ matrix.pandas-version }}

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -4,4 +4,4 @@ python:
   install:
   - method: pip
     path: .
-    extra_requirements: [tests]
+    extra_requirements: [docs]

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,7 +16,6 @@
 
 # Import so that autodoc can find code
 import ixmp
-import ixmp.testing
 
 # -- Project information ---------------------------------------------------------------
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -51,6 +51,7 @@ documentation = "https://docs.messageix.org/ixmp"
 
 [project.optional-dependencies]
 docs = [
+  "ixmp[tests]",
   "GitPython",
   "numpydoc",
   "sphinx >= 3.0",
@@ -60,7 +61,7 @@ docs = [
 report = ["genno[compat,graphviz]"]
 tutorial = ["jupyter"]
 tests = [
-  "ixmp[docs,report,tutorial]",
+  "ixmp[report,tutorial]",
   "memory_profiler",
   "nbclient >= 0.5",
   "pretenders >= 1.4.4",


### PR DESCRIPTION
Replaces #483 to enable testing if the docs are still built successfully by RTD.

## How to review

- Read the diff and note that the CI checks all pass.
- Build the documentation and check that it works as usual (also on RTD).

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A; CI changes only.
- ~Update release notes.~ N/A