### PR TITLE
Avoid locking on failed operations

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,8 +1,10 @@
-.. Next release
-.. ============
+Next release
+============
 
 .. All changes
 .. -----------
+
+- New :func:`.utils.discard_on_error` and matching argument to :meth:`.TimeSeries.transact` to avoid locking :class:`.TimeSeries` / :class:`.Scenario` on failed operations with :class:`.JDBCBackend` (:pull:`488`).
 
 .. _v3.7.0:
 

--- a/doc/api.rst
+++ b/doc/api.rst
@@ -205,6 +205,7 @@ Utilities
 
    .. autosummary::
       diff
+      discard_on_error
       format_scenario_list
       maybe_check_out
       maybe_commit

--- a/ixmp/core/timeseries.py
+++ b/ixmp/core/timeseries.py
@@ -1,5 +1,5 @@
 import logging
-from contextlib import contextmanager
+from contextlib import contextmanager, nullcontext
 from os import PathLike
 from pathlib import Path
 from typing import Any, Dict, Optional, Sequence, Tuple, Union
@@ -203,7 +203,9 @@ class TimeSeries:
         self._backend("discard_changes")
 
     @contextmanager
-    def transact(self, message: str = "", condition: bool = True):
+    def transact(
+        self, message: str = "", condition: bool = True, discard_on_error: bool = False
+    ):
         """Context manager to wrap code in a 'transaction'.
 
         If `condition` is :obj:`True`, the TimeSeries (or :class:`.Scenario`) is
@@ -221,10 +223,15 @@ class TimeSeries:
         >>> # Changes to `ts` have been committed
         """
         # TODO implement __enter__ and __exit__ to allow simpler "with ts: …"
+        from ixmp.utils import discard_on_error as discard_on_error_cm
+
         if condition:
             maybe_check_out(self)
         try:
-            yield
+            # Use the discard_on_error context manager (cm) if the parameter of the same
+            # name is True
+            with discard_on_error_cm(self) if discard_on_error else nullcontext():
+                yield
         finally:
             maybe_commit(self, condition, message)
 

--- a/ixmp/core/timeseries.py
+++ b/ixmp/core/timeseries.py
@@ -208,10 +208,22 @@ class TimeSeries:
     ):
         """Context manager to wrap code in a 'transaction'.
 
-        If `condition` is :obj:`True`, the TimeSeries (or :class:`.Scenario`) is
-        checked out *before* the block begins. When the block ends, the object is
-        committed with `message`. If `condition` is :obj:`False`, nothing occurs before
-        or after the block.
+        Parameters
+        ----------
+        message : str
+            Commit message to use, if any commit is performed.
+        condition : bool
+            If :obj:`True` (the default):
+
+            - Before entering the code block, the TimeSeries (or :class:`.Scenario`) is
+              checked out.
+            - On exiting the code block normally (without an exception), changes are
+              committed with `message`.
+
+            If :obj:`False`, nothing occurs on entry or exit.
+        discard_on_error : bool
+            If :obj:`True` (default :obj:`False`), then the anti-locking behaviour of
+            :func:`.discard_on_error` also applies to any exception raised in the block.
 
         Example
         -------

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -86,7 +86,12 @@ __all__ = [
 def pytest_addoption(parser):
     """Add the ``--user-config`` command-line option to pytest."""
     parser.addoption(
-        "--user-config",
+        "--ixmp-jvm-mem",
+        action="store",
+        help="Heap space to allocated for the JDBCBackend/JVM.",
+    )
+    parser.addoption(
+        "--ixmp-user-config",
         action="store_true",
         help="Use the user's existing config/'local' platform.",
     )
@@ -96,7 +101,7 @@ def pytest_sessionstart(session):
     """Unset any configuration read from the user's directory."""
     from ixmp.backend import jdbc
 
-    if not session.config.option.user_config:
+    if not session.config.option.ixmp_user_config:
         ixmp_config.clear()
         # Further clear an automatic reference to the user's home directory. See fixture
         # tmp_env below.
@@ -164,7 +169,7 @@ def tmp_env(pytestconfig, tmp_path_factory):
     base_temp = tmp_path_factory.getbasetemp()
     os.environ["IXMP_DATA"] = str(base_temp)
 
-    if not pytestconfig.option.user_config:
+    if not pytestconfig.option.ixmp_user_config:
         # Set the path for the default/local platform in the test directory
         localdb = base_temp.joinpath("localdb", "default")
         ixmp_config.values["platform"]["local"]["path"] = localdb

--- a/ixmp/utils/__init__.py
+++ b/ixmp/utils/__init__.py
@@ -174,7 +174,10 @@ def discard_on_error(ts: "TimeSeries"):
     try:
         yield
     except Exception as e:
-        log.info(f"Avoid locking {ts!r} before raising {str(e).splitlines()[0]!r}")
+        log.info(
+            f"Avoid locking {ts!r} before raising {e.__class__.__name__}: "
+            + str(e).splitlines()[0].strip('"')
+        )
         try:
             ts.discard_changes()
             log.info("Discard scenario changes")

--- a/ixmp/utils/__init__.py
+++ b/ixmp/utils/__init__.py
@@ -180,7 +180,7 @@ def discard_on_error(ts: "TimeSeries"):
         )
         try:
             ts.discard_changes()
-            log.info("Discard scenario changes")
+            log.info(f"Discard {ts.__class__.__name__.lower()} changes")
         except Exception:
             pass
         mp.close_db()

--- a/ixmp/utils/__init__.py
+++ b/ixmp/utils/__init__.py
@@ -12,7 +12,7 @@ import pandas as pd
 
 from ixmp.backend import ItemType
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from ixmp import TimeSeries
 
 log = logging.getLogger(__name__)

--- a/ixmp/utils/sphinx_linkcode_github.py
+++ b/ixmp/utils/sphinx_linkcode_github.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 
 from sphinx.util import logging
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     import sphinx.application
 
 log = logging.getLogger(__name__)


### PR DESCRIPTION
The PR adds a new context manager `.utils.discard_on_error()` that can be used to avoid leaving scenarios in a locked state. This can occur when exceptions are raised and JDBCBackend is in use: an unclean exit means the database is left in a state that marks the scenario as "locked" for use by a particular user.

Originally developed for iiasa/message_data#446.

## How to review

- Read the diff and note that the CI checks all pass.
- Read the additions to the docs including examples and ensure they are clear.
- Optionally, try a particular code operation known to fail and leave scenario(s) in a locked state.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.