### PR TITLE
Record Python package versions in GDX files

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [`doc/README.rst`](doc/README.rst) for further details.
 
 ## License
 
-Copyright © 2017–2023 IIASA Energy, Climate, and Environment (ECE) program
+Copyright © 2017–2024 IIASA Energy, Climate, and Environment (ECE) program
 
 `ixmp` is licensed under the Apache License, Version 2.0 (the "License"); you
 may not use the files in this repository except in compliance with the License.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -17,6 +17,8 @@ All changes
 - :mod:`ixmp` is tested and compatible with `Python 3.12 <https://www.python.org/downloads/release/python-3120/>`__ (:pull:`504`).
 - Support for Python 3.7 is dropped (:pull:`492`), as it has reached end-of-life.
 - Rename :mod:`ixmp.report` and :mod:`ixmp.util` (:pull:`500`).
+- New option :py:`record_version_packages` to :class:`.GAMSModel` (:pull:`502`).
+  Versions of the named Python packages are recorded in a special set in GDX-format input and output files to help associate these files with generating code.
 - New reporting operators :func:`.from_url`, :func:`.get_ts`, and :func:`.remove_ts` (:pull:`500`).
 - New CLI command :program:`ixmp platform copy` and :doc:`CLI documentation <cli>` (:pull:`500`).
 - New argument :py:`indexed_by=...` to :meth:`.Scenario.items` (thus :meth:`.Scenario.par_list` and similar methods) to iterate over (or list) only items that are indexed by a particular set (:issue:`402`, :pull:`500`).

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,7 +10,7 @@ from typing import Optional
 # -- Project information ---------------------------------------------------------------
 
 project = "ixmp"
-copyright = "2017–2023, IIASA Energy, Climate, and Environment (ECE) program"
+copyright = "2017–2024, IIASA Energy, Climate, and Environment (ECE) program"
 author = "ixmp Developers"
 
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -3,8 +3,9 @@
 # This file only contains a selection of the most common options. For a full list see
 # the documentation: https://www.sphinx-doc.org/en/master/usage/configuration.html
 
-# Import so that autodoc can find code
-import ixmp
+import importlib.metadata
+from pathlib import Path
+from typing import Optional
 
 # -- Project information ---------------------------------------------------------------
 
@@ -44,7 +45,7 @@ nitpicky = True
 
 # A string of reStructuredText that will be included at the beginning of every source
 # file that is read.
-version = ixmp.__version__
+version = importlib.metadata.version("ixmp")
 rst_prolog = rf"""
 .. role:: py(code)
    :language: python
@@ -85,9 +86,25 @@ extlinks = {
 
 # -- Options for sphinx.ext.intersphinx ------------------------------------------------
 
+
+def local_inv(name: str, *parts: str) -> Optional[str]:
+    """Construct the path to a local intersphinx inventory."""
+
+    from importlib.util import find_spec
+
+    spec = find_spec(name)
+    if spec is None:
+        return None
+
+    if 0 == len(parts):
+        parts = ("doc", "_build", "html")
+    assert spec.origin is not None
+    return str(Path(spec.origin).parents[1].joinpath(*parts, "objects.inv"))
+
+
 intersphinx_mapping = {
     "dask": ("https://docs.dask.org/en/stable/", None),
-    "genno": ("https://genno.readthedocs.io/en/latest/", None),
+    "genno": ("https://genno.readthedocs.io/en/latest/", (local_inv("genno"), None)),
     "jpype": ("https://jpype.readthedocs.io/en/latest", None),
     "message_ix": ("https://docs.messageix.org/en/latest/", None),
     "message-ix-models": (

--- a/doc/reporting.rst
+++ b/doc/reporting.rst
@@ -55,7 +55,7 @@ The following top-level objects from :mod:`genno` may also be imported from
       from_scenario
       set_filters
 
-   The Computer class provides the following methods:
+   The Reporter class inherits from Computer the following methods:
 
    .. currentmodule:: genno
    .. autosummary::
@@ -74,7 +74,7 @@ The following top-level objects from :mod:`genno` may also be imported from
       ~Computer.visualize
       ~Computer.write
 
-   The following methods are deprecated; equivalent or better functionality is available through :meth:`.Computer.add`.
+   The following methods are deprecated; equivalent or better functionality is available through :meth:`Reporter.add <genno.Computer.add>`.
    See the genno documentation for each method for suggested changes/migrations.
 
    .. autosummary::
@@ -132,6 +132,10 @@ Configuration
    The only difference from :func:`genno.config.units` is that this handler keeps the configuration values stored in ``Reporter.graph["config"]``.
    This is so that :func:`.data_for_quantity` can make use of ``["units"]["apply"]``
 
+.. automethod:: ixmp.report.configure
+
+   This is the same as :func:`genno.configure`.
+
 
 Operators
 =========
@@ -186,7 +190,7 @@ Utilities
 .. autodata:: RENAME_DIMS
 
    User code **should** avoid directly manipulating :data:`RENAME_DIMS`.
-   Instead, call :func:`.configure`:
+   Instead, call :func:`~genno.configure`:
 
    .. code-block:: python
 

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -604,7 +604,7 @@ class JDBCBackend(CachingBackend):
 
         ts, filters = self._handle_rw_filters(kwargs.pop("filters", {}))
         if path.suffix == ".gdx" and item_type is ItemType.SET | ItemType.PAR:
-            if len(filters):
+            if len(filters):  # pragma: no cover
                 raise NotImplementedError("write to GDX with filters")
             elif not isinstance(ts, Scenario):  # pragma: no cover
                 raise ValueError("write to GDX requires a Scenario object")
@@ -957,7 +957,7 @@ class JDBCBackend(CachingBackend):
         except jpype.JException as e:
             if "There exists no" in e.args[0]:
                 raise KeyError(name)
-            else:
+            else:  # pragma: no cover
                 _raise_jexception(e)
         self.cache_invalidate(s, type, name)
 

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -952,7 +952,13 @@ class JDBCBackend(CachingBackend):
                 _raise_jexception(e)
 
     def delete_item(self, s, type, name):
-        getattr(self.jindex[s], f"remove{type.title()}")(name)
+        try:
+            getattr(self.jindex[s], f"remove{type.title()}")(name)
+        except jpype.JException as e:
+            if "There exists no" in e.args[0]:
+                raise KeyError(name)
+            else:
+                _raise_jexception(e)
         self.cache_invalidate(s, type, name)
 
     def item_index(self, s, name, sets_or_names):

--- a/ixmp/model/dantzig.gms
+++ b/ixmp/model/dantzig.gms
@@ -23,6 +23,8 @@ Sets
     j   markets
 ;
 
+Set ixmp_version(*,*) "Versions of Python packages";
+
 Parameters
     a(i)   capacity of plant i in cases
     b(j)   demand at market j in cases
@@ -45,6 +47,7 @@ $IF NOT set out $SETGLOBAL out 'ix_transport_results.gdx'
 
 $GDXIN '%in%'
 $LOAD i, j, a, b, d, f
+$LOAD ixmp_version
 $GDXIN
 
 Parameter c(i,j)  transport cost in thousands of dollars per case ;

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -244,7 +244,9 @@ class GAMSModel(Model):
             try:
                 # Initialize the set
                 self.scenario.init_set(name, ["*", "*"], ["package", "version"])
-            except ValueError as e:
+            except ValueError as e:  # pragma: no cover
+                # NB this will only occur if the user directly creates the set; the one
+                #    created here is deleted in run()
                 if "already exists" not in e.args[0]:
                     raise
 

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -248,8 +248,6 @@ class GAMSModel(Model):
                 if "already exists" not in e.args[0]:
                     raise
 
-            self.scenario.remove_set(name, self.scenario.set(name))
-
             # Handle each identified package
             for package in self.record_version_packages:
                 try:
@@ -329,6 +327,10 @@ class GAMSModel(Model):
                 "GAMSModel requires a Backend that can write to GDX files, e.g. "
                 "JDBCBackend"
             )
+        else:
+            # Remove ixmp_version set entirely
+            with scenario.transact():
+                scenario.remove_set("ixmp_version")
 
         try:
             # Invoke GAMS

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -46,7 +46,7 @@ def gams_version() -> Optional[str]:
     # Find and return the version string
     if match := re.search(r"^GAMS ([\d\.]+)\s*Copyright", output, re.MULTILINE):
         return match.group(0)
-    else:
+    else:  # pragma: no cover
         return None
 
 
@@ -211,7 +211,7 @@ class GAMSModel(Model):
                 f"    {lp_5}",
                 f"and {backend_class.__name__} could not read the solution.",
             ]
-        else:
+        else:  # pragma: no cover
             return exc  # Other exception
 
         # Add a reference to the listing file, if it exists

--- a/ixmp/report/operator.py
+++ b/ixmp/report/operator.py
@@ -129,7 +129,7 @@ def data_for_quantity(
         # First rename, then set index
         data = data.rename(columns=common.RENAME_DIMS).set_index(dims)
 
-    # Convert to a Quantity, assign attrbutes and name
+    # Convert to a Quantity, assign attributes and name
     qty = Quantity(
         data[column], name=name + ("-margin" if column == "mrg" else ""), attrs=attrs
     )

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -172,6 +172,11 @@ class TestJDBCBackend:
         # Initialize the item; succeeds
         be.init_item(s, type="var", name=name, idx_sets=idx_sets, idx_names=idx_sets)
 
+    def test_delete_item(self, mp, be):
+        s = ixmp.Scenario(mp, "model name", "scenario name", version="new")
+        with pytest.raises(KeyError):
+            be.delete_item(s, "set", "foo")
+
     def test_set_data_inf(self, mp):
         """:meth:`JDBCBackend.set_data` errors on :data:`numpy.inf` values."""
         # Make `mp` think it is connected to an Oracle database

--- a/ixmp/util/sphinx_linkcode_github.py
+++ b/ixmp/util/sphinx_linkcode_github.py
@@ -103,6 +103,9 @@ class GitHubLinker:
 
         Records the file and source line numbers containing `obj`.
         """
+        # TODO Handle wrapper_descriptor, e.g.
+        #      message_ix_models.tests.model.test_bare.TestConfig.__init__
+
         # Identify the object for which to locate code
         if isinstance(obj, property):
             # Reference the getter method


### PR DESCRIPTION
This PR provides the basic functionality for addressing iiasa/message_ix#747.

The GAMSModel class gains an attribute/parameter (`record_version_packages`) and a method (`record_versions()`); the latter is called from within the `run()` method. This adds a set to the Scenario that is to be solved, with entries like:
```
Set ixmp_version(*,*) Versions of Python packages used to generate this model /
'message_ix'.'3-7-1-dev55+g2e0a9c49', 
'ixmp'.'3-7-1-dev67+g6cab755-d20231122'
'notapackage'.'(not installed)' /;
```
(The list of included packages is according to `record_version_packages`, so can be extended by downstream packages, like `message-ix`, that use or subclass GAMSModel.)

## How to review

Read the diff and note that the CI checks all pass.

Test together with a message_ix PR to be opened next.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.