### PR TITLE
Remove workaround for #494 due to new lxml release

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -92,10 +92,6 @@ jobs:
       run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
       shell: bash
 
-    - name: Work around https://bugs.launchpad.net/lxml/+bug/2035206
-      if: matrix.python-version == '3.8'
-      run: pip install "lxml != 4.9.3"
-
     - name: Install Python package and dependencies
       # [docs] contains [tests], which contains [report,tutorial]
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -92,6 +92,10 @@ jobs:
       run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
       shell: bash
 
+    - name: Work around https://bugs.launchpad.net/lxml/+bug/2035206
+      if: matrix.python-version == '3.8' && matrix.os == 'macos-latest'
+      run: pip install "lxml == 4.9.2"
+
     - name: Install Python package and dependencies
       # [docs] contains [tests], which contains [report,tutorial]
       run: |


### PR DESCRIPTION
LXML has published a new release yesterday, which includes wheels for python 3.8 again. Unfortunately, there is only one wheel for python 3.8 and macos, which specifies macos version 11. Our GHA uses version 12.6, so we still can't get the lxml wheel from pypi for this workflow. This PR makes the workaround workflow step more specific and only executes it on macos. 

<!-- Optional: write a longer description to help a reviewer understand the PR in ~3 minutes. -->

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] Update tests ✅
- ~[ ] Add, expand, or update documentation.~ Just CI
- ~[ ] Update release notes.~ Just CI

