### PR TITLE
Return *only* the version from gams_version()

### DIFF
--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -45,7 +45,7 @@ def gams_version() -> Optional[str]:
 
     # Find and return the version string
     if match := re.search(r"^GAMS ([\d\.]+)\s*Copyright", output, re.MULTILINE):
-        return match.group(0)
+        return match.group(1)
     else:  # pragma: no cover
         return None
 

--- a/ixmp/tests/test_model.py
+++ b/ixmp/tests/test_model.py
@@ -98,8 +98,12 @@ def test_model_initialize(test_mp, caplog):
 
 
 def test_gams_version():
-    # Returns a version string like X.Y.Z
-    assert len(gams_version().split(".")) == 3
+    parts = gams_version().split(".")
+
+    # Returns a version string like X.Y.Z, in which each part is a number (no leading or
+    # trailing text)
+    assert 3 == len(parts)
+    assert [int(p) for p in parts]
 
 
 class TestGAMSModel:


### PR DESCRIPTION
Fix a regression introduced in #502 that resulted in [this downstream failure](https://github.com/iiasa/message_ix/actions/runs/7472698249/job/20335399000?pr=765#step:9:376):
```
______________________________ test_message_macro ______________________________

    def test_message_macro():
        # Constructor runs successfully
        MESSAGE_MACRO()
    
        class _MM(MESSAGE_MACRO):
            """Dummy subclass requiring a non-existent GAMS version."""
    
            GAMS_min_version = "99.9.9"
    
        # Constructor complains about an insufficient GAMS version
>       with pytest.raises(
            RuntimeError, match="MESSAGE-MACRO requires GAMS >= " "99.9.9; found "
        ):
E       Failed: DID NOT RAISE <class 'RuntimeError'>

message_ix/tests/test_models.py:38: Failed
```

Also add a test to check this expectation.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update release notes.~
