### PR TITLE
Fix Sphinx nitpicks fron message_ix docs

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,9 +5,9 @@ Migration notes
 ---------------
 Update code that imports from the following modules:
 
-- :py:`ixmp.reporting` → use :py:`ixmp.report`.
-- :py:`ixmp.reporting.computations` → use :py:`ixmp.report.operator`.
-- :py:`ixmp.utils` → use :py:`ixmp.util`.
+- :py:`ixmp.reporting` → use :mod:`ixmp.report`.
+- :py:`ixmp.reporting.computations` → use :mod:`ixmp.report.operator`.
+- :py:`ixmp.utils` → use :mod:`ixmp.util`.
 
 Code that imports from the old locations will continue to work, but will raise :class:`DeprecationWarning`.
 

--- a/ixmp/backend/__init__.py
+++ b/ixmp/backend/__init__.py
@@ -54,7 +54,7 @@ BACKENDS: Dict[str, Type] = {}
 
 
 class ItemType(IntFlag):
-    """Type of data items in :class:`.TimeSeries` and :class:`.Scenario`."""
+    """Type of data items in :class:`.ixmp.TimeSeries` and :class:`.ixmp.Scenario`."""
 
     # NB the docstring comments ('#:') are placed as they are to ensure the
     #    output is readable.

--- a/ixmp/core/timeseries.py
+++ b/ixmp/core/timeseries.py
@@ -277,7 +277,7 @@ class TimeSeries:
         Examples
         --------
         To form a complete URL (e.g. to use with :meth:`.from_url`), use a configured
-        :class:`Platform` name:
+        :class:`.ixmp.Platform` name:
 
         >>> platform_name = "my-ixmp-platform"
         >>> mp = Platform(platform_name)

--- a/ixmp/report/operator.py
+++ b/ixmp/report/operator.py
@@ -150,7 +150,7 @@ _FROM_URL_REF: Set[Any] = set()
 
 
 def from_url(url: str, cls=TimeSeries) -> "TimeSeries":
-    """Return a :class:`.TimeSeries` or subclass instance, given its `url`.
+    """Return a :class:`.ixmp.TimeSeries` or subclass instance, given its `url`.
 
     Parameters
     ----------


### PR DESCRIPTION
This PR adjusts some internal intersphinx references.

Where the following would ordinarily be sufficient for an internal reference:
```
:class:`.Platform`
```
…this leads to a missing reference when the docstring that contains it is included in the downstream (message_ix) docs.

This PR adjusts some of these references to, for instance:
```
:class:`.ixmp.Platform`
```

This has no effect on the appearance of the ixmp docs, but allows the reference target to be correctly identified downstream.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- ~Update release notes.~ N/A, docs details only
