### PR TITLE
Update minimum version of genno

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,6 +4,7 @@ Next release
 All changes
 -----------
 
+- Increase minimum required version of genno dependency to 1.20 (:pull:`514`)
 - To aid debugging when execution fails, :class:`.GAMSModel` also displays the path to the GAMS log file (:pull:`513`).
 
 .. _v3.8.0:

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,7 +4,7 @@ Next release
 All changes
 -----------
 
-- Increase minimum required version of genno dependency to 1.20 (:pull:`514`)
+- Increase minimum required version of genno dependency to 1.20 (:pull:`514`).
 - To aid debugging when execution fails, :class:`.GAMSModel` also displays the path to the GAMS log file (:pull:`513`).
 
 .. _v3.8.0:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ classifiers = [
 requires-python = ">=3.8"
 dependencies = [
   "click",
-  "genno >= 1.16",
+  "genno >= 1.20",
   "JPype1 >= 1.2.1",
   "JPype1 <= 1.4.0; python_version < '3.11'",
   "openpyxl",


### PR DESCRIPTION
As noted by @awais307, we should bump the minimum required version of genno to the one that introduces `genno.operator`. 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Just bumping dependency
- ~[ ] Add, expand, or update documentation.~ Just bumping dependency
- ~[ ] Update release notes.~ Just bumping dependency

