### PR TITLE
Address GitHub Actions warnings re: node.js 16

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -2,7 +2,6 @@ name: Build package / publish
 
 on:
   push:
-    branches: [ main ]
     tags: [ "v*" ]
   release:
     types: [ published ]

--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -9,6 +9,9 @@ on:
   pull_request:
     branches: [ main ]
 
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
   publish:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -51,14 +51,12 @@ jobs:
     # name: ${{ matrix.os }}-py${{ matrix.python-version }}-pandas${{ matrix.pandas-version }}
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       with:
         fetch-depth: ${{ env.depth }}
+        fetch-tags: true
 
-    - name: Fetch tags (for setuptools-scm)
-      run: git fetch --tags --depth=${{ env.depth }}
-
-    - uses: actions/setup-python@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         cache: pip
@@ -135,8 +133,8 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - uses: actions/setup-python@v4
+    - uses: actions/checkout@v4
+    - uses: actions/setup-python@v5
       with:
         python-version: "3.x"
 

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,7 @@ repos:
     language: python
     entry: bash -c ". ${PRE_COMMIT_MYPY_VENV:-/dev/null}/bin/activate 2>/dev/null; mypy $0 $@"
     additional_dependencies:
-    - mypy
+    - mypy >= 1.8.0
     - genno
     - GitPython
     - nbclient
@@ -18,11 +18,9 @@ repos:
     - sphinx
     - xarray
     args: ["."]
-- repo: https://github.com/psf/black
-  rev: 23.7.0
-  hooks:
-  - id: black
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.0.287
+  rev: v0.1.14
   hooks:
   - id: ruff
+  - id: ruff-format
+    args: [ --check ]

--- a/ixmp/tests/test_model.py
+++ b/ixmp/tests/test_model.py
@@ -155,8 +155,6 @@ class TestGAMSModel:
 For details, see the terminal output above, plus:
 Listing   : {}
 Log file  : {}
-Input data: {}""".format(
-                *paths
-            ),
+Input data: {}""".format(*paths),
         ):
             s.solve(model_file=test_data_path / "_abort.gms", use_temp_dir=False)


### PR DESCRIPTION
GitHub Actions has started warning about deprecation of Node.js 16, for instance [here](https://github.com/iiasa/ixmp/actions/runs/7691414018):

> Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, actions/setup-python@v4, ts-graphviz/setup-graphviz@v1.2.0, r-lib/actions/setup-r@v2, actions/cache@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.

This PR updates 'first-party' actions as suggested:

- actions/checkout v3 → v4
- actions/setup-python v4 → v5

We cannot yet update the third-party actions:

- [pre-commit/action](https://github.com/pre-commit/action): no update or issue.
- r-lib/actions/setup-r: r-lib/actions#792.
- [ts-graphviz/setup-graphviz](https://github.com/ts-graphviz/setup-graphviz): no update or issue.

Other housekeeping:
- Replace `black` with `ruff format` for code style (iiasa/message_ix#772).
- Tweak the "publish" CI workflow:
  - Remove the trigger for pushes to `main` (analogous to #515).
  - Add `concurrency:` setting to prevent 2 conflicting jobs being started on a release (one triggered by the release event, one by the tag creation event).

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, CI changes only
- ~Update release notes.~