### PR TITLE
Bump versions of GHAs

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -62,7 +62,7 @@ jobs:
         cache: pip
         cache-dependency-path: "**/pyproject.toml"
 
-    - uses: ts-graphviz/setup-graphviz@v1.2.0
+    - uses: ts-graphviz/setup-graphviz@v2
       with:
         macos-skip-brew-update: true
 
@@ -72,7 +72,7 @@ jobs:
         r-version: '4.2.3'
 
     - name: Cache GAMS installer and R packages
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       with:
         path: |
           gams
@@ -125,7 +125,7 @@ jobs:
       shell: bash
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v3
+      uses: codecov/codecov-action@v4
 
   pre-commit:
     name: Code quality

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -126,6 +126,8 @@ jobs:
 
     - name: Upload test coverage to Codecov.io
       uses: codecov/codecov-action@v4
+      with:
+        token: ${{ secrets.CODECOV_TOKEN }} # required
 
   pre-commit:
     name: Code quality


### PR DESCRIPTION
This PR is a follow-up of #517 and bumps the remaining versions except for pre-commit, which seems unwilling to release a new version at the moment.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Just CI update
- ~[ ] Add, expand, or update documentation.~ Just CI update
- ~[ ] Update release notes.~ Just CI update
