### PR TITLE
Update deprecated pytest hook arg

### DIFF
--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -116,7 +116,7 @@ def pytest_sessionstart(session):
     jdbc._GC_AGGRESSIVE = False
 
 
-def pytest_report_header(config, startdir):
+def pytest_report_header(config, start_path):
     """Add the ixmp configuration to the pytest report header."""
     return f"ixmp config: {repr(ixmp_config.values)}"
 


### PR DESCRIPTION
Our whole CI is failing (same for several downstream projects) because one of the pytest hooks here is using a deprecated argument: `startdir` has been replaced by `start_path`. This was kindly pointed out in https://github.com/pytest-dev/pytest/issues/12061, though I have to admit even with the [linked deprecation changelog](https://docs.pytest.org/en/stable/deprecations.html#py-path-local-arguments-for-hooks-replaced-with-pathlib-path), this might not have been entirely clear to me. After all, the changelog says the hook is now receiving 'additional arguments', not 'changed arguments'. Either way, this PR includes the fix.

Should we update the release notes since other projects might have seen failures due to the hook arguments being out of date? If so, we haven't received an issue yet.

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ Just an internal change
- ~[ ] Add, expand, or update documentation.~ Just an internal change
- ~[ ] Update release notes.~ Just an internal change

