### PR TITLE
Limit CI runtime on Windows runners

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -129,6 +129,7 @@ jobs:
       # FIXME Limit runtime until
       # https://github.com/codecov/codecov-action/issues/1316 is resolved
       timeout-minutes: 1
+      continue-on-error: true
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # required
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -126,6 +126,9 @@ jobs:
 
     - name: Upload test coverage to Codecov.io
       uses: codecov/codecov-action@v4
+      # FIXME Limit runtime until
+      # https://github.com/codecov/codecov-action/issues/1316 is resolved
+      timeout-minutes: 1
       with:
         token: ${{ secrets.CODECOV_TOKEN }} # required
 


### PR DESCRIPTION
Currently, our CI is "failing" because the codecov-action gets stuck for Windows runners despite the last line showing `info - 2024-03-07 05:18:14,167 -- Process Upload complete`. It seems this success is not correctly registered so that the workflow doesn't move to the next job. See also

- https://github.com/codecov/codecov-action/issues/1316 

At the moment, this PR simply applies a time limit to this CI step (1 minute should be plenty for a step that usually takes ~5s), but the step will then still fail. So we might want to explore other options such as downgrading to codecov-action@v3.
Another option would probably be to run codecov as a command line tool manually.

## How to review

Please check the added comment is enough to understand how/when to remove this temporary addition. The CI is not expected to pass on Windows runners.


## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- ~[ ] Add or expand tests; coverage checks both ✅~ No intention to keep this change 
- ~[ ] Add, expand, or update documentation.~ No intention to keep this change
- ~[ ] Update release notes.~ No intention to keep this change

