### PR TITLE
Housekeeping for 2024-W13

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,27 @@
+version: 2
+updates:
+- package-ecosystem: "github-actions"
+  # Only update major versions
+  ignore:
+  - dependency-name: "*"
+    update-types:
+    - "version-update:semver-minor"
+    - "version-update:semver-patch"
+  # Below config mirrors the example at
+  # https://github.com/dependabot/dependabot-core/blob/main/.github/dependabot.yml
+  directory: "/"
+  schedule:
+    interval: "weekly"
+    day: "sunday"
+    time: "16:00"
+  groups:
+    all-actions:
+      patterns: [ "*" ]
+  assignees:
+  - "glatterf42"
+  - "khaeru"
+  labels:
+  - "dependencies"
+  reviewers:
+  - "glatterf42"
+  - "khaeru"

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,32 @@
 <!--
+Delete each of these comments as you fill out the PR description.
+This confirms you have given enough information for others to understand what
+the PR does.
 
-Delete each of these instruction comments as you complete it.
-
-Title: use a short, declarative statement similar to a commit message,
-e.g. “Change [thing X] to [fix solve bug|enable feature Y]”
-
+Title: use a short, declarative statement similar to a commit message.
+For example: “Change [thing X] to [fix solve bug|enable feature Y]”
 -->
 
 **Required:** write a single sentence that describes the changes made by this PR.
 
-<!-- Optional: write a longer description to help a reviewer understand the PR in ~3 minutes. -->
+<!--
+Optional:
+
+- Write a ≤3 minute summary so a reviewer can understand the PR.
+- Write a longer, exhaustive description.
+-->
 
 ## How to review
 
 **Required:** describe specific things that reviewer(s) must do, in order to ensure that the PR achieves its goal.
-If no review is required, write “No review:” and describe why.
+If no review is required, write “No review: …” and describe why.
 
 <!--
 For example, one or more of:
 
 - Read the diff and note that the CI checks all pass.
 - Run a specific code snippet or command and check the output.
-- Build the documentation and look at a certain page.
+- View the preview build of the documentation and look at a certain page.
 - Ensure that changes/additions are self-documenting, i.e. that another
   developer (someone like the reviewer) will be able to understand what the code
   does in the future.
@@ -31,15 +36,16 @@ For example, one or more of:
 
 <!-- This item is always required. -->
 - [ ] Continuous integration checks all ✅
-  <!--
-  The following items are all *required* if the PR results in changes to user-
-  facing behaviour, e.g. new features or fixes to existing behaviour. They are
-  *optional* if the changes are solely to documentation, CI configuration, etc.
-  
-  In ambiguous cases, strike them out and add a short explanation, e.g.
-  
-  - ~Add or expand tests.~ No change in behaviour, simply refactoring.
-  -->
+<!--
+The following items are *required* if the PR results in changes to user-facing
+behaviour—such as new features, or fixes to existing behaviour.
+
+They are *optional* if the changes are solely to documentation, test/CI
+configuration, etc. In such cases, strike them out and add a short explanation,
+for example:
+
+- ~Add or expand tests.~ No change in behaviour, simply refactoring.
+-->
 - [ ] Add or expand tests; coverage checks both ✅
 - [ ] Add, expand, or update documentation.
 - [ ] Update release notes.
@@ -47,7 +53,7 @@ For example, one or more of:
   To do this, add a single line at the TOP of the “Next release” section of
   RELEASE_NOTES.rst, where '999' is the GitHub pull request number:
 
-  - :pull:`999`: Title or single-sentence description from above.
+  - Title or single-sentence description from above (:pull:`999`:).
 
   Commit with a message like “Add #999 to release notes”
   -->

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -141,12 +141,11 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - uses: actions/setup-python@v5
-      with:
-        python-version: "3.x"
+      with: { python-version: "3.12" }
 
     - name: Force recreation of pre-commit virtual environment for mypy
       if: github.event_name == 'schedule'
       run: gh cache list -L 999 | cut -f2 | grep pre-commit | xargs -I{} gh cache delete "{}" || true
       env: { GH_TOKEN: "${{ github.token }}" }
 
-    - uses: pre-commit/action@v3.0.0
+    - uses: pre-commit/action@v3.0.1

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -19,7 +19,7 @@ repos:
     - xarray
     args: ["."]
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.1.14
+  rev: v0.3.4
   hooks:
   - id: ruff
   - id: ruff-format

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,10 +10,11 @@ repos:
     language: python
     entry: bash -c ". ${PRE_COMMIT_MYPY_VENV:-/dev/null}/bin/activate 2>/dev/null; mypy $0 $@"
     additional_dependencies:
-    - mypy >= 1.8.0
+    - mypy >= 1.9.0
     - genno
     - GitPython
     - nbclient
+    - pandas-stubs
     - pytest
     - sphinx
     - xarray

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -19,7 +19,7 @@ author = "ixmp Developers"
 # Add any Sphinx extension module names here, as strings. They can be extensions coming
 # with Sphinx (named 'sphinx.ext.*') or your custom ones.
 extensions = [
-    "ixmp.util.sphinx_linkcode_github",
+    # First party
     "sphinx.ext.autodoc",
     "sphinx.ext.autosummary",
     "sphinx.ext.coverage",
@@ -29,6 +29,9 @@ extensions = [
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx.ext.todo",
+    # Others
+    "ixmp.util.sphinx_linkcode_github",
+    "genno.compat.sphinx.rewrite_refs",
     "sphinxcontrib.bibtex",
 ]
 
@@ -76,6 +79,14 @@ html_static_path = ["_static"]
 
 # The theme to use for HTML and HTML Help pages.
 html_theme = "sphinx_rtd_theme"
+
+# -- Options for genno.compat.sphinx.rewrite_refs --------------------------------------
+
+reference_aliases = {
+    r"(genno\.|)Quantity": "genno.core.attrseries.AttrSeries",
+    "AnyQuantity": ":data:`genno.core.quantity.AnyQuantity`",
+}
+
 
 # -- Options for sphinx.ext.extlinks ---------------------------------------------------
 

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -132,7 +132,7 @@ intersphinx_mapping = {
     "python": ("https://docs.python.org/3/", None),
     "sparse": ("https://sparse.pydata.org/en/stable/", None),
     "sphinx": ("https://www.sphinx-doc.org/en/master/", None),
-    "xarray": ("https://xarray.pydata.org/en/stable/", None),
+    "xarray": ("https://docs.xarray.dev/en/stable", None),
 }
 
 # -- Options for sphinx.ext.linkcode / ixmp.util.sphinx_linkcode_github ----------------

--- a/doc/reporting.rst
+++ b/doc/reporting.rst
@@ -143,7 +143,10 @@ Operators
 .. automodule:: ixmp.report.operator
    :members:
 
-   :mod:`ixmp.report` defines these operators:
+   More than 30 operators are defined by :mod:`genno.operator` and its compatibility modules including :mod:`genno.compat.plotnine` and :mod:`genno.compat.sdmx`.
+   See the genno documentation for details.
+
+   :mod:`ixmp.report` defines these additional operators:
 
    .. autosummary::
 
@@ -151,36 +154,9 @@ Operators
       from_url
       get_ts
       map_as_qty
-      update_scenario
-      store_ts
       remove_ts
-
-   Basic operators are defined by :mod:`genno.operator` and its compatibility modules; see there for details:
-
-   .. autosummary::
-
-      ~genno.compat.plotnine.Plot
-      ~genno.operator.add
-      ~genno.operator.aggregate
-      ~genno.operator.apply_units
-      ~genno.compat.pyam.operator.as_pyam
-      ~genno.operator.broadcast_map
-      ~genno.operator.combine
-      ~genno.operator.concat
-      ~genno.operator.disaggregate_shares
-      ~genno.operator.div
-      ~genno.operator.group_sum
-      ~genno.operator.interpolate
-      ~genno.operator.load_file
-      ~genno.operator.mul
-      ~genno.operator.pow
-      ~genno.operator.product
-      ~genno.operator.relabel
-      ~genno.operator.rename_dims
-      ~genno.operator.ratio
-      ~genno.operator.select
-      ~genno.operator.sum
-      ~genno.operator.write_report
+      store_ts
+      update_scenario
 
 Utilities
 =========

--- a/ixmp/backend/__init__.py
+++ b/ixmp/backend/__init__.py
@@ -1,4 +1,5 @@
 """Backend API."""
+
 from enum import IntFlag
 from typing import Dict, List, Type, Union
 

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -112,7 +112,9 @@ def s_write_excel(be, s, path, item_type, filters=None, max_row=None):
             sheet_name = name + (f"({sheet_num})" if sheet_num > 1 else "")
 
             # Subset the data (only on rows, if a DataFrame) and write
-            data.iloc[first_row:last_row].to_excel(writer, sheet_name, index=False)
+            data.iloc[first_row:last_row].to_excel(
+                writer, sheet_name=sheet_name, index=False
+            )
 
     # Discard entries that were not written
     for name in omitted:

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -174,7 +174,7 @@ def maybe_init_item(scenario, ix_type, name, new_idx, path):
             raise ValueError from None
 
 
-# FIXME reduce complexity from 26 to <=15
+# FIXME reduce complexity 22 → ≤13
 def s_read_excel(  # noqa: C901
     be, s, path, add_units=False, init_items=False, commit_steps=False
 ):

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -965,7 +965,7 @@ class JDBCBackend(CachingBackend):
         jitem = self._get_item(s, "item", name, load=False)
         return list(getattr(jitem, f"getIdx{sets_or_names.title()}")())
 
-    # FIXME reduce complexity from 19 to <=15
+    # FIXME reduce complexity 18 → ≤13
     def item_get_elements(self, s, type, name, filters=None):  # noqa: C901
         if filters:
             # Convert filter elements to strings

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -9,7 +9,7 @@ from ixmp._config import config
 from ixmp.backend import BACKENDS, FIELDS, ItemType
 from ixmp.util import as_str_list
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     from ixmp.backend.base import Backend
 
 
@@ -235,11 +235,11 @@ class Platform:
                 "model or scenario."
             )
         filters = {
-            "model": as_str_list(model) or [],
-            "scenario": as_str_list(scenario) or [],
-            "variable": as_str_list(variable) or [],
-            "unit": as_str_list(unit) or [],
-            "region": as_str_list(region) or [],
+            "model": as_str_list(model),
+            "scenario": as_str_list(scenario),
+            "variable": as_str_list(variable),
+            "unit": as_str_list(unit),
+            "region": as_str_list(region),
             "default": default,
             "export_all_runs": export_all_runs,
         }

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -186,7 +186,7 @@ class Scenario(TimeSeries):
         """
         return self._backend("item_get_elements", "set", name, filters)
 
-    # FIXME reduce complexity from 17 to <=15
+    # FIXME reduce complexity 18 → ≤13
     def add_set(  # noqa: C901
         self,
         name: str,
@@ -535,7 +535,8 @@ class Scenario(TimeSeries):
     #: List all defined variables. See :meth:`list_items`.
     var_list = partialmethod(list_items, ItemType.VAR)
 
-    def add_par(
+    # FIXME reduce complexity 15 → ≤13
+    def add_par(  # noqa: C901
         self,
         name: str,
         key_or_data: Optional[Union[str, Sequence[str], Dict, pd.DataFrame]] = None,

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -31,6 +31,7 @@ These include:
      get_cell_output
 
 """
+
 import logging
 import os
 import shutil

--- a/ixmp/testing/data.py
+++ b/ixmp/testing/data.py
@@ -3,14 +3,13 @@ from itertools import product
 from math import ceil
 from typing import Any, List
 
+import genno
 import numpy as np
 import pandas as pd
 import pint
-import xarray as xr
 
 from ixmp import Platform, Scenario, TimeSeries
 from ixmp.backend import IAMC_IDX
-from ixmp.report import Quantity
 
 #: Common (model name, scenario name) pairs for testing.
 SCEN = {
@@ -145,9 +144,8 @@ def add_test_data(scen: Scenario):
 
     # Data
     ureg = pint.get_application_registry()
-    x = Quantity(
-        xr.DataArray(np.random.rand(len(t), len(y)), coords=[("t", t), ("y", y)]),
-        units=ureg.kg,
+    x = genno.Quantity(
+        np.random.rand(len(t), len(y)), coords={"t": t, "y": y}, units=ureg.kg
     )
 
     # As a pd.DataFrame with units

--- a/ixmp/testing/jupyter.py
+++ b/ixmp/testing/jupyter.py
@@ -1,4 +1,5 @@
 """Testing Juypter notebooks."""
+
 import os
 import sys
 from warnings import warn

--- a/ixmp/testing/resource.py
+++ b/ixmp/testing/resource.py
@@ -1,4 +1,5 @@
 """Performance testing."""
+
 import logging
 from collections import namedtuple
 from typing import Any, Optional

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -1,4 +1,5 @@
 """Tests of :class:`ixmp.Platform`."""
+
 import logging
 import re
 from sys import getrefcount

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -3,6 +3,7 @@
 import logging
 import re
 from sys import getrefcount
+from typing import TYPE_CHECKING
 from weakref import getweakrefcount
 
 import pandas as pd
@@ -13,6 +14,9 @@ from pytest import raises
 import ixmp
 from ixmp.backend import FIELDS
 from ixmp.testing import DATA, assert_logs, models
+
+if TYPE_CHECKING:
+    from ixmp import Platform
 
 
 class TestPlatform:
@@ -68,14 +72,11 @@ def test_scenario_list(mp):
     assert scenario[0] == "Hitchhiker"
 
 
-def test_export_timeseries_data(test_mp, tmp_path):
+def test_export_timeseries_data(mp: "Platform", tmp_path) -> None:
     path = tmp_path / "export.csv"
-    test_mp.export_timeseries_data(
-        path, model="Douglas Adams", unit="???", region="World"
-    )
+    mp.export_timeseries_data(path, model="Douglas Adams", unit="???", region="World")
 
     obs = pd.read_csv(path, index_col=False, header=0)
-
     exp = (
         DATA[0]
         .assign(**models["h2g2"], version=1, subannual="Year", meta=0)

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -239,6 +239,23 @@ class TestScenario:
         scen.init_par("foo", idx_sets=["i", "i", "j"], idx_names=["i0", "i1", "j"])
         scen.add_par("foo", pd.DataFrame(columns=["i0", "i1", "j"]), value=1.0)
 
+    def test_add_set(self, scen_empty) -> None:
+        # NB See also test_set(), below
+        scen = scen_empty
+
+        # Initialize a 0-D set
+        scen.init_set("i")
+        scen.init_set("foo", idx_sets=["i"])
+
+        # Exception raised on invalid arguments
+        with pytest.raises(ValueError, match="ambiguous; both key.*"):
+            scen.add_set("i", pd.DataFrame(columns=["i", "comment"]), comment="FOO")
+
+        # Bare str for 1-D set key is wrapped automatically
+        scen.add_set("i", "i0")
+        scen.add_set("foo", "i0")
+        assert {"i0"} == set(scen.set("foo")["i"])
+
     # Retrieve data
     def test_idx(self, scen):
         assert scen.idx_sets("d") == ["i", "j"]
@@ -549,7 +566,7 @@ def test_gh_210(scen_empty):
     assert all(foo_data.columns == columns)
 
 
-def test_set(scen_empty):
+def test_set(scen_empty) -> None:
     """Test ixmp.Scenario.add_set(), .set(), and .remove_set()."""
     scen = scen_empty
 

--- a/ixmp/tests/report/test_operator.py
+++ b/ixmp/tests/report/test_operator.py
@@ -1,6 +1,7 @@
 import logging
 import re
 from functools import partial
+from typing import cast
 
 import genno
 import pandas as pd
@@ -123,7 +124,8 @@ def test_update_scenario(caplog, test_mp) -> None:
     c.add("target", scen)
 
     # Create a pd.DataFrame suitable for Scenario.add_par()
-    data = dantzig_data["d"].query("j == 'chicago'").assign(j="toronto")
+    d = cast(pd.DataFrame, dantzig_data["d"])
+    data = d.query("j == 'chicago'").assign(j="toronto")
     data["value"] += 1.0
 
     # Add to the Reporter
@@ -141,7 +143,7 @@ def test_update_scenario(caplog, test_mp) -> None:
     assert len(scen.par("d")) == N_before + len(data)
 
     # Modify the data
-    data = pd.concat([dantzig_data["d"], data]).reset_index(drop=True)
+    data = pd.concat([d, data]).reset_index(drop=True)
     data["value"] *= 2.0
 
     # Convert to a Quantity object and re-add

--- a/ixmp/tests/report/test_operator.py
+++ b/ixmp/tests/report/test_operator.py
@@ -2,10 +2,11 @@ import logging
 import re
 from functools import partial
 
+import genno
 import pandas as pd
 import pyam
 import pytest
-from genno import ComputationError, Computer, Quantity
+from genno import ComputationError, Computer
 from genno.testing import assert_qty_equal
 from pandas.testing import assert_frame_equal
 
@@ -25,7 +26,7 @@ from ixmp.testing import assert_logs, make_dantzig
 pytestmark = pytest.mark.usefixtures("parametrize_quantity_class")
 
 
-def test_from_url(test_mp):
+def test_from_url(test_mp) -> None:
     ts = make_dantzig(test_mp)
 
     full_url = f"ixmp://{ts.platform.name}/{ts.url}"
@@ -43,7 +44,7 @@ def test_from_url(test_mp):
     assert ts.url == result.url
 
 
-def test_get_remove_ts(caplog, test_mp):
+def test_get_remove_ts(caplog, test_mp) -> None:
     ts = make_dantzig(test_mp)
 
     caplog.set_level(logging.INFO, "ixmp")
@@ -79,7 +80,7 @@ def test_get_remove_ts(caplog, test_mp):
     assert 3 == len(ts.timeseries())
 
 
-def test_map_as_qty():
+def test_map_as_qty() -> None:
     b = ["b1", "b2", "b3", "b4"]
     input = pd.DataFrame(
         [["f1", "b1"], ["f1", "b2"], ["f2", "b3"]], columns=["foo", "bar"]
@@ -87,7 +88,7 @@ def test_map_as_qty():
 
     result = map_as_qty(input, b)
 
-    exp = Quantity(
+    exp = genno.Quantity(
         pd.DataFrame(
             [
                 ["f1", "b1", 1],
@@ -105,7 +106,7 @@ def test_map_as_qty():
     assert_qty_equal(exp, result)
 
 
-def test_update_scenario(caplog, test_mp):
+def test_update_scenario(caplog, test_mp) -> None:
     scen = make_dantzig(test_mp)
     scen.check_out()
     scen.add_set("j", "toronto")
@@ -144,7 +145,7 @@ def test_update_scenario(caplog, test_mp):
     data["value"] *= 2.0
 
     # Convert to a Quantity object and re-add
-    q = Quantity(data.set_index(["i", "j"])["value"], name="d", units="km")
+    q = genno.Quantity(data.set_index(["i", "j"])["value"], name="d", units="km")
     c.add("input", q)
 
     # Revise the task; the parameter name ('demand') is read from the Quantity
@@ -158,7 +159,7 @@ def test_update_scenario(caplog, test_mp):
     assert_frame_equal(scen.par("d"), data)
 
 
-def test_store_ts(request, caplog, test_mp):
+def test_store_ts(request, caplog, test_mp) -> None:
     # Computer and target scenario
     c = Computer()
 

--- a/ixmp/tests/report/test_reporter.py
+++ b/ixmp/tests/report/test_reporter.py
@@ -23,7 +23,7 @@ def scenario(test_mp):
 
 
 @pytest.mark.usefixtures("protect_rename_dims")
-def test_configure(test_mp, test_data_path):
+def test_configure(test_mp, test_data_path) -> None:
     # Configure globally; handles 'rename_dims' section
     configure(rename_dims={"i": "i_renamed"})
 
@@ -43,7 +43,7 @@ def test_configure(test_mp, test_data_path):
     pytest.raises(KeyError, rep.get, "i")
 
 
-def test_reporter_from_scenario(scenario):
+def test_reporter_from_scenario(scenario) -> None:
     r = Reporter.from_scenario(scenario)
 
     r.finalize(scenario)
@@ -51,7 +51,7 @@ def test_reporter_from_scenario(scenario):
     assert "scenario" in r.graph
 
 
-def test_platform_units(test_mp, caplog, ureg):
+def test_platform_units(test_mp, caplog, ureg) -> None:
     """Test handling of units from ixmp.Platform.
 
     test_mp is loaded with some units including '-', '???', 'G$', etc. which
@@ -142,7 +142,7 @@ def test_platform_units(test_mp, caplog, ureg):
     assert unit.dimensionality == {"[USD]": 1, "[pkm]": -1}
 
 
-def test_cli(ixmp_cli, test_mp, test_data_path):
+def test_cli(ixmp_cli, test_mp, test_data_path) -> None:
     # Put something in the database
     test_mp.open_db()
     make_dantzig(test_mp)
@@ -187,7 +187,7 @@ seattle    chicago     1\.7
     ), result.output
 
 
-def test_filters(test_mp, tmp_path, caplog):
+def test_filters(test_mp, tmp_path, caplog) -> None:
     """Reporting can be filtered ex ante."""
     scen = ixmp.Scenario(test_mp, "Reporting filters", "Reporting filters", "new")
     t, t_foo, t_bar, x = add_test_data(scen)

--- a/ixmp/tests/report/test_util.py
+++ b/ixmp/tests/report/test_util.py
@@ -1,4 +1,4 @@
-def test_import_rename_dims():
+def test_import_rename_dims() -> None:
     """RENAME_DIMS can be imported from .report.util, though defined in .common."""
     from ixmp.report.util import RENAME_DIMS
 

--- a/ixmp/tests/test_compat.py
+++ b/ixmp/tests/test_compat.py
@@ -1,4 +1,5 @@
 """Tests for compatibility with other packages, especially :mod:`message_ix`."""
+
 from pathlib import Path
 
 import pytest

--- a/ixmp/tests/test_perf.py
+++ b/ixmp/tests/test_perf.py
@@ -1,4 +1,5 @@
 """Performance tests."""
+
 from functools import partial
 
 import pytest

--- a/ixmp/tests/test_util.py
+++ b/ixmp/tests/test_util.py
@@ -1,4 +1,5 @@
 """Tests for ixmp.util."""
+
 import logging
 
 import numpy as np

--- a/ixmp/util/__init__.py
+++ b/ixmp/util/__init__.py
@@ -618,13 +618,8 @@ def show_versions(file=sys.stdout):
 
         # Retrieve git log information, if any
         gl = _git_log(mod)
-        try:
-            version = mod.__version__
-        except Exception:
-            # __version__ not available
-            version = "installed"
-        finally:
-            info.append((module_name, version + gl))
+        version = getattr(mod, "__version__", "installed") or ""
+        info.append((module_name, version + gl))
 
         if module_name == "jpype":
             info.append(("… JVM path", mod.getDefaultJVMPath()))

--- a/ixmp/util/__init__.py
+++ b/ixmp/util/__init__.py
@@ -9,7 +9,7 @@ from importlib.util import find_spec
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
-    Dict,
+    Any,
     Iterable,
     Iterator,
     List,
@@ -57,7 +57,7 @@ def logger():
     return logging.getLogger("ixmp")
 
 
-def as_str_list(arg, idx_names: Optional[Iterable[str]] = None):
+def as_str_list(arg, idx_names: Optional[Iterable[str]] = None) -> List[str]:
     """Convert various `arg` to list of str.
 
     Several types of arguments are handled:
@@ -70,11 +70,11 @@ def as_str_list(arg, idx_names: Optional[Iterable[str]] = None):
 
     """
     if arg is None:
-        return None
+        return []
     elif idx_names is None:
         # arg must be iterable
-        # NB narrower ABC Sequence does not work here; e.g. test_excel_io()
-        #    fails via Scenario.add_set().
+        # NB narrower ABC Sequence does not work here; e.g. test_excel_io() fails via
+        #    Scenario.add_set().
         if isinstance(arg, Iterable) and not isinstance(arg, str):
             return list(map(str, arg))
         else:
@@ -120,7 +120,7 @@ def diff(a, b, filters=None) -> Iterator[Tuple[str, pd.DataFrame]]:
     ]
     # State variables for loop
     name = ["", ""]
-    data: List[pd.DataFrame] = [None, None]
+    data: List[pd.DataFrame] = [pd.DataFrame(), pd.DataFrame()]
 
     # Elements for first iteration
     name[0], data[0] = next(items[0])
@@ -146,7 +146,7 @@ def diff(a, b, filters=None) -> Iterator[Tuple[str, pd.DataFrame]]:
 
         # Either merge on remaining columns; or, for scalars, on the indices
         on = sorted(set(left.columns) - {"value", "unit"})
-        on_arg: Dict[str, object] = (
+        on_arg: Mapping[str, Any] = (
             dict(on=on) if on else dict(left_index=True, right_index=True)
         )
 
@@ -173,7 +173,7 @@ def diff(a, b, filters=None) -> Iterator[Tuple[str, pd.DataFrame]]:
             except StopIteration:
                 # No more data for this iterator.
                 # Use "~" because it sorts after all ASCII characters
-                name[i], data[i] = "~ end", None
+                name[i], data[i] = "~ end", pd.DataFrame()
 
         if name[0] == name[1] == "~ end":
             break

--- a/ixmp/util/sphinx_linkcode_github.py
+++ b/ixmp/util/sphinx_linkcode_github.py
@@ -10,7 +10,7 @@ from typing import TYPE_CHECKING, Optional, Tuple
 
 from sphinx.util import logging
 
-if TYPE_CHECKING:  # pragma: no cover
+if TYPE_CHECKING:
     import sphinx.application
 
 log = logging.getLogger(__name__)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -107,15 +107,13 @@ markers = [
   "performance: ixmp performance test.",
 ]
 
-[tool.ruff]
+[tool.ruff.lint]
 select = ["C9", "E", "F", "I", "W"]
-
-[tool.ruff.mccabe]
 # FIXME the following exceed this limit
 # .backend.io.s_read_excel: 26
 # .backend.jdbc.JDBCBackend.item_get_elements: 19
 # .core.scenario.Scenario.add_set: 17
-max-complexity = 15
+mccabe.max-complexity = 15
 
 [tool.setuptools.packages]
 find = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -83,12 +83,10 @@ omit = ["ixmp/util/sphinx_linkcode_github.py"]
 [[tool.mypy.overrides]]
 # Packages/modules for which no type hints are available.
 module = [
-  "dask.*",
   "jpype",
   "memory_profiler",
-  "pandas.*",
-  "pyam",
   "pretenders.*",
+  "pyam",
 ]
 ignore_missing_imports = true
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,6 +50,7 @@ documentation = "https://docs.messageix.org/ixmp"
 [project.optional-dependencies]
 docs = [
   "ixmp[tests]",
+  "genno >= 1.26",  # For sphinx extensions; see doc/conf.py
   "GitPython",
   "numpydoc",
   "sphinx >= 3.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -109,10 +109,11 @@ markers = [
 [tool.ruff.lint]
 select = ["C9", "E", "F", "I", "W"]
 # FIXME the following exceed this limit
-# .backend.io.s_read_excel: 26
-# .backend.jdbc.JDBCBackend.item_get_elements: 19
-# .core.scenario.Scenario.add_set: 17
-mccabe.max-complexity = 15
+# .backend.io.s_read_excel: 22
+# .backend.jdbc.JDBCBackend.item_get_elements: 18
+# .core.scenario.Scenario.add_par: 15
+# .core.scenario.Scenario.add_set: 18
+mccabe.max-complexity = 13
 
 [tool.setuptools.packages]
 find = {}


### PR DESCRIPTION
- Adapt to genno 1.25.
- Improve documentation cross-references using sphinx extensions provided by genno 1.26.
- Bump ruff, mypy versions and remove outdated typing exclusions.
  - Adjust code to pass type checks with pandas-stubs.
- Handle `package.__version__ = None` in show_versions().
- Add dependabot config for GitHub Actions used in workflows.
- Bump pre-commit action version to suppress GHA warnings.

## How to review

- Read the diff and note that the CI checks all pass.
- View the preview build of the documentation, particularly the reporting page.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- ~Update release notes.~ No change in functionality.