### PR TITLE
Use "macos-13" runner label in "pytest" workflow

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       matrix:
         os:
-        - macos-latest
+        - macos-13
         - ubuntu-latest
         - windows-latest
         python-version:


### PR DESCRIPTION
@glatterf42 noticed today that CI jobs were failing:
- For ixmp, message-ix, and message-ix-models.
- For macOS only.

…and traced this to a change in the standard GitHub Actions runners.

- `macos-latest` now runs on the M1/amd64 architecture.
- The amd64 architecture runners encounter the same problem discussed at #473 and more recently [again in Slack](https://iiasa-ece.slack.com/archives/CD0GBHHA4/p1712746002896289).
- We looked at:
  - https://github.com/actions/runner-images/blame/a76eae469e4c8c16b0f91c38e17f9e1ffb5c633d/README.md#L26-L30
  - actions/runner-images#9255
  - https://github.blog/changelog/2024-01-30-github-actions-macos-14-sonoma-is-now-available/
  - https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners/about-larger-runners
  - https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories
- We interpret that:
  - For macOS, the only available options are (a) `macos-14`=`macos-latest`, which is on amd64, or (b) `macos-14-large`=`macos-latest-large`, which is on x86_64 but (per the above) not free.
  - The most recent macOS image that is both free and on x86_64 is `macos-13`.

This PR switches to `macos-13` for these workflows.
**NB** I also had to change the branch protection rule for `main` to replace `macos-latest-py3.12` as a required check with `macos-13-py3.12`.

- Another possible mitigation, but more work, is to get the workaround discussed in #473 to function on the GHA amd64 runners.
- In the future, `macos-12` and eventually `macos-13` labels will be deprecated and removed by GitHub. The above issue gives 2024-Q3 to deprecate and 2024-Q4 to remove `macos-12`, and has `macos-13` still in general availability ("GA") through 2024-Q4.
- We would need to either do the above or get the test suite running with ixmp4 for macOS, i.e. via #516 and other work.

## How to review

Note that the CI checks all pass.

## PR checklist

- [ ] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A
- ~Update release notes.~