### PR TITLE
Pin bottle version to fix CI runs

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -115,6 +115,9 @@ jobs:
         # see https://github.com/iiasa/ixmp/issues/534
         pip install "pint != 0.24.0" "numpy < 2"
 
+        # TEMPORARY Work around pretenders/pretenders#153
+        pip install "bottle < 0.13"
+
     - name: Install R dependencies and tutorial requirements
       run: |
         install.packages(c("remotes", "Rcpp"))


### PR DESCRIPTION
Exactly the same as #541 to ensure the windows CI failures don't originate from that PR coming from my fork.

Four days ago, [bottle released version 0.13.0](https://pypi.org/project/bottle/) and `v0.13.1` two days afterwards. Unfortunately, these versions are incompatible with [pretenders](https://github.com/pretenders/pretenders), which we use in `test_access` to mock a local http server which we can target with access-related requests. 

Pretenders hasn't been updated in two years, so I think it's unlikely we'll receive a patch here. For clarification, I've still opened https://github.com/pretenders/pretenders/issues/153, though.

To replace pretenders, I thought about using `monkeypatch` to patch the result of `self._backend.get_auth()` in `Platform.check_access()`, but that would probably miss the point since we want to test this authentication-getting function, I think.
I've considered [responses](https://github.com/getsentry/responses) (as suggested [here](https://smirnov-am.github.io/pytest-testing_http_client/)) but couldn't quite get it to work. Maybe the information I'm missing is not in their docs or maybe it's just too awkward to configure a mock server response for the authentication code, which seems to be baked into the old java code. 
Next, I've tried [pytest-httpserver](https://pytest-httpserver.readthedocs.io/en/latest/index.html), which just needs to be installed with `pip` and is then immediately available as a pytest fixture. I got a little further here, did at least manage to get the login request sent to the mock server, but still couldn't make it work because I was apparently missing something about json-deserialization, strings and lists in java:

```java
Caused by: com.fasterxml.jackson.databind.exc.MismatchedInputException: Cannot deserialize instance of `java.util.ArrayList` out of VALUE_STRING token
```

Lastly, I considered migrating the code from pretenders into our code base (the essential part at least) and using bottle directly. However, this seems unwise in terms of maintenance. So for now, this PR pins the bottle version to the latest working one. In an ideal world, we put a bit more focus on developing ixmp4 and begin the migration still this year, so that we don't have to worry about this for too long.
Alternatively, we might have to revisit this and fix our mocking approach when the pinned bottle version doesn't support the latest python version or some such.


## How to review

Please jump in here if you have a good idea for a sustainable solution. Otherwise, just note the CI checks all pass ... for now.

@khaeru Please let me know if we should also put this pin in `pyproject.toml`. If we don't, new installations will probably end up with not-working dependencies.

## PR checklist

- [x] Continuous integration checks all ✅
- ~Add or expand tests;~ coverage checks both ✅ Just CI.
- ~Add, expand, or update documentation.~ Just CI.
- ~Update release notes.~
