### PR TITLE
Remove pin of outdated R version

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -80,8 +80,6 @@ jobs:
 
     - uses: r-lib/actions/setup-r@v2
       id: setup-r
-      with:
-        r-version: '4.2.3'
 
     - name: Cache GAMS installer and R packages
       uses: actions/cache@v4


### PR DESCRIPTION
Today, I was reminded of #479, which recorded some problem of possibly interfering versions `4.2.3` and `4.3.0` of R in our CI test suite. These were encountered in #478, which introduced a workaround by pinning to `4.2.3`.

The current release is `4.4.1`, so this workaround/pin might be outdated. This PR tries removing the pin to see if our test suite is still working fine with the latest version of R.

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

- [x] Continuous integration checks all ✅
- [x] Update tests setup
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update release notes.~ Just CI.

