### PR TITLE
Fix CI run on `ubuntu-latest-py3.12`

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -126,7 +126,7 @@ jobs:
         remotes::install_cran(
           c("IRkernel", "reticulate"),
           dependencies = TRUE,
-          # force = TRUE,
+          force = TRUE,
         )
 
         IRkernel::installspec()

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -143,9 +143,9 @@ jobs:
 
         paste(c(shQuote('jupyter'), c('kernelspec', '--version')), collapse = " ")
 
-        system('jupyter kernelspec --version')
+        system('jupyter-kernelspec --version')
 
-        system2('jupyter', c('kernelspec', '--version'), TRUE, TRUE)
+        system2('jupyter-kernelspec', '--version', TRUE, TRUE)
 
         IRkernel::installspec()
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -138,6 +138,10 @@ jobs:
         )
 
         system2('which', 'python', TRUE, TRUE)
+
+        system2('which', 'pip', TRUE, TRUE)
+        system2('pip', 'list', TRUE, TRUE)
+
         system2('which', 'jupyter', TRUE, TRUE)
         system2('which', 'jupyter-kernelspec', TRUE, TRUE)
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -128,6 +128,10 @@ jobs:
       run: echo $PATH
       shell: bash
 
+    - name: Debug PYTHONPATH
+      run: echo $PYTHONPATH
+      shell: bash
+
     - name: Install R dependencies and tutorial requirements
       run: |
         install.packages(c("remotes", "Rcpp"))

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -120,6 +120,10 @@ jobs:
       run: jupyter kernelspec --version
       shell: bash
 
+    - name: Debug which Rscript is used below
+      run: which Rscript
+      shell: bash
+
     - name: Install R dependencies and tutorial requirements
       run: |
         install.packages(c("remotes", "Rcpp"))

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -138,6 +138,7 @@ jobs:
         )
 
         system2('which', 'python', TRUE, TRUE)
+        system2('echo', '$PYTHONPATH', TRUE, TRUE)
 
         system2('which', 'pip', TRUE, TRUE)
         system2('pip', 'list', TRUE, TRUE)

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -133,6 +133,11 @@ jobs:
           force = TRUE,
         )
 
+        system2('which', 'python', TRUE, TRUE)
+        system2('which', 'jupyter', TRUE, TRUE)
+
+        system('jupyter', c('kernelspec', '--version'), TRUE, TRUE)
+
         system2('jupyter', c('kernelspec', '--version'), TRUE, TRUE)
 
         IRkernel::installspec()

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -129,7 +129,7 @@ jobs:
           force = TRUE,
         )
 
-        system2('jupyter', c('kernelspec', '--version'), FALSE, FALSE)
+        system2('jupyter', c('kernelspec', '--version'), TRUE, TRUE)
 
         IRkernel::installspec()
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -19,14 +19,14 @@ jobs:
     strategy:
       matrix:
         os:
-        - macos-13
-        - macos-latest
+        # - macos-13
+        # - macos-latest
         - ubuntu-latest
-        - windows-latest
+        # - windows-latest
         python-version:
-        - "3.8"  # Earliest version supported by ixmp
-        - "3.9"
-        - "3.10"
+        # - "3.8"  # Earliest version supported by ixmp
+        # - "3.9"
+        # - "3.10"
         - "3.11"
         - "3.12"  # Latest supported by ixmp
         gams-version:
@@ -74,32 +74,32 @@ jobs:
         cache: pip
         cache-dependency-path: "**/pyproject.toml"
 
-    - uses: ts-graphviz/setup-graphviz@v2
-      # TEMPORARY Work around ts-graphviz/setup-graphviz#630
-      if: ${{ ! startswith(matrix.os, 'macos-') }}
+    # - uses: ts-graphviz/setup-graphviz@v2
+    #   # TEMPORARY Work around ts-graphviz/setup-graphviz#630
+    #   if: ${{ ! startswith(matrix.os, 'macos-') }}
 
     - uses: r-lib/actions/setup-r@v2
       id: setup-r
 
-    - name: Cache GAMS installer and R packages
-      uses: actions/cache@v4
-      with:
-        path: |
-          gams
-          ${{ env.R_LIBS_USER }}
-        key: ${{ matrix.os }}-R${{ steps.setup-r.outputs.installed-r-version }}
-        restore-keys: |
-          ${{ matrix.os }}-
+    # - name: Cache GAMS installer and R packages
+    #   uses: actions/cache@v4
+    #   with:
+    #     path: |
+    #       gams
+    #       ${{ env.R_LIBS_USER }}
+    #     key: ${{ matrix.os }}-R${{ steps.setup-r.outputs.installed-r-version }}
+    #     restore-keys: |
+    #       ${{ matrix.os }}-
 
-    - uses: iiasa/actions/setup-gams@main
-      with:
-        version: ${{ matrix.gams-version }}
-        license: ${{ secrets.GAMS_LICENSE }}
+    # - uses: iiasa/actions/setup-gams@main
+    #   with:
+    #     version: ${{ matrix.gams-version }}
+    #     license: ${{ secrets.GAMS_LICENSE }}
 
-    - name: Set RETICULATE_PYTHON
-      # Use the environment variable set by the setup-python action, above.
-      run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
-      shell: bash
+    # - name: Set RETICULATE_PYTHON
+    #   # Use the environment variable set by the setup-python action, above.
+    #   run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
+    #   shell: bash
 
     - name: Install Python package and dependencies
       # [docs] contains [tests], which contains [report,tutorial]

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -128,8 +128,8 @@ jobs:
       run: echo $PATH
       shell: bash
 
-    - name: Debug PYTHONPATH
-      run: echo $PYTHONPATH
+    - name: Debug python path
+      run: python -c "import sys; print(sys.executable, sys.path)"
       shell: bash
 
     - name: Install R dependencies and tutorial requirements
@@ -142,7 +142,7 @@ jobs:
         )
 
         system2('which', 'python', TRUE, TRUE)
-        system2('echo', '$PYTHONPATH', TRUE, TRUE)
+        system2('python', '-c "import sys; print(sys.executable, sys.path)"', TRUE, TRUE)
 
         system2('which', 'pip', TRUE, TRUE)
         system2('pip', 'list', TRUE, TRUE)

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -136,6 +136,8 @@ jobs:
         system2('which', 'python', TRUE, TRUE)
         system2('which', 'jupyter', TRUE, TRUE)
 
+        paste(c(shQuote('jupyter'), c('kernelspec', '--version')), collapse = " ")
+
         system('jupyter kernelspec --version')
 
         system2('jupyter', c('kernelspec', '--version'), TRUE, TRUE)

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -129,6 +129,8 @@ jobs:
           force = TRUE,
         )
 
+        system2('jupyter', c('kernelspec', '--version'), FALSE, FALSE)
+
         IRkernel::installspec()
 
         # commented: for debugging

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -136,7 +136,7 @@ jobs:
         system2('which', 'python', TRUE, TRUE)
         system2('which', 'jupyter', TRUE, TRUE)
 
-        system('jupyter', c('kernelspec', '--version'), TRUE, TRUE)
+        system('jupyter kernelspec --version')
 
         system2('jupyter', c('kernelspec', '--version'), TRUE, TRUE)
 
@@ -145,7 +145,7 @@ jobs:
         # commented: for debugging
         # print(reticulate::py_config())
         # reticulate::py_run_string("import os; print(os.environ)")
-      shell: Rscript {0}
+      shell: Rscript --verbose {0}
 
     - name: Run test suite using pytest
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -116,6 +116,10 @@ jobs:
         # TEMPORARY Work around pretenders/pretenders#153
         pip install "bottle < 0.13"
 
+    - name: Debug jupyter kernelspec --version
+      run: jupyter kernelspec --version
+      shell: bash
+
     - name: Install R dependencies and tutorial requirements
       run: |
         install.packages(c("remotes", "Rcpp"))

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -124,6 +124,10 @@ jobs:
       run: which Rscript
       shell: bash
 
+    - name: Debug PATH
+      run: echo $PATH
+      shell: bash
+
     - name: Install R dependencies and tutorial requirements
       run: |
         install.packages(c("remotes", "Rcpp"))
@@ -135,6 +139,7 @@ jobs:
 
         system2('which', 'python', TRUE, TRUE)
         system2('which', 'jupyter', TRUE, TRUE)
+        system2('which', 'jupyter-kernelspec', TRUE, TRUE)
 
         paste(c(shQuote('jupyter'), c('kernelspec', '--version')), collapse = " ")
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -67,6 +67,10 @@ jobs:
       with:
         fetch-depth: ${{ env.depth }}
         fetch-tags: true
+  
+    - name: Debug python path
+      run: python -c "import sys; print(sys.executable, sys.path)"
+      shell: bash
 
     - uses: actions/setup-python@v5
       with:


### PR DESCRIPTION
At the moment, this PR mainly runs the CI checks to debug the mysterious error message observed even after multiple re-runs and cache deletions on `ubuntu-latest-py3.12`:

```Rscript
 Error in IRkernel::installspec() : 
  jupyter-client has to be installed but “jupyter kernelspec --version” exited with code 1.
```

This error is not flaky and does not seem to originate from outdated cached tool versions (at least after removing the `ubuntu-latest-R-4.4.1` cache, the error persisted). It might be related to [`ubuntu-latest` slowly changing to `24.04` over the course of this month](https://github.com/actions/runner-images/issues/10636), but the `...-py3.11` test uses the exact same runner image and workflow file without problems. 

## How to review

**Required:** describe specific things that reviewer(s) must do, in order to ensure that the PR achieves its goal.
If no review is required, write “No review: …” and describe why.

<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- View the preview build of the documentation and look at a certain page.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist


- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.

