### PR TITLE
Bump codecov-action version to v5

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -142,7 +142,7 @@ jobs:
       shell: bash
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v4
+      uses: codecov/codecov-action@v5
       # FIXME Limit runtime until
       # https://github.com/codecov/codecov-action/issues/1316 is resolved
       timeout-minutes: 1


### PR DESCRIPTION
dependabot opened #548 automatically, but for some reason, the codecov status is not reported (and the check continually 'expected'). This happens infrequently and usually, I just un-require the check, merge the PR, and re-require it if I now the PR is not making changes to coverage anyway. 
This time, though, I'm not too sure that everything's alright since we are changing the version of the codecov action that our pytest workflow is using. I tried running all checks again, but that didn't trigger the codecov check. Next, I has dependabot 'recreate' #548, which triggered some kind of rebase, but the checks still didn't run. In the meantime, I looked at the [codecov page for the PR](https://app.codecov.io/gh/iiasa/ixmp/pull/548), which seems to say that no reports for the PR's only commit were uploaded. Unfortunately, there doesn't seem to be any option to trigger the check manually, either. That's why I'm now creating this brand new PR with exactly the same changes as #548 in the hopes of triggering the codecov checks.
If this doesn't work, I might have to explore in detail what changed with the version bump and how we relied on that. 

## How to review

- Read the diff and note that the CI checks all pass (in particular the codecov checks).


## PR checklist

- [x] Continuous integration checks all ✅
- [ ] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI version bump.
- ~[ ] Update release notes.~ Just CI version bump.
