### PR TITLE
Adjust test suite to JPype1.5.1

### DIFF
--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -1,5 +1,4 @@
 import re
-import sys
 from pathlib import Path
 from shutil import copyfile
 
@@ -98,13 +97,8 @@ class TestScenario:
 
         # Giving an invalid scenario with errors='warn' causes a message to be logged
         msg = (
-            "ValueError: "
-            + (
-                "scenario='Hitchhikerfoo'"
-                if sys.version_info.minor != 12
-                else "model, scenario, or version not found"
-            )
-            + f"\nwhen loading Scenario from url: {repr(url + 'foo')}"
+            "ValueError: scenario='Hitchhikerfoo'\n"
+            f"when loading Scenario from url: {repr(url + 'foo')}"
         )
         with assert_logs(caplog, msg):
             scen, mp = ixmp.Scenario.from_url(url + "foo")

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -1,5 +1,4 @@
 import re
-import sys
 from pathlib import Path
 
 import pandas as pd
@@ -422,12 +421,7 @@ def test_solve(ixmp_cli, test_mp):
     ]
     result = ixmp_cli.invoke(cmd)
     assert result.exit_code == 1, result.output
-    exp = (
-        "='non-existing'"
-        if sys.version_info.minor != 12
-        else ", scenario, or version not found"
-    )
-    assert f"Error: model{exp}" in result.output
+    assert "Error: model='non-existing'" in result.output
 
     result = ixmp_cli.invoke([f"--url=ixmp://{test_mp.name}/foo/bar", "solve"])
     assert UsageError.exit_code == result.exit_code, result.output


### PR DESCRIPTION
JPype1 just released their version 1.5.1, which now supports Python 3.13 :)
Unfortunately, it also broke our CI test suite, but only two parts [that we initially adjusted for Python 3.12 and JPype1 1.5.0](https://github.com/iiasa/ixmp/commit/b4a135ebf585a592c9214c86eb5f2f5f89b0b963#diff-290e07a543b8219f2380c85fa9ed7e9e188c01e6df0acb23c14f8238eefb75edL406), so this PR simply reverts these changes, hoping it should let the tests pass again. 


## How to review


- Read the diff and note that the CI checks all pass.


## PR checklist


- [x] Continuous integration checks all ✅
- [x] Update tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just test adjustment.
- ~[ ] Update release notes.~ Just test adjustment.

