### PR TITLE
Apply workaround for Ubuntu Python 3.12-path-R CI failure

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -123,12 +123,6 @@ jobs:
         )
 
         reticulate::py_config()
-
-        # commented: for debugging
-        # print(reticulate::py_config())
-        # reticulate::py_run_string("import os; print(os.environ)")
-
-        # IRkernel::installspec()
       shell: Rscript {0}
 
     - name: Install R dependencies and tutorial requirements

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -112,6 +112,27 @@ jobs:
         pip install --upgrade pint
 
     - name: Install R dependencies and tutorial requirements
+      # Workaround for https://github.com/actions/runner-images/issues/11137
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+      run: |
+        install.packages(c("remotes", "Rcpp"))
+        remotes::install_cran(
+          c("IRkernel", "reticulate"),
+          dependencies = TRUE,
+          # force = TRUE,
+        )
+
+        reticulate::py_config()
+
+        # commented: for debugging
+        # print(reticulate::py_config())
+        # reticulate::py_run_string("import os; print(os.environ)")
+
+        # IRkernel::installspec()
+      shell: Rscript {0}
+
+    - name: Install R dependencies and tutorial requirements
+      if: ${{ ! (matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12') }}
       run: |
         install.packages(c("remotes", "Rcpp"))
         remotes::install_cran(
@@ -121,10 +142,10 @@ jobs:
         )
 
         # commented: for debugging
-        print(reticulate::py_config())
-        reticulate::py_run_string("import os; print(os.environ)")
+        # print(reticulate::py_config())
+        # reticulate::py_run_string("import os; print(os.environ)")
 
-        # IRkernel::installspec()
+        IRkernel::installspec()
       shell: Rscript {0}
 
     - name: Run test suite using pytest

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -99,6 +99,15 @@ jobs:
       run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
       shell: bash
 
+    # Workaround Python Path in R issue https://github.com/actions/runner-images/issues/11137
+    - name: Install system dependencies for R packages
+      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
+        sudo apt-get install -y python3-pip python3-dev
+        # pip3 install jupyter
+
     - name: Install Python package and dependencies
       # [docs] contains [tests], which contains [report,tutorial]
       run: |
@@ -111,21 +120,35 @@ jobs:
         # limits pint < 0.17. Override. cf. iiasa/ixmp#544
         pip install --upgrade pint
 
-    - name: Install R dependencies and tutorial requirements
+    # - name: Install R dependencies and tutorial requirements
+    #   run: |
+    #     install.packages(c("remotes", "Rcpp"))
+    #     remotes::install_cran(
+    #       c("IRkernel", "reticulate"),
+    #       dependencies = TRUE,
+    #       # force = TRUE,
+    #     )
+
+    #     pip install jupyter
+    #     Rscript -e "IRkernel::installspec()"
+
+    #     # IRkernel::installspec()
+
+    #     # commented: for debugging
+    #     # print(reticulate::py_config())
+    #     # reticulate::py_run_string("import os; print(os.environ)")
+    #   shell: Rscript {0}
+
+    - name: Install R dependencies
       run: |
-        install.packages(c("remotes", "Rcpp"))
-        remotes::install_cran(
-          c("IRkernel", "reticulate"),
-          dependencies = TRUE,
-          # force = TRUE,
-        )
-
-        IRkernel::installspec()
-
-        # commented: for debugging
-        # print(reticulate::py_config())
-        # reticulate::py_run_string("import os; print(os.environ)")
-      shell: Rscript {0}
+        R -e "install.packages(c('remotes', 'Rcpp'))"
+        R -e "remotes::install_cran(c('IRkernel', 'reticulate'), dependencies = TRUE)"
+    - name: Install Jupyter via pip
+      run: |
+        pip install jupyter
+    - name: Configure IRkernel
+      run: |
+        Rscript -e "IRkernel::installspec()"
 
     - name: Run test suite using pytest
       run: |

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -99,15 +99,6 @@ jobs:
       run: echo "RETICULATE_PYTHON=$pythonLocation" >> $GITHUB_ENV
       shell: bash
 
-    # Workaround Python Path in R issue https://github.com/actions/runner-images/issues/11137
-    - name: Install system dependencies for R packages
-      if: ${{ matrix.os == 'ubuntu-latest' && matrix.python-version == '3.12' }}
-      run: |
-        sudo apt-get update
-        sudo apt-get install -y libcurl4-openssl-dev libssl-dev libxml2-dev
-        sudo apt-get install -y python3-pip python3-dev
-        # pip3 install jupyter
-
     - name: Install Python package and dependencies
       # [docs] contains [tests], which contains [report,tutorial]
       run: |
@@ -120,35 +111,21 @@ jobs:
         # limits pint < 0.17. Override. cf. iiasa/ixmp#544
         pip install --upgrade pint
 
-    # - name: Install R dependencies and tutorial requirements
-    #   run: |
-    #     install.packages(c("remotes", "Rcpp"))
-    #     remotes::install_cran(
-    #       c("IRkernel", "reticulate"),
-    #       dependencies = TRUE,
-    #       # force = TRUE,
-    #     )
-
-    #     pip install jupyter
-    #     Rscript -e "IRkernel::installspec()"
-
-    #     # IRkernel::installspec()
-
-    #     # commented: for debugging
-    #     # print(reticulate::py_config())
-    #     # reticulate::py_run_string("import os; print(os.environ)")
-    #   shell: Rscript {0}
-
-    - name: Install R dependencies
+    - name: Install R dependencies and tutorial requirements
       run: |
-        R -e "install.packages(c('remotes', 'Rcpp'))"
-        R -e "remotes::install_cran(c('IRkernel', 'reticulate'), dependencies = TRUE)"
-    - name: Install Jupyter via pip
-      run: |
-        pip install jupyter
-    - name: Configure IRkernel
-      run: |
-        Rscript -e "IRkernel::installspec()"
+        install.packages(c("remotes", "Rcpp"))
+        remotes::install_cran(
+          c("IRkernel", "reticulate"),
+          dependencies = TRUE,
+          # force = TRUE,
+        )
+
+        # commented: for debugging
+        print(reticulate::py_config())
+        reticulate::py_run_string("import os; print(os.environ)")
+
+        # IRkernel::installspec()
+      shell: Rscript {0}
 
     - name: Run test suite using pytest
       run: |


### PR DESCRIPTION
This PR tries to implement the workaround identified in https://github.com/actions/runner-images/issues/11137 for the CI failure on Ubuntu 24.04 with Python 3.12. 
I'm not sure which part(s) of the suggested workaround are actually required, some seem to evaluate to no-ops (e.g. `libssl-dev is already the newest version (3.0.2-0ubuntu1.18).`). I'll play around with the steps to see if the workaround can be made more concise. 

## How to review

- Read the diff and note that the CI checks all pass (in particular the one on `ubuntu-latest-py3.12`).


## PR checklist


- [x] Continuous integration checks all ✅
- [x] Update tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update release notes.~ Just CI.
