### PR TITLE
Add ixmp4-backed platform functions

### DIFF
--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -204,12 +204,13 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def get_nodes(self) -> Iterable[tuple[str, Optional[str], str, str]]:
+    def get_nodes(self) -> Iterable[tuple[str, Optional[str], Optional[str], str]]:
         """Iterate over all nodes stored on the Platform.
 
         Yields
         -------
         tuple
+
             The members of each tuple are:
 
             ========= =========== ===
@@ -820,7 +821,7 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def list_items(self, s: Scenario, type: str) -> list[str]:
+    def list_items(self, s: Scenario, type: Literal["set", "par", "equ"]) -> list[str]:
         """Return a list of names of items of `type`.
 
         Parameters
@@ -832,7 +833,7 @@ class Backend(ABC):
     def init_item(
         self,
         s: Scenario,
-        type: str,
+        type: Literal["set", "par", "equ", "var"],
         name: str,
         idx_sets: Sequence[str],
         idx_names: Optional[Sequence[str]],
@@ -871,7 +872,9 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def item_index(self, s: Scenario, name: str, sets_or_names: str) -> list[str]:
+    def item_index(
+        self, s: Scenario, name: str, sets_or_names: Literal["sets", "names"]
+    ) -> list[str]:
         """Return the index sets or names of item `name`.
 
         Parameters
@@ -932,7 +935,7 @@ class Backend(ABC):
     def item_set_elements(
         self,
         s: Scenario,
-        type: str,
+        type: Literal["par", "set"],
         name: str,
         elements: Iterable[tuple[Any, Optional[float], Optional[str], Optional[str]]],
     ) -> None:

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -180,7 +180,10 @@ class IXMP4Backend(CachingBackend):
     def is_default(self, ts: TimeSeries) -> bool:
         return self.index[ts].is_default()
 
-    # Handle various items
+    def has_solution(self, s: Scenario) -> bool:
+        return self.index[s].optimization.has_solution()
+
+    # Handle optimization items
 
     # TODO: type hints
     def _get_repo(
@@ -308,10 +311,6 @@ class IXMP4Backend(CachingBackend):
         if comment:
             scalar.docs = comment
 
-    ### TODO
-    ###
-    ### Currently, tests fail because they expect 'cases' to be predefined on the test_mp
-
     def _add_data_to_parameter(
         self,
         s: Scenario,
@@ -396,7 +395,6 @@ class IXMP4Backend(CachingBackend):
             # as such?
             _, item = self._get_item(s=s, name=name, type=type)
             data = pd.DataFrame(item.data)
-            print(data)
             if type == "par":
                 data.rename(columns={"values": "value", "units": "unit"}, inplace=True)
             else:
@@ -404,6 +402,8 @@ class IXMP4Backend(CachingBackend):
                     columns={"levels": "level", "marginals": "marginal"}, inplace=True
                 )
             return data
+
+    # Handle timeslices
 
     # The below methods of base.Backend are not yet implemented
     def _ni(self, *args, **kwargs):
@@ -422,7 +422,6 @@ class IXMP4Backend(CachingBackend):
     get_geo = _ni
     get_meta = _ni
     get_timeslices = _ni
-    has_solution = _ni
     item_delete_elements = _ni
     last_update = _ni
     remove_meta = _ni

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -1,8 +1,12 @@
 import logging
-from collections.abc import Generator, MutableMapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from collections.abc import Generator, Iterable, MutableMapping, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
+
+import pandas as pd
 
 from ixmp.backend.base import CachingBackend
+from ixmp.core.scenario import Scenario
+from ixmp.core.timeseries import TimeSeries
 
 if TYPE_CHECKING:
     import ixmp4
@@ -16,6 +20,10 @@ class IXMP4Backend(CachingBackend):
 
     _platform: "ixmp4.Platform"
     _backend: "ixmp4_backend"
+
+    # Mapping from ixmp.TimeSeries object to the underlying ixmp4.Run object (or
+    # subclasses of either)
+    index: dict[TimeSeries, "ixmp4.Run"] = {}
 
     def __init__(self, _backend: Optional["ixmp4_backend"] = None) -> None:
         from ixmp4 import Platform
@@ -56,8 +64,10 @@ class IXMP4Backend(CachingBackend):
     # def close_db(self) -> None:
     #     self._backend.close()
 
+    # Modifying the Platform
+
     def add_scenario_name(self, name: str) -> None:
-        self._platform.scenarios.create(name)
+        self._platform.scenarios.create(name=name)
 
     # TODO clarify: ixmp4.Run doesn't have a name, but is the new ixmp.Scenario
     # should it have a name or are these scenario names okay?
@@ -66,7 +76,7 @@ class IXMP4Backend(CachingBackend):
             yield scenario.name
 
     def add_model_name(self, name: str) -> None:
-        self._platform.models.create(name)
+        self._platform.models.create(name=name)
 
     def get_model_names(self) -> Generator[str, None, None]:
         for model in self._platform.models.list():
@@ -76,10 +86,324 @@ class IXMP4Backend(CachingBackend):
         return self._platform.runs.list()
 
     def set_unit(self, name: str, comment: str) -> None:
-        self._platform.units.create(name).docs = comment
+        self._platform.units.create(name=name).docs = comment
 
     def get_units(self) -> list[str]:
         return [unit.name for unit in self._platform.units.list()]
+
+    def set_node(
+        self,
+        name: str,
+        parent: Optional[str] = None,
+        hierarchy: Optional[str] = None,
+        synonym: Optional[str] = None,
+    ) -> None:
+        if parent:
+            log.warning(f"Discarding parent parameter {parent}; unused in ixmp4.")
+        if synonym:
+            log.warning(f"Discarding synonym parameter {synonym}; unused in ixmp4.")
+        if hierarchy is None:
+            raise ValueError("IXMP4Backend.set_node() requires to specify 'hierarchy'!")
+        self._platform.regions.create(name=name, hierarchy=hierarchy)
+
+    def get_nodes(self) -> list[tuple[str, str, None, str]]:
+        return [
+            (region.name, region.name, None, region.hierarchy)
+            for region in self._platform.regions.list()
+        ]
+
+    # Modifying the Run object
+
+    def _index_and_set_attrs(self, run: "ixmp4.Run", ts: TimeSeries) -> None:
+        """Add *run* to index and update attributes of *ts*.
+
+        Helper for init and get.
+        """
+        # Add to index
+        self.index[ts] = run
+
+        # Retrieve the version of the ixmp4.Run object
+        v = run.version
+        if ts.version is None:
+            # The default version was requested; update the attribute
+            ts.version = v
+        elif v != ts.version:  # pragma: no cover
+            # Something went wrong on the ixmp4 side
+            raise RuntimeError(f"got version {v} instead of {ts.version}")
+
+    def init(self, ts: TimeSeries, annotation: str) -> None:
+        run = self._platform.runs.create(model=ts.model, scenario=ts.scenario)
+        # TODO either do log.warning that annotation is unused or
+        # run.docs = annotation
+        self._index_and_set_attrs(run, ts)
+
+    def get(self, ts: TimeSeries) -> None:
+        v = int(ts.version) if ts.version else None
+        run = self._platform.runs.get(model=ts.model, scenario=ts.scenario, version=v)
+        self._index_and_set_attrs(run, ts)
+
+    def check_out(self, ts: TimeSeries, timeseries_only: bool) -> None:
+        log.warning("ixmp4 backed Scenarios/Runs don't need to be checked out!")
+
+    def discard_changes(self, ts: TimeSeries) -> None:
+        log.warning(
+            "ixmp4 backed Scenarios/Runs are changed immediately, can't "
+            "discard changes. To avoid the need, be sure to start work on "
+            "fresh clones."
+        )
+
+    def commit(self, ts: TimeSeries, comment: str) -> None:
+        log.warning(
+            "ixmp4 backed Scenarios/Runs are changed immediately, no need for "
+            "a commit!"
+        )
+
+    def clear_solution(self, s: Scenario, from_year: Optional[int] = None) -> None:
+        if from_year:
+            log.warning(
+                "ixmp4 does not support removing the solution only after a "
+                "certain year"
+            )
+        self.index[s].optimization.remove_solution()
+
+    def set_as_default(self, ts: TimeSeries) -> None:
+        # TODO are we okay with always loading a Run for this or should we adapt
+        # TimeSeries to have a `_run` attribute that has the Run loaded?
+        self.index[ts].set_as_default()
+
+    # Information about the Run
+
+    def run_id(self, ts: TimeSeries) -> int:
+        # TODO is the Run.version really what this function is after?
+        return self.index[ts].version
+
+    def is_default(self, ts: TimeSeries) -> bool:
+        return self.index[ts].is_default()
+
+    # Handle various items
+
+    # TODO: type hints
+    def _get_repo(
+        self,
+        s: Scenario,
+        type: Literal["scalar", "indexset", "set", "par", "equ", "var"],
+    ):
+        if type == "scalar":
+            return self.index[s].optimization.scalars
+        if type == "indexset":
+            return self.index[s].optimization.indexsets
+        if type == "set":
+            return self.index[s].optimization.tables
+        elif type == "par":
+            return self.index[s].optimization.parameters
+        elif type == "equ":
+            return self.index[s].optimization.equations
+        else:  # "var"
+            return self.index[s].optimization.variables
+
+    def init_item(
+        self,
+        s: Scenario,
+        type: Literal["set", "par", "equ", "var"],
+        name: str,
+        idx_sets: Sequence[str],
+        idx_names: Optional[Sequence[str]],
+    ) -> None:
+        # TODO how are scalars created? Scalars require a value in ixmp4
+        # In base::item_get_elements, it sounds like "equ" and "var" can also target
+        # scalars, whereas below, inspired from jdbc, I'm only linking "par" to scalars
+        if type == "set" and len(idx_sets) == 0:
+            repo = self._get_repo(s=s, type="indexset")
+            repo.create(name=name)
+        else:
+            repo = self._get_repo(s=s, type=type)
+            repo.create(
+                name=name, constrained_to_indexsets=idx_sets, column_names=idx_names
+            )
+
+    def list_items(self, s: Scenario, type: Literal["set", "par", "equ"]) -> list[str]:
+        if type == "set":
+            indexset_repo = self._get_repo(s=s, type="indexset")
+            set_repo = self._get_repo(s=s, type=type)
+            return [item.name for item in indexset_repo.list()] + [
+                item.name for item in set_repo.list()
+            ]
+        else:
+            repo = self._get_repo(s=s, type=type)
+            return [item.name for item in repo.list()]
+
+    # TODO type hints
+    def _find_item(self, s: Scenario, name: str):
+        # NOTE this currently assumes that `name` will only be present once among
+        # Tables, Parameters, Equations, Variables. This is in line with the assumption
+        # made in the Java backend, but ixmp4 enforces no such constraint.
+        for type in ("scalar", "indexset", "set", "par", "equ", "var"):
+            repo = self._get_repo(s=s, type=type)
+            item_list = repo.list(name=name)
+            if (
+                len(item_list) == 1
+            ):  # ixmp4 enforces names to be unique among individual item classes
+                return (type, item_list[0])
+
+    def _get_item(
+        self,
+        s: Scenario,
+        name: str,
+        type: Literal["scalar", "indexset", "set", "par", "equ", "var"],
+    ):
+        # TODO add try except here to always return using IndexError from repo.list()[0]
+        repo = self._get_repo(s=s, type=type)
+        item_list = repo.list(name=name)
+        if (
+            len(item_list) == 1
+        ):  # ixmp4 enforces names to be unique among individual item classes
+            return (type, item_list[0])
+
+    # TODO mypy says this function is missing a return statement. But why?
+    # AFAICT, items.items() will always contain something, so we will always return
+    # something (unless we raise). Am I missing something?
+    def item_index(  # type: ignore[return]
+        self, s: Scenario, name: str, sets_or_names: Literal["sets", "names"]
+    ) -> list[str]:
+        type, item = self._find_item(s=s, name=name)
+        if item is None:
+            raise LookupError(f"No item called {name} found on this Scenario!")
+        if type == "indexset":
+            return cast(list[str], [])
+        else:
+            return (
+                [column.name for column in item.columns]
+                if sets_or_names == "names"
+                else item.constrained_to_indexsets
+            )
+
+    def _add_data_to_set(
+        self, s: Scenario, name: str, key: str | list[str], comment: Optional[str]
+    ) -> None:
+        if comment:
+            log.warning(
+                "`comment` currently unused with ixmp4 when adding data to Tables."
+            )
+        # Assumption: if key is just one value, we're dealing with an IndexSet
+        if isinstance(key, str):
+            self.index[s].optimization.indexsets.get(name=name).add(key)
+        else:
+            table = self.index[s].optimization.tables.get(name=name)
+            data_to_add = {
+                table.constrained_to_indexsets[i]: key[i] for i in range(len(key))
+            }
+            table.add(data=data_to_add)
+
+    def _create_scalar(
+        self,
+        s: Scenario,
+        name: str,
+        value: float,
+        unit: Optional[str],
+        comment: Optional[str],
+    ) -> None:
+        scalar = self.index[s].optimization.scalars.create(
+            name=name, value=value, unit=unit
+        )
+        if comment:
+            scalar.docs = comment
+
+    ### TODO
+    ###
+    ### Currently, tests fail because they expect 'cases' to be predefined on the test_mp
+
+    def _add_data_to_parameter(
+        self,
+        s: Scenario,
+        name: str,
+        key: str | list[str],
+        value: float,
+        unit: str,
+        comment: Optional[str],
+    ) -> None:
+        if comment:
+            log.warning(
+                "`comment` currently unused with ixmp4 when adding data to "
+                "Parameters."
+            )
+        parameter = self.index[s].optimization.parameters.get(name=name)
+        # TODO there's got to be a better way for handling possible lists
+        if isinstance(key, str):
+            key = [key]
+        data_to_add: dict[str, Union[list[float], list[str]]] = {
+            parameter.constrained_to_indexsets[i]: [key[i]] for i in range(len(key))
+        }
+        data_to_add["values"] = [value]
+        data_to_add["units"] = [unit]
+        parameter.add(data=data_to_add)
+
+    def item_set_elements(
+        self,
+        s: Scenario,
+        type: Literal["par", "set"],
+        name: str,
+        elements: Iterable[tuple[Any, Optional[float], Optional[str], Optional[str]]],
+    ) -> None:
+        for key, value, unit, comment in elements:
+            if type == "set":
+                self._add_data_to_set(s=s, name=name, key=key, comment=comment)
+            else:
+                if key is None:
+                    assert value, "Creating a Scalar requires a value!"
+                    self._create_scalar(
+                        s=s, name=name, value=value, unit=unit, comment=comment
+                    )
+                else:
+                    assert value, "Adding data to a Parameter requires a value!"
+                    assert unit, "Adding data to a Parameter requires a unit!"
+                    self._add_data_to_parameter(
+                        s=s, name=name, key=key, value=value, unit=unit, comment=comment
+                    )
+
+    def _get_set_data(
+        self, s: Scenario, name: str, filters: Optional[dict[str, list[Any]]] = None
+    ) -> Union[pd.Series, pd.DataFrame]:
+        # TODO handle filters
+        from ixmp4.core import IndexSet, Table
+        from ixmp4.core.exceptions import NotFound
+
+        item: Union[IndexSet, Table]
+        try:
+            repo = self._get_repo(s=s, type="indexset")
+            item = cast(IndexSet, repo.get(name=name))
+        except NotFound:
+            repo = self._get_repo(s=s, type="set")
+            item = cast(Table, repo.get(name=name))
+
+        return (
+            pd.DataFrame(item.data) if isinstance(item, Table) else pd.Series(item.data)
+        )
+
+    def item_get_elements(
+        self,
+        s: Scenario,
+        type: Literal["equ", "par", "set", "var"],
+        name: str,
+        filters: Optional[dict[str, list[Any]]] = None,
+    ) -> Union[dict[str, Any], pd.Series, pd.DataFrame]:
+        # TODO handle filters
+        if type == "set":
+            return self._get_set_data(s=s, name=name, filters=filters)
+        # TODO this is not handling scalars at the moment, but maybe try with type,
+        # except NotFound, try scalar?
+        else:
+            # TODO this can really only be Equation, Parameter, or Variable, so cast
+            # as such?
+            _, item = self._get_item(s=s, name=name, type=type)
+            data = pd.DataFrame(item.data)
+            print(data)
+            if type == "par":
+                data.rename(columns={"values": "value", "units": "unit"}, inplace=True)
+            else:
+                data.rename(
+                    columns={"levels": "level", "marginals": "marginal"}, inplace=True
+                )
+            return data
 
     # The below methods of base.Backend are not yet implemented
     def _ni(self, *args, **kwargs):
@@ -88,38 +412,22 @@ class IXMP4Backend(CachingBackend):
     cat_get_elements = _ni
     cat_list = _ni
     cat_set_elements = _ni
-    check_out = _ni
-    clear_solution = _ni
     clone = _ni
-    commit = _ni
     delete = _ni
     delete_geo = _ni
     delete_item = _ni
     delete_meta = _ni
-    discard_changes = _ni
-    get = _ni
     get_data = _ni
     get_doc = _ni
     get_geo = _ni
     get_meta = _ni
-    get_nodes = _ni
     get_timeslices = _ni
     has_solution = _ni
-    init = _ni
-    init_item = _ni
-    is_default = _ni
     item_delete_elements = _ni
-    item_get_elements = _ni
-    item_index = _ni
-    item_set_elements = _ni
     last_update = _ni
-    list_items = _ni
     remove_meta = _ni
-    run_id = _ni
-    set_as_default = _ni
     set_data = _ni
     set_doc = _ni
     set_geo = _ni
     set_meta = _ni
-    set_node = _ni
     set_timeslice = _ni

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -406,6 +406,7 @@ def _setup_ixmp4_platform(mp: Platform) -> None:
     """Set up an ixmp4-backed Platform with things hardcoded in Java."""
     mp.add_unit("cases", comment="As pre-defined in Java.")
     mp.add_unit("km", comment="As pre-defined in Java.")
+    mp.add_region(region="World", hierarchy="common")
 
 
 def _platform_fixture(

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -401,6 +401,13 @@ def create_test_platform(tmp_path, data_path, name, **properties):
 # Private utilities
 
 
+# TODO Check if this setup is necessary when running all tests (not just test_platform)
+def _setup_ixmp4_platform(mp: Platform) -> None:
+    """Set up an ixmp4-backed Platform with things hardcoded in Java."""
+    mp.add_unit("cases", comment="As pre-defined in Java.")
+    mp.add_unit("km", comment="As pre-defined in Java.")
+
+
 def _platform_fixture(
     request: pytest.FixtureRequest, tmp_env, test_data_path, backend: str
 ) -> Generator[Platform, Any, None]:
@@ -429,6 +436,8 @@ def _platform_fixture(
 
     # Launch Platform
     mp = Platform(name=platform_name, backend=backend)
+    if backend == "ixmp4":
+        _setup_ixmp4_platform(mp=mp)
     yield mp
 
     # Teardown: don't show log messages when destroying the platform, even if

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,8 @@ docs = [
   "sphinx_rtd_theme",
   "sphinxcontrib-bibtex",
 ]
-# Change ixmp4 to new release after https://github.com/iiasa/ixmp4/pull/153 is merged
-ixmp4 = ["ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/expose-run-is-default"]
+# Change ixmp4 to new release after https://github.com/iiasa/ixmp4/pull/154 is merged
+ixmp4 = ["ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/introduce-has-solution"]
 report = ["genno[compat,graphviz]"]
 tutorial = ["jupyter"]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ docs = [
   "sphinx_rtd_theme",
   "sphinxcontrib-bibtex",
 ]
-ixmp4 = ["ixmp4"]
+# Change ixmp4 to new release after https://github.com/iiasa/ixmp4/pull/153 is merged
+ixmp4 = ["ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/expose-run-is-default"]
 report = ["genno[compat,graphviz]"]
 tutorial = ["jupyter"]
 tests = [


### PR DESCRIPTION
As suggested in https://github.com/iiasa/ixmp/pull/552#issuecomment-2602447693, this PR adds `IXMP4Backend` functions that are required to pass the `test_platform` tests. This is separate to keep the PR reviews manageable.

As far as passing the test_platform tests go, this work is incomplete. In some places, I'm not sure best to proceed. For example, `test_add_region` and `test_add_region_synonym` are currently failing because the regions-DataFrame returned from the ixmp4 Backend does not include the data the tests currently expect. This is in turn due to the ixmp4 DB model for regions is different from the one in ixmp.
Most notably, ixmp4 requires the `hierarchy` parameter, but doesn't use `parent` or `synonym`. I asked @meksor and @danielhuppmann about this and they said that's on purpose and ixmp doesn't really use these parameters anymore, either. So I think it should be fine to adapt the existing tests, but please let me know what you think, @khaeru.

Similarly, ixmp4 does not seem to store timeslices in a similar way to the JDBC. It looks like I'll have to add this feature first, but I'm not really familiar with the IAMC data storage we currently have implemented. 

Another missing feature is the ability to delete stuff in ixmp4. Both optimization data and items as well as `Run`s as a whole still lack this. 

There are several more open questions marked as `TODO` inline. For example: `ixmp4.Run.clone()` doesn't support `first_model_year` and `platform_dest`. How crucial are these features?

## How to review

**Required:** describe specific things that reviewer(s) must do, in order to ensure that the PR achieves its goal.
If no review is required, write “No review: …” and describe why.

<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- View the preview build of the documentation and look at a certain page.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
<!--
The following items are *required* if the PR results in changes to user-facing
behaviour—such as new features, or fixes to existing behaviour.

They are *optional* if the changes are solely to documentation, test/CI
configuration, etc. In such cases, strike them out and add a short explanation,
for example:

- ~Add or expand tests.~ No change in behaviour, simply refactoring.
-->
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - Title or single-sentence description from above (:pull:`999`:).

  Commit with a message like “Add #999 to release notes”
  -->
