### PR TITLE
Introduce GAMS I/O for `IXMP4Backend`

### DIFF
--- a/ixmp/_config.py
+++ b/ixmp/_config.py
@@ -70,7 +70,11 @@ def _platform_default():
         },
         "ixmp4-local": {
             "class": "ixmp4",
-            "dsn": "sqlite:///:memory:",
+            "dsn": (
+                "sqlite:///"
+                f"{Path.home().joinpath('.local', 'share', 'ixmp4', 'databases')}"
+                "/ixmp4-local.sqlite3"
+            ),
         },
     }
 

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -10,42 +10,14 @@ from typing import Any, Literal, Optional, Union
 import pandas as pd
 
 # TODO Import this from typing when dropping Python 3.11
-from typing_extensions import TypedDict, Unpack
+from typing_extensions import Unpack
 
 from ixmp.backend import ItemType
 from ixmp.backend.io import s_read_excel, s_write_excel, ts_read_file
 from ixmp.core.platform import Platform
 from ixmp.core.scenario import Scenario
 from ixmp.core.timeseries import TimeSeries
-
-
-# These are based on existing calls within ixmp
-class WriteFiltersKwargs(TypedDict, total=False):
-    scenario: Scenario | list[str]
-    model: list[str]
-    variable: list[str]
-    unit: list[str]
-    region: list[str]
-    default: bool
-    export_all_runs: bool
-
-
-class WriteKwargs(TypedDict, total=False):
-    filters: WriteFiltersKwargs
-    record_version_packages: list[str]
-
-
-class ReadKwargs(TypedDict, total=False):
-    filters: WriteFiltersKwargs
-    firstyear: Optional[Any]
-    lastyear: Optional[Any]
-    add_units: bool
-    init_items: bool
-    commit_steps: bool
-    check_solution: bool
-    comment: str
-    equ_list: list[str]
-    var_list: list[str]
+from ixmp.util.ixmp4 import ReadKwargs, WriteFiltersKwargs, WriteKwargs
 
 
 class Backend(ABC):

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -2,15 +2,14 @@ import logging
 from collections import deque
 from collections.abc import Iterable
 from pathlib import Path
-from typing import Optional, TypeVar, Union
+from typing import Literal, Optional, TypeVar, Union, cast
 
 import gams.transfer as gt
 import pandas as pd
-
-# from gams import GamsWorkspace
 from ixmp4.core import Run
+from ixmp4.core.optimization.base import Lister
 from ixmp4.core.optimization.equation import Equation
-from ixmp4.core.optimization.indexset import IndexSet
+from ixmp4.core.optimization.indexset import IndexSet, IndexSetRepository
 from ixmp4.core.optimization.parameter import Parameter
 from ixmp4.core.optimization.scalar import Scalar
 from ixmp4.core.optimization.table import Table
@@ -19,6 +18,7 @@ from ixmp4.data.abstract.optimization.equation import Equation as AbstractEquati
 from ixmp4.data.abstract.optimization.variable import Variable as AbstractVariable
 
 from ixmp.util import as_str_list, maybe_check_out, maybe_commit
+from ixmp.util.ixmp4 import ContainerData
 
 from . import ItemType
 
@@ -334,69 +334,171 @@ def s_read_excel(  # noqa: C901
     maybe_commit(s, not commit_steps, f"Import from {path}")
 
 
-def _add_to_container(container: gt.Container, items: list[Item4]) -> None:
-    """Add ixmp4 data `items` to `container`."""
+def _domain(item: Item4) -> Optional[list[str]]:
+    """Return domain for `item`.
+
+    For IndexSets and Scalars, this is :obj:`None`.
+
+    For all others, this is `item.indexsets`.
+    """
+    if isinstance(item, (IndexSet, Scalar)):
+        return None
+    else:
+        return item.indexsets
+
+
+def _records(
+    item: Item4,
+    kind: str,
+) -> Union[
+    float,
+    Union[list[float], list[int], list[str]],
+    dict[str, Union[list[float], list[int], list[str]]],
+    None,
+]:
+    """Return records for `item`.
+
+    For Scalars, this is `item.value`.
+
+    For empty other items, this is :obj:`None`.
+
+    For IndexSets and Tables, this is `item.data`.
+
+    For Parameters, this is `item.data` without the column 'units'.
+
+    For Equations and Variables, this is `item.data`
+    without the columns 'levels' and 'marginals'.
+    """
+    if isinstance(item, Scalar):
+        return item.value
+    elif not len(item.data):
+        return None
+
+    if isinstance(item, (IndexSet, Table)):
+        return item.data
+
+    result = item.data
+
+    # Pop items not to be stored
+    for name in {
+        "Equation": ["levels", "marginals"],
+        "Parameter": ["units"],
+        "Variable": ["levels", "marginals"],
+    }[kind]:
+        result.pop(name)
+
+    return result
+
+
+def _ensure_correct_item_order(items: list[Item4], repo: Lister) -> list[Item4]:
+    """Reorder items to ensure the GDX file is written correctly.
+
+    gamsapi stores all unique elements of all items in a single list internally. If item
+    A adds elements that item B shares, item B is not adding them again. If B's elements
+    are then requested, they are returned starting with those in A in their order,
+    disrupting expectations.
+    """
+    if isinstance(repo, IndexSetRepository):
+        # Move all indexsets called 'type_*' to the end of the list
+        for type_indexset in list(
+            filter(lambda item: item.name.startswith("type_"), items)
+        ):
+            items.remove(type_indexset)
+            items.append(type_indexset)
+
+    return items
+
+
+def _align_records_and_domain(
+    item: Item4, records: dict[str, Union[list[float], list[int], list[str]]]
+) -> dict[str, Union[list[float], list[int], list[str]]]:
+    """Align the order of `records.keys()` with domain of `item`."""
+    # This function will only be called for these types
+    assert isinstance(item, (Table, Parameter, Variable, Equation))
+
+    # `records` may contain keys that are column_names, but not indexsets
+    domain_order = item.column_names or item.indexsets
+
+    if not domain_order:
+        # This could happen for Variables or Equations
+        return records
+    else:
+        # Parameters contain values that we want to keep
+        if isinstance(item, Parameter):
+            domain_order.append("values")
+
+        return {key: records[key] for key in domain_order}
+
+
+def _add_items_to_container(
+    container: gt.Container, items: list[ContainerData]
+) -> None:
+    """Add `items` to `container`."""
     if not items:
         return  # Nothing to be done
 
-    # Identify the ixmp4 class name and corresponding gams.transfer class
-    kind = type(items[0]).__name__
-    klass = {
-        "IndexSet": gt.Set,
-        "Parameter": gt.Parameter,
-        "Scalar": gt.Parameter,
-        "Table": gt.Set,
-        "Variable": gt.Variable,
-        "Equation": gt.Equation,
-    }[kind]
+    for item in items:
+        # Identify the corresponding gams.transfer class
+        klass = {
+            "IndexSet": gt.Set,
+            "Parameter": gt.Parameter,
+            "Scalar": gt.Parameter,
+            "Table": gt.Set,
+            "Variable": gt.Variable,
+            "Equation": gt.Equation,
+        }[item.kind]
 
-    def domain(item: Item4) -> Optional[list[str]]:
-        if isinstance(item, (IndexSet, Scalar)):
-            return None
-        else:
-            return item.indexsets
+        # NOTE A container may already contain some data from the MESSAGE-specific setup
+        # This seems to imply a UniqueConstraint over all item names, though.
+        if not container.hasSymbols(item.name):
+            # The gams documentation confuses me: The docstring says `type` is required
+            # for Equations, the example says no. It seems to work fine like this, but
+            # if we do need a value, maybe we could guess based on
+            # https://github.com/iiasa/ixmp_source/blob/master/src/main/java/at/ac/iiasa/ixmp/objects/Scenario.java#L1926,
 
-    def records(
-        item: Item4,
-    ) -> Union[
-        float,
-        Union[list[float], list[int], list[str]],
-        dict[str, Union[list[float], list[int], list[str]]],
-        None,
-    ]:
-        if isinstance(item, Scalar):
-            return item.value
-        elif not len(item.data):
-            return None
+            # Create an item instance linked to the container
+            klass(
+                container=container,
+                name=item.name,
+                domain=item.domain,
+                records=item.records,
+                # Optional, but must be str
+                description=item.docs or "",
+            )
 
-        if isinstance(item, IndexSet):
-            return item.data
 
-        result = item.data
+def _convert_ixmp4_items_to_containerdata(items: list[Item4]) -> list[ContainerData]:
+    """Convert list of ixmp4 `items` to ContainerData."""
+    if not items:
+        return []  # Nothing to be done
 
-        # Pop items not to be stored
-        for name in {
-            "Equation": ["levels", "marginals"],
-            "Parameter": ["units"],
-            "Variable": ["levels", "marginals"],
-        }[kind]:
-            result.pop(name)
+    # Identify the ixmp4 class name
+    kind = cast(
+        Literal["Scalar", "IndexSet", "Table", "Parameter", "Equation", "Variable"],
+        type(items[0]).__name__,
+    )
 
-        return result
+    container_items: list[ContainerData] = []
 
     for item in items:
-        # The gams documentation confuses me: The docstring says `type` is required for
-        # Equations, the example says no. It seems to work fine like this, but if we do
-        # need a value, maybe we could guess based on
-        # https://github.com/iiasa/ixmp_source/blob/master/src/main/java/at/ac/iiasa/ixmp/objects/Scenario.java#L1926,
-        klass(
-            container=container,
-            name=item.name,
-            domain=domain(item),
-            records=records(item),
-            # Optional, but must be str
-            description=item.docs if item.docs else "",
+        records = _records(item=item, kind=kind)
+        # The order of keys in 'domain' is used by gamsapi to overwrite the order of
+        # keys in 'records', so make sure they are aligned:
+        # NOTE ixmp4 ensures that all _records.keys() are in _domain and vice-versa
+        if isinstance(records, dict):
+            records = _align_records_and_domain(item=item, records=records)
+
+        container_items.append(
+            ContainerData(
+                name=item.name,
+                kind=kind,
+                records=records,
+                domain=_domain(item),
+                docs=item.docs,
+            )
         )
+
+    return container_items
 
 
 def _record_versions(container: gt.Container, packages: list[str]) -> None:
@@ -431,16 +533,35 @@ def _record_versions(container: gt.Container, packages: list[str]) -> None:
 def write_run_to_gdx(
     run: Run,
     file_name: Path,
+    container_data: list[ContainerData],
     record_version_packages: list[str],
     include_variables_and_equations: bool = False,
 ) -> None:
-    """Write scenario data from the `run` to a GDX file via GAMS container."""
+    """Write data from the `run` to a GDX file at `file_name` via a GAMS Container.
 
-    # TODO How to deal with [*] Set?
+    Parameters
+    ----------
+    run : :class:`ixmp4.core.Run`
+        The Run in which the Scenario data is stored.
+    file_name: :obj:`Path`
+        The location at which the GDX file should be written.
+    container_data : list of :class:`ixmp.util.ixmp4.ContainerData`.
+        Data that should also be written to the GDX file
+        in the form of ContainerData.
+    record_version_packages : list of str
+        A list of package names for which versions will be stored in the GDX file.
+    include_variables_and_equations: bool, optional
+        Flag to indicate whether Variabels and Equations should be written to the GDX
+        file.
+        Default: :obj:`False`.
+    """
 
+    # TODO How to deal with [*] Set? That seems to be handled by GAMS automatically.
+
+    # Define the container
     container = gt.Container()
 
-    repository = [
+    repository: list[Lister] = [
         run.optimization.indexsets,
         run.optimization.scalars,
         run.optimization.tables,
@@ -450,55 +571,88 @@ def write_run_to_gdx(
     ]
     idx = slice(None) if include_variables_and_equations else slice(-2)
     for r in repository[idx]:
-        # FIXME Type of 'r' is inferred as BaseFacade, the narrowest common supertype of
-        #       IndexSetRepository etc.; BaseFacade.list() is not defined.
-        _add_to_container(container, r.list())  # type: ignore [attr-defined]
+        # Reorder items if necessary for GAMS to successfully read the GDX
+        ixmp4_items = _ensure_correct_item_order(items=r.list(), repo=r)
+
+        # Convert ixmp4 items to ContainerData to streamline adding to container
+        container_items = _convert_ixmp4_items_to_containerdata(items=ixmp4_items)
+
+        _add_items_to_container(container, container_items)
+
+    # Add additional data *after* the required items to avoid confusing GAMS' internal
+    # Unique Element List
+    _add_items_to_container(container, container_data)
 
     _record_versions(container=container, packages=record_version_packages)
 
     container.write(write_to=file_name)
 
 
+# NOTE since we currently only read Variables and Equations, this function only covers
+# these cases
+def _set_columns_to_read_from_records(
+    item: Union[AbstractVariable, AbstractEquation],
+) -> list[str]:
+    """Gather all columns for `item` to read from GDX records."""
+    # Prepare columns to select from container.data
+    # DF also includes lower, upper, scale
+    columns = ["levels", "marginals"]
+    item_columns = item.column_names or item.indexsets
+    if item_columns:
+        item_columns.extend(columns)
+
+    return item_columns if item_columns else columns
+
+
+# NOTE not sure we only need equations and variables; if we need others, abstracting one
+# function for reading would not be as easy, since we might need different details, so
+# I'm keeping them separate for now
+
+
 def _read_variables_to_run(
     container: gt.Container, run: Run, variables: Iterable[AbstractVariable]
 ) -> None:
+    """Read `variables` from `container` and store them in `run`."""
     for variable in variables:
-        # Prepare columns to select from container.data
-        # DF also includes lower, upper, scale
-        columns = ["level", "marginal"]
-        variable_columns = variable.column_names or variable.indexsets
-        if variable_columns:
-            columns += variable_columns
+        columns_of_interest = _set_columns_to_read_from_records(item=variable)
 
-        run.backend.optimization.variables.add_data(
-            variable_id=variable.id,
-            data=(
-                container.data[variable.name]
-                .records[columns]
-                .rename(columns={"level": "levels", "marginal": "marginals"})
-            ),
-        )
+        records = pd.DataFrame(container.data[variable.name].records)
+
+        # Avoid touching the DB for empty data
+        if not records.empty:
+            # NOTE Overwriting the columns changes GAMS' "level" and "marginal" to the
+            # ixmp4-expected "levels" and "marginals"
+            # NOTE This assumes that the order the columns are defined in the gams code
+            # is equal to the order in item.column_names and item.indexsets
+            records.columns = pd.Index(
+                columns_of_interest + ["lower", "upper", "scale"]
+            )
+            run.backend.optimization.variables.add_data(
+                variable_id=variable.id, data=(records[columns_of_interest])
+            )
 
 
 def _read_equations_to_run(
     container: gt.Container, run: Run, equations: Iterable[AbstractEquation]
 ) -> None:
+    """Read `equations` from `container` and store them in `run`."""
     for equation in equations:
-        # Prepare columns to select from container.data
-        # DF also includes lower, upper, scale
-        columns = ["level", "marginal"]
-        equation_columns = equation.column_names or equation.indexsets
-        if equation_columns:
-            columns += equation_columns
+        columns_of_interest = _set_columns_to_read_from_records(item=equation)
 
-        run.backend.optimization.equations.add_data(
-            equation_id=equation.id,
-            data=(
-                container.data[equation.name]
-                .records[columns]
-                .rename(columns={"level": "levels", "marginal": "marginals"})
-            ),
-        )
+        records = pd.DataFrame(container.data[equation.name].records)
+
+        # Avoid touching the DB for empty data
+        if not records.empty:
+            # NOTE Overwriting the columns changes GAMS' "level" and "marginal" to the
+            # ixmp4-expected "levels" and "marginals"
+            # NOTE This assumes that the order the columns are defined in the gams code
+            # is equal to the order in item.column_names and item.indexsets
+            records.columns = pd.Index(
+                columns_of_interest + ["lower", "upper", "scale"]
+            )
+            run.backend.optimization.equations.add_data(
+                equation_id=equation.id, data=(records[columns_of_interest])
+            )
 
 
 def read_gdx_to_run(
@@ -509,6 +663,27 @@ def read_gdx_to_run(
     comment: str,
     check_solution: bool,
 ) -> None:
+    """Read data from `result_file` to `run` via a GAMS Container.
+
+    Parameters
+    ----------
+    run : :class:`ixmp4.core.Run`
+        The Run in which the Scenario data is to be stored.
+    result_file: :obj:`Path`
+        The location from which the GDX file should be read.
+    equ_list : list of str
+        Names of Equations to read from `result_file`.
+    var_list : list of str
+        Names of Variables to read from `result_file`.
+    comment : str
+        Unused by ixmp4.
+        A comment to store when adding the data to `run`.
+    check_solution : bool
+        Unused by ixmp4.
+        A flag to indicate whether the solution should be checked
+        (for consistency, maybe?).
+    """
+    # Warn about unused parameters
     if comment:
         log.warning(f"Ignoring comment {comment} for now; unused by ixmp4!")
     if check_solution:
@@ -516,18 +691,25 @@ def read_gdx_to_run(
             f"Ignoring check_solution={check_solution} for now; unused by ixmp4!"
         )
 
+    # Create a GAMS Container from the `result_file`
+    container = gt.Container(load_from=result_file)
+
+    # Load requested Variables and read them to `run`
+    # NOTE This handles empty `var_list`, too,
+    # which is not necessary as long as any Variables are required in message_ix
     variables = (
         run.backend.optimization.variables.list(name__in=var_list)
         if len(var_list)
         else run.backend.optimization.variables.list()
     )
+    _read_variables_to_run(container=container, run=run, variables=variables)
+
+    # Load requested Equations and read them to `run`
+    # NOTE This handles empty `equ_list`, too,
+    # which is not necessary as long as any Equations are required in message_ix
     equations = (
         run.backend.optimization.equations.list(name__in=equ_list)
         if len(equ_list)
         else run.backend.optimization.equations.list()
     )
-
-    container = gt.Container(load_from=result_file)
-
-    _read_variables_to_run(container=container, run=run, variables=variables)
     _read_equations_to_run(container=container, run=run, equations=equations)

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -2,15 +2,19 @@ import logging
 from collections import deque
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, TypeVar, Union
 
 import gams.transfer as gt
 import pandas as pd
 
 # from gams import GamsWorkspace
 from ixmp4.core import Run
+from ixmp4.core.optimization.equation import Equation
 from ixmp4.core.optimization.indexset import IndexSet
+from ixmp4.core.optimization.parameter import Parameter
 from ixmp4.core.optimization.scalar import Scalar
+from ixmp4.core.optimization.table import Table
+from ixmp4.core.optimization.variable import Variable
 from ixmp4.data.abstract.optimization.equation import Equation as AbstractEquation
 from ixmp4.data.abstract.optimization.variable import Variable as AbstractVariable
 
@@ -18,20 +22,8 @@ from ixmp.util import as_str_list, maybe_check_out, maybe_commit
 
 from . import ItemType
 
-if TYPE_CHECKING:
-    from typing import TypeVar
-
-    from ixmp4.core.optimization.equation import Equation
-
-    # from ixmp4.core.optimization.indexset import IndexSet
-    from ixmp4.core.optimization.parameter import Parameter
-
-    # from ixmp4.core.optimization.scalar import Scalar
-    from ixmp4.core.optimization.table import Table
-    from ixmp4.core.optimization.variable import Variable
-
-    # Type variable that can be any one of these 6 types, but not a union of 2+ of them
-    Item4 = TypeVar("Item4", Equation, IndexSet, Parameter, Scalar, Table, Variable)
+# Type variable that can be any one of these 6 types, but not a union of 2+ of them
+Item4 = TypeVar("Item4", Equation, IndexSet, Parameter, Scalar, Table, Variable)
 
 
 log = logging.getLogger(__name__)
@@ -393,9 +385,9 @@ def _add_to_container(container: gt.Container, items: list[Item4]) -> None:
         return result
 
     for item in items:
-        # The gams documentation confuses me: The docstring says `type` is required, the
-        # example says no. It seems to work fine like this, but if we do need a value,
-        # maybe we could guess based on
+        # The gams documentation confuses me: The docstring says `type` is required for
+        # Equations, the example says no. It seems to work fine like this, but if we do
+        # need a value, maybe we could guess based on
         # https://github.com/iiasa/ixmp_source/blob/master/src/main/java/at/ac/iiasa/ixmp/objects/Scenario.java#L1926,
         klass(
             container=container,

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -570,7 +570,10 @@ class IXMP4Backend(CachingBackend):
                 data.rename(columns={"values": "value", "units": "unit"}, inplace=True)
             else:
                 data.rename(
-                    columns={"levels": "level", "marginals": "marginal"}, inplace=True
+                    # NOTE the ixmp.report(er) expects these names, unfortunately; see
+                    # ixmp.report.util::keys_for_quantity()
+                    columns={"levels": "lvl", "marginals": "mrg"},
+                    inplace=True,
                 )
             return data
 

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -60,6 +60,8 @@ class Platform:
         "set_meta",
     ]
 
+    _units_to_warn_about: Optional[list[str]] = None
+
     def __init__(
         self, name: Optional[str] = None, backend: Optional[str] = None, **backend_args
     ):

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -9,6 +9,7 @@ import pandas as pd
 from ixmp._config import config
 from ixmp.backend import BACKENDS, FIELDS, ItemType
 from ixmp.util import as_str_list
+from ixmp.util.ixmp4 import WriteFiltersKwargs
 
 if TYPE_CHECKING:
     from ixmp.backend.base import Backend
@@ -236,15 +237,15 @@ class Platform:
                 "Invalid arguments: export_all_runs cannot be used when providing a "
                 "model or scenario."
             )
-        filters = {
-            "model": as_str_list(model),
-            "scenario": as_str_list(scenario),
-            "variable": as_str_list(variable),
-            "unit": as_str_list(unit),
-            "region": as_str_list(region),
-            "default": default,
-            "export_all_runs": export_all_runs,
-        }
+        filters = WriteFiltersKwargs(
+            scenario=as_str_list(scenario),
+            model=as_str_list(model),
+            variable=as_str_list(variable),
+            unit=as_str_list(unit),
+            region=as_str_list(region),
+            default=default,
+            export_all_runs=export_all_runs,
+        )
 
         self._backend.write_file(path, ItemType.TS, filters=filters)
 

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Sequence
 from os import PathLike
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -63,7 +63,10 @@ class Platform:
     _units_to_warn_about: Optional[list[str]] = None
 
     def __init__(
-        self, name: Optional[str] = None, backend: Optional[str] = None, **backend_args
+        self,
+        name: Optional[str] = None,
+        backend: Optional[Literal["ixmp4", "jdbc"]] = None,
+        **backend_args,
     ):
         if name is None:
             if backend is None and not len(backend_args):

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -705,6 +705,7 @@ class Scenario(TimeSeries):
         else:
             self._backend("item_delete_elements", "par", name, self._keys(name, key))
 
+    # FIXME What ensures that filters has the correct type?
     def var(self, name: str, filters=None, **kwargs):
         """Return a dataframe of (filtered) elements for a specific variable.
 

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -41,7 +41,7 @@ class Scenario(TimeSeries):
     """
 
     #: Scheme of the Scenario.
-    scheme = None
+    scheme: Optional[str] = None
 
     def __init__(
         self,

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -15,6 +15,7 @@ from ixmp.backend.jdbc import JDBCBackend
 from ixmp.core.scenario import Scenario
 from ixmp.model.base import Model, ModelError
 from ixmp.util import as_str_list
+from ixmp.util.ixmp4 import ContainerData
 
 log = logging.getLogger(__name__)
 
@@ -180,6 +181,9 @@ class GAMSModel(Model):
     record_version_packages : list of str, optional
         Names of Python packages to record versions. Default: :py:`["ixmp"]`.
         See :meth:`record_versions`.
+    container_data : list of :class:`ixmp.util.ixmp4.ContainerData`, optional
+        List of data to add to the GAMS Container used by the IXMP4Backend for GAMS I/O.
+        Default: empty list.
     """  # noqa: E501
 
     # Make attributes known to self
@@ -196,6 +200,7 @@ class GAMSModel(Model):
     quiet: bool
     use_temp_dir: bool
     record_version_packages: list[str]
+    container_data: list[ContainerData]
 
     #: Model name.
     name = "default"
@@ -216,6 +221,7 @@ class GAMSModel(Model):
         "quiet": False,
         "use_temp_dir": True,
         "record_version_packages": ["ixmp"],
+        "container_data": [],
     }
 
     def __init__(self, name_=None, **model_options):
@@ -386,6 +392,7 @@ class GAMSModel(Model):
         # Instruct ixmp4 to record package versions
         if backend_type == "ixmp4":
             s_arg["record_version_packages"] = self.record_version_packages
+            s_arg["container_data"] = self.container_data
 
         try:
             # Write model data to file
@@ -411,6 +418,7 @@ class GAMSModel(Model):
             else:  # backend_type == "ixmp4"
                 # Clean up s_arg for use in read_file()
                 s_arg.pop("record_version_packages")
+                s_arg.pop("container_data")
         try:
             # Invoke GAMS
             run(command, shell=os.name == "nt", cwd=self.cwd, check=True)

--- a/ixmp/report/reporter.py
+++ b/ixmp/report/reporter.py
@@ -1,5 +1,5 @@
 from itertools import chain, repeat
-from typing import Union, cast
+from typing import Literal, Union, cast
 
 import dask
 import pandas as pd
@@ -53,7 +53,7 @@ class Reporter(Computer):
         all_keys: list[Union[str, Key]] = []
 
         # List of parameters, equations, and variables
-        quantities = chain(
+        quantities: chain[tuple[Literal["par", "equ", "var"], str]] = chain(
             zip(repeat("par"), sorted(scenario.par_list())),
             zip(repeat("equ"), sorted(scenario.equ_list())),
             zip(repeat("var"), sorted(scenario.var_list())),

--- a/ixmp/report/util.py
+++ b/ixmp/report/util.py
@@ -1,12 +1,18 @@
 from functools import lru_cache, partial
+from typing import TYPE_CHECKING, Literal, Union
 
 import pandas as pd
 from genno import Key
 
 from ixmp.report import common
 
+if TYPE_CHECKING:
+    from genno.types import AnyQuantity
 
-def dims_for_qty(data):
+    from ixmp.core.scenario import Scenario
+
+
+def dims_for_qty(data: Union[list[str], pd.DataFrame]) -> list[str]:
     """Return the list of dimensions for *data*.
 
     If *data* is a :class:`pandas.DataFrame`, its columns are processed;
@@ -28,7 +34,9 @@ def dims_for_qty(data):
     return [common.RENAME_DIMS.get(d, d) for d in dims]
 
 
-def keys_for_quantity(ix_type, name, scenario):
+def keys_for_quantity(
+    ix_type: Literal["par", "equ", "var"], name: str, scenario: "Scenario"
+) -> list[tuple[Key, partial["AnyQuantity"], str, str]]:
     """Return keys for *name* in *scenario*."""
     from .operator import data_for_quantity
 
@@ -36,7 +44,7 @@ def keys_for_quantity(ix_type, name, scenario):
     dims = dims_for_qty(scenario.idx_names(name))
 
     # Column for retrieving data
-    column = "value" if ix_type == "par" else "lvl"
+    column: Literal["mrg", "lvl", "value"] = "value" if ix_type == "par" else "lvl"
 
     # A computation to retrieve the data
     result = [
@@ -63,11 +71,11 @@ def keys_for_quantity(ix_type, name, scenario):
 
 
 @lru_cache(1)
-def get_reversed_rename_dims():
+def get_reversed_rename_dims() -> dict[str, str]:
     return {v: k for k, v in common.RENAME_DIMS.items()}
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> dict[str, str]:
     if name == "RENAME_DIMS":
         return common.RENAME_DIMS
     else:

--- a/ixmp/testing/data.py
+++ b/ixmp/testing/data.py
@@ -11,6 +11,7 @@ import pytest
 
 from ixmp import Platform, Scenario, TimeSeries
 from ixmp.backend import IAMC_IDX
+from ixmp.backend.ixmp4 import IXMP4Backend
 
 if TYPE_CHECKING:
     from typing import TypedDict
@@ -182,6 +183,11 @@ def add_test_data(scen: Scenario):
     return t, t_foo, t_bar, x
 
 
+def _add_required_units(mp: Platform) -> None:
+    mp.add_unit("USD")
+    mp.add_unit("???")
+
+
 def make_dantzig(
     mp: Platform,
     solve: bool = False,
@@ -209,6 +215,9 @@ def make_dantzig(
     --------
     .DantzigModel
     """
+    if isinstance(mp._backend, IXMP4Backend):
+        _add_required_units(mp=mp)
+
     # Add custom units and region for time series data
     try:
         mp.add_unit("USD/km")

--- a/ixmp/util/ixmp4.py
+++ b/ixmp/util/ixmp4.py
@@ -1,6 +1,8 @@
 # TODO Import this from typing when dropping Python 3.11
-from typing import TYPE_CHECKING, Any, Optional
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union
 
+import pandas as pd
 from typing_extensions import TypedDict
 
 if TYPE_CHECKING:
@@ -18,9 +20,28 @@ class WriteFiltersKwargs(TypedDict, total=False):
     export_all_runs: bool
 
 
+@dataclass
+class ContainerData:
+    name: str
+    kind: Literal["IndexSet", "Table", "Scalar", "Parameter", "Equation", "Variable"]
+    records: Optional[
+        Union[
+            float,
+            list[int],
+            list[float],
+            list[str],
+            dict[str, Union[list[float], list[int], list[str]]],
+            pd.DataFrame,
+        ]
+    ]
+    domain: Optional[list[str]] = None
+    docs: Optional[str] = None
+
+
 class WriteKwargs(TypedDict, total=False):
     filters: WriteFiltersKwargs
     record_version_packages: list[str]
+    container_data: list[ContainerData]
 
 
 class ReadKwargs(TypedDict, total=False):

--- a/ixmp/util/ixmp4.py
+++ b/ixmp/util/ixmp4.py
@@ -1,0 +1,36 @@
+# TODO Import this from typing when dropping Python 3.11
+from typing import TYPE_CHECKING, Any, Optional
+
+from typing_extensions import TypedDict
+
+if TYPE_CHECKING:
+    from ixmp.core.scenario import Scenario
+
+
+# These are based on existing calls within ixmp
+class WriteFiltersKwargs(TypedDict, total=False):
+    scenario: "Scenario | list[str]"
+    model: list[str]
+    variable: list[str]
+    unit: list[str]
+    region: list[str]
+    default: bool
+    export_all_runs: bool
+
+
+class WriteKwargs(TypedDict, total=False):
+    filters: WriteFiltersKwargs
+    record_version_packages: list[str]
+
+
+class ReadKwargs(TypedDict, total=False):
+    filters: WriteFiltersKwargs
+    firstyear: Optional[Any]
+    lastyear: Optional[Any]
+    add_units: bool
+    init_items: bool
+    commit_steps: bool
+    check_solution: bool
+    comment: str
+    equ_list: list[str]
+    var_list: list[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ docs = [
 ]
 # Change ixmp4 to new release after https://github.com/iiasa/ixmp4/pull/164 is merged
 ixmp4 = [
-  "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/make-equation-indexsets-optional", 
+  "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/remove-linked-items-when-removing-indexset-items", 
   "gamsapi[core,transfer] >= 45.7.0",
 ]
 report = ["genno[compat,graphviz]"]


### PR DESCRIPTION
This PR adds the next step of functionality for the new `IXMP4Backend`: I/O for GAMS. I can't yet confirm that the functions here cover all functionality, but locally, the `scenario.solve()` step in `make_dantzig()` works. 
The PR also adds `delete_item()` to `IXMP4Backend` since that was still needed before getting to the GAMS I/O. The `GAMSModel` always want to record the package versions and remove the sets later on. As it turns out, we don't need to store the package versions in an ixmp4 DB, but I only noticed that _after_ adding the functionality.

The whole `make_dantzig()` function still fails, however, because it's also trying to add timeseries data, which I will look into next. Handling timeseries data is more on a platform-level, I would say, that's why I want to do that in a separate PR. 
The commits here are not very clean, either, sorry for that. I figure that's okay since no one else is working on these files at the moment.

## How to review

TBD

<!-- 
This could include something like

- Check for obvious errors
- Search for TODOs and see how urgent they are
- Look at passing tests (once they do)

-->

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.
