### PR TITLE
Enable `populate_test_platform()` with `IXMP4Backend`

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,6 +7,7 @@ repos:
     additional_dependencies:
     - genno
     - GitPython
+    - ixmp4
     - nbclient
     - pandas-stubs
     - pytest

--- a/ixmp/__init__.py
+++ b/ixmp/__init__.py
@@ -4,6 +4,7 @@ from importlib.metadata import PackageNotFoundError, version
 
 from ixmp._config import config
 from ixmp.backend import BACKENDS, IAMC_IDX, ItemType
+from ixmp.backend.ixmp4 import IXMP4Backend
 from ixmp.backend.jdbc import JDBCBackend
 from ixmp.core.platform import Platform
 from ixmp.core.scenario import Scenario, TimeSeries
@@ -47,6 +48,7 @@ sys.meta_path.append(
 
 # Register Backends provided by ixmp
 BACKENDS["jdbc"] = JDBCBackend
+BACKENDS["ixmp4"] = IXMP4Backend
 
 # Register Models provided by ixmp
 MODELS.update(

--- a/ixmp/_config.py
+++ b/ixmp/_config.py
@@ -68,6 +68,10 @@ def _platform_default():
             "driver": "hsqldb",
             "path": next(_iter_config_paths())[1].joinpath("localdb", "default"),
         },
+        "ixmp4-local": {
+            "class": "ixmp4",
+            "dsn": "sqlite:///:memory:",
+        },
     }
 
 

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -204,12 +204,13 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def get_nodes(self) -> Iterable[tuple[str, Optional[str], str, str]]:
+    def get_nodes(self) -> Iterable[tuple[str, Optional[str], Optional[str], str]]:
         """Iterate over all nodes stored on the Platform.
 
         Yields
         -------
         tuple
+
             The members of each tuple are:
 
             ========= =========== ===
@@ -820,7 +821,7 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def list_items(self, s: Scenario, type: str) -> list[str]:
+    def list_items(self, s: Scenario, type: Literal["set", "par", "equ"]) -> list[str]:
         """Return a list of names of items of `type`.
 
         Parameters
@@ -832,7 +833,7 @@ class Backend(ABC):
     def init_item(
         self,
         s: Scenario,
-        type: str,
+        type: Literal["set", "par", "equ", "var"],
         name: str,
         idx_sets: Sequence[str],
         idx_names: Optional[Sequence[str]],
@@ -871,7 +872,9 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def item_index(self, s: Scenario, name: str, sets_or_names: str) -> list[str]:
+    def item_index(
+        self, s: Scenario, name: str, sets_or_names: Literal["sets", "names"]
+    ) -> list[str]:
         """Return the index sets or names of item `name`.
 
         Parameters
@@ -932,7 +935,7 @@ class Backend(ABC):
     def item_set_elements(
         self,
         s: Scenario,
-        type: str,
+        type: Literal["par", "set"],
         name: str,
         elements: Iterable[tuple[Any, Optional[float], Optional[str], Optional[str]]],
     ) -> None:
@@ -974,7 +977,9 @@ class Backend(ABC):
         """
 
     @abstractmethod
-    def item_delete_elements(self, s: Scenario, type: str, name: str, keys) -> None:
+    def item_delete_elements(
+        self, s: Scenario, type: Literal["par", "set"], name: str, keys
+    ) -> None:
         """Remove elements of item `name`.
 
         Parameters

--- a/ixmp/backend/base.py
+++ b/ixmp/backend/base.py
@@ -10,42 +10,14 @@ from typing import Any, Literal, Optional, Union
 import pandas as pd
 
 # TODO Import this from typing when dropping Python 3.11
-from typing_extensions import TypedDict, Unpack
+from typing_extensions import Unpack
 
 from ixmp.backend import ItemType
 from ixmp.backend.io import s_read_excel, s_write_excel, ts_read_file
 from ixmp.core.platform import Platform
 from ixmp.core.scenario import Scenario
 from ixmp.core.timeseries import TimeSeries
-
-
-# These are based on existing calls within ixmp
-class WriteFiltersKwargs(TypedDict, total=False):
-    scenario: Scenario | list[str]
-    model: list[str]
-    variable: list[str]
-    unit: list[str]
-    region: list[str]
-    default: bool
-    export_all_runs: bool
-
-
-class WriteKwargs(TypedDict, total=False):
-    filters: WriteFiltersKwargs
-    record_version_packages: list[str]
-
-
-class ReadKwargs(TypedDict, total=False):
-    filters: WriteFiltersKwargs
-    firstyear: Optional[Any]
-    lastyear: Optional[Any]
-    add_units: bool
-    init_items: bool
-    commit_steps: bool
-    check_solution: bool
-    comment: str
-    equ_list: list[str]
-    var_list: list[str]
+from ixmp.util.ixmp4 import ReadKwargs, WriteFiltersKwargs, WriteKwargs
 
 
 class Backend(ABC):

--- a/ixmp/backend/io.py
+++ b/ixmp/backend/io.py
@@ -2,15 +2,19 @@ import logging
 from collections import deque
 from collections.abc import Iterable
 from pathlib import Path
-from typing import TYPE_CHECKING, Optional, Union
+from typing import Optional, TypeVar, Union
 
 import gams.transfer as gt
 import pandas as pd
 
 # from gams import GamsWorkspace
 from ixmp4.core import Run
+from ixmp4.core.optimization.equation import Equation
 from ixmp4.core.optimization.indexset import IndexSet
+from ixmp4.core.optimization.parameter import Parameter
 from ixmp4.core.optimization.scalar import Scalar
+from ixmp4.core.optimization.table import Table
+from ixmp4.core.optimization.variable import Variable
 from ixmp4.data.abstract.optimization.equation import Equation as AbstractEquation
 from ixmp4.data.abstract.optimization.variable import Variable as AbstractVariable
 
@@ -18,20 +22,8 @@ from ixmp.util import as_str_list, maybe_check_out, maybe_commit
 
 from . import ItemType
 
-if TYPE_CHECKING:
-    from typing import TypeVar
-
-    from ixmp4.core.optimization.equation import Equation
-
-    # from ixmp4.core.optimization.indexset import IndexSet
-    from ixmp4.core.optimization.parameter import Parameter
-
-    # from ixmp4.core.optimization.scalar import Scalar
-    from ixmp4.core.optimization.table import Table
-    from ixmp4.core.optimization.variable import Variable
-
-    # Type variable that can be any one of these 6 types, but not a union of 2+ of them
-    Item4 = TypeVar("Item4", Equation, IndexSet, Parameter, Scalar, Table, Variable)
+# Type variable that can be any one of these 6 types, but not a union of 2+ of them
+Item4 = TypeVar("Item4", Equation, IndexSet, Parameter, Scalar, Table, Variable)
 
 
 log = logging.getLogger(__name__)
@@ -393,9 +385,9 @@ def _add_to_container(container: gt.Container, items: list[Item4]) -> None:
         return result
 
     for item in items:
-        # The gams documentation confuses me: The docstring says `type` is required, the
-        # example says no. It seems to work fine like this, but if we do need a value,
-        # maybe we could guess based on
+        # The gams documentation confuses me: The docstring says `type` is required for
+        # Equations, the example says no. It seems to work fine like this, but if we do
+        # need a value, maybe we could guess based on
         # https://github.com/iiasa/ixmp_source/blob/master/src/main/java/at/ac/iiasa/ixmp/objects/Scenario.java#L1926,
         klass(
             container=container,

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -2,15 +2,11 @@ import logging
 from collections.abc import Generator, MutableMapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional
 
-from ixmp4 import Platform
-from ixmp4.conf.base import PlatformInfo
-from ixmp4.data.backend import SqliteTestBackend
-from ixmp4.data.backend.base import Backend as ixmp4_backend
-
 from ixmp.backend.base import CachingBackend
 
 if TYPE_CHECKING:
     import ixmp4
+    from ixmp4.data.backend.base import Backend as ixmp4_backend
 
 log = logging.getLogger(__name__)
 
@@ -19,9 +15,13 @@ class IXMP4Backend(CachingBackend):
     """Backend using :mod:`ixmp4`."""
 
     _platform: "ixmp4.Platform"
-    _backend: ixmp4_backend
+    _backend: "ixmp4_backend"
 
-    def __init__(self, _backend: Optional[ixmp4_backend] = None) -> None:
+    def __init__(self, _backend: Optional["ixmp4_backend"] = None) -> None:
+        from ixmp4 import Platform
+        from ixmp4.conf.base import PlatformInfo
+        from ixmp4.data.backend import SqliteTestBackend
+
         # Create a default backend if None is provided
         if not _backend:
             log.warning("Falling back to default SqliteBackend 'ixmp4-local'")

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -180,7 +180,10 @@ class IXMP4Backend(CachingBackend):
     def is_default(self, ts: TimeSeries) -> bool:
         return self.index[ts].is_default()
 
-    # Handle various items
+    def has_solution(self, s: Scenario) -> bool:
+        return self.index[s].optimization.has_solution()
+
+    # Handle optimization items
 
     # TODO: type hints
     def _get_repo(
@@ -308,10 +311,6 @@ class IXMP4Backend(CachingBackend):
         if comment:
             scalar.docs = comment
 
-    ### TODO
-    ###
-    ### Currently, tests fail because they expect 'cases' to be predefined on the test_mp
-
     def _add_data_to_parameter(
         self,
         s: Scenario,
@@ -396,7 +395,6 @@ class IXMP4Backend(CachingBackend):
             # as such?
             _, item = self._get_item(s=s, name=name, type=type)
             data = pd.DataFrame(item.data)
-            print(data)
             if type == "par":
                 data.rename(columns={"values": "value", "units": "unit"}, inplace=True)
             else:
@@ -404,6 +402,8 @@ class IXMP4Backend(CachingBackend):
                     columns={"levels": "level", "marginals": "marginal"}, inplace=True
                 )
             return data
+
+    # Handle timeslices
 
     # The below methods of base.Backend are not yet implemented
     def _ni(self, *args, **kwargs):
@@ -422,7 +422,6 @@ class IXMP4Backend(CachingBackend):
     get_geo = _ni
     get_meta = _ni
     get_timeslices = _ni
-    has_solution = _ni
     item_delete_elements = _ni
     last_update = _ni
     remove_meta = _ni

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -19,6 +19,8 @@ class IXMP4Backend(CachingBackend):
 
         # Add an ixmp4.Platform using ixmp4's own configuration code
         # TODO Move this to a test fixture
+        # NB ixmp.tests.conftest.test_sqlite_mp exists, but is not importable (missing
+        #    __init__.py)
         import ixmp4.conf
 
         dsn = "sqlite:///:memory:"
@@ -29,6 +31,15 @@ class IXMP4Backend(CachingBackend):
 
         # Instantiate and store
         self._platform = ixmp4.Platform(name)
+
+    def get_scenarios(self, default, model, scenario):
+        # Current fails with:
+        # sqlalchemy.exc.OperationalError: (sqlite3.OperationalError) no such table: run
+        # [SQL: SELECT DISTINCT run.model__id, run.scenario__id, run.version,
+        # run.is_default, run.id
+        # FROM run
+        # WHERE run.is_default = 1 ORDER BY run.id ASC]
+        return self._platform.runs.list()
 
     # The below methods of base.Backend are not yet implemented
     def _ni(self, *args, **kwargs):
@@ -55,7 +66,6 @@ class IXMP4Backend(CachingBackend):
     get_meta = _ni
     get_model_names = _ni
     get_nodes = _ni
-    get_scenarios = _ni
     get_scenario_names = _ni
     get_timeslices = _ni
     get_units = _ni

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -1,8 +1,12 @@
 import logging
-from collections.abc import Generator, MutableMapping, Sequence
-from typing import TYPE_CHECKING, Any, Optional
+from collections.abc import Generator, Iterable, MutableMapping, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Optional, Union, cast
+
+import pandas as pd
 
 from ixmp.backend.base import CachingBackend
+from ixmp.core.scenario import Scenario
+from ixmp.core.timeseries import TimeSeries
 
 if TYPE_CHECKING:
     import ixmp4
@@ -16,6 +20,10 @@ class IXMP4Backend(CachingBackend):
 
     _platform: "ixmp4.Platform"
     _backend: "ixmp4_backend"
+
+    # Mapping from ixmp.TimeSeries object to the underlying ixmp4.Run object (or
+    # subclasses of either)
+    index: dict[TimeSeries, "ixmp4.Run"] = {}
 
     def __init__(self, _backend: Optional["ixmp4_backend"] = None) -> None:
         from ixmp4 import Platform
@@ -56,8 +64,10 @@ class IXMP4Backend(CachingBackend):
     # def close_db(self) -> None:
     #     self._backend.close()
 
+    # Modifying the Platform
+
     def add_scenario_name(self, name: str) -> None:
-        self._platform.scenarios.create(name)
+        self._platform.scenarios.create(name=name)
 
     # TODO clarify: ixmp4.Run doesn't have a name, but is the new ixmp.Scenario
     # should it have a name or are these scenario names okay?
@@ -66,7 +76,7 @@ class IXMP4Backend(CachingBackend):
             yield scenario.name
 
     def add_model_name(self, name: str) -> None:
-        self._platform.models.create(name)
+        self._platform.models.create(name=name)
 
     def get_model_names(self) -> Generator[str, None, None]:
         for model in self._platform.models.list():
@@ -76,10 +86,324 @@ class IXMP4Backend(CachingBackend):
         return self._platform.runs.list()
 
     def set_unit(self, name: str, comment: str) -> None:
-        self._platform.units.create(name).docs = comment
+        self._platform.units.create(name=name).docs = comment
 
     def get_units(self) -> list[str]:
         return [unit.name for unit in self._platform.units.list()]
+
+    def set_node(
+        self,
+        name: str,
+        parent: Optional[str] = None,
+        hierarchy: Optional[str] = None,
+        synonym: Optional[str] = None,
+    ) -> None:
+        if parent:
+            log.warning(f"Discarding parent parameter {parent}; unused in ixmp4.")
+        if synonym:
+            log.warning(f"Discarding synonym parameter {synonym}; unused in ixmp4.")
+        if hierarchy is None:
+            raise ValueError("IXMP4Backend.set_node() requires to specify 'hierarchy'!")
+        self._platform.regions.create(name=name, hierarchy=hierarchy)
+
+    def get_nodes(self) -> list[tuple[str, str, None, str]]:
+        return [
+            (region.name, region.name, None, region.hierarchy)
+            for region in self._platform.regions.list()
+        ]
+
+    # Modifying the Run object
+
+    def _index_and_set_attrs(self, run: "ixmp4.Run", ts: TimeSeries) -> None:
+        """Add *run* to index and update attributes of *ts*.
+
+        Helper for init and get.
+        """
+        # Add to index
+        self.index[ts] = run
+
+        # Retrieve the version of the ixmp4.Run object
+        v = run.version
+        if ts.version is None:
+            # The default version was requested; update the attribute
+            ts.version = v
+        elif v != ts.version:  # pragma: no cover
+            # Something went wrong on the ixmp4 side
+            raise RuntimeError(f"got version {v} instead of {ts.version}")
+
+    def init(self, ts: TimeSeries, annotation: str) -> None:
+        run = self._platform.runs.create(model=ts.model, scenario=ts.scenario)
+        # TODO either do log.warning that annotation is unused or
+        # run.docs = annotation
+        self._index_and_set_attrs(run, ts)
+
+    def get(self, ts: TimeSeries) -> None:
+        v = int(ts.version) if ts.version else None
+        run = self._platform.runs.get(model=ts.model, scenario=ts.scenario, version=v)
+        self._index_and_set_attrs(run, ts)
+
+    def check_out(self, ts: TimeSeries, timeseries_only: bool) -> None:
+        log.warning("ixmp4 backed Scenarios/Runs don't need to be checked out!")
+
+    def discard_changes(self, ts: TimeSeries) -> None:
+        log.warning(
+            "ixmp4 backed Scenarios/Runs are changed immediately, can't "
+            "discard changes. To avoid the need, be sure to start work on "
+            "fresh clones."
+        )
+
+    def commit(self, ts: TimeSeries, comment: str) -> None:
+        log.warning(
+            "ixmp4 backed Scenarios/Runs are changed immediately, no need for "
+            "a commit!"
+        )
+
+    def clear_solution(self, s: Scenario, from_year: Optional[int] = None) -> None:
+        if from_year:
+            log.warning(
+                "ixmp4 does not support removing the solution only after a "
+                "certain year"
+            )
+        self.index[s].optimization.remove_solution()
+
+    def set_as_default(self, ts: TimeSeries) -> None:
+        # TODO are we okay with always loading a Run for this or should we adapt
+        # TimeSeries to have a `_run` attribute that has the Run loaded?
+        self.index[ts].set_as_default()
+
+    # Information about the Run
+
+    def run_id(self, ts: TimeSeries) -> int:
+        # TODO is the Run.version really what this function is after?
+        return self.index[ts].version
+
+    def is_default(self, ts: TimeSeries) -> bool:
+        return self.index[ts].is_default()
+
+    # Handle various items
+
+    # TODO: type hints
+    def _get_repo(
+        self,
+        s: Scenario,
+        type: Literal["scalar", "indexset", "set", "par", "equ", "var"],
+    ):
+        if type == "scalar":
+            return self.index[s].optimization.scalars
+        if type == "indexset":
+            return self.index[s].optimization.indexsets
+        if type == "set":
+            return self.index[s].optimization.tables
+        elif type == "par":
+            return self.index[s].optimization.parameters
+        elif type == "equ":
+            return self.index[s].optimization.equations
+        else:  # "var"
+            return self.index[s].optimization.variables
+
+    def init_item(
+        self,
+        s: Scenario,
+        type: Literal["set", "par", "equ", "var"],
+        name: str,
+        idx_sets: Sequence[str],
+        idx_names: Optional[Sequence[str]],
+    ) -> None:
+        # TODO how are scalars created? Scalars require a value in ixmp4
+        # In base::item_get_elements, it sounds like "equ" and "var" can also target
+        # scalars, whereas below, inspired from jdbc, I'm only linking "par" to scalars
+        if type == "set" and len(idx_sets) == 0:
+            repo = self._get_repo(s=s, type="indexset")
+            repo.create(name=name)
+        else:
+            repo = self._get_repo(s=s, type=type)
+            repo.create(
+                name=name, constrained_to_indexsets=idx_sets, column_names=idx_names
+            )
+
+    def list_items(self, s: Scenario, type: Literal["set", "par", "equ"]) -> list[str]:
+        if type == "set":
+            indexset_repo = self._get_repo(s=s, type="indexset")
+            set_repo = self._get_repo(s=s, type=type)
+            return [item.name for item in indexset_repo.list()] + [
+                item.name for item in set_repo.list()
+            ]
+        else:
+            repo = self._get_repo(s=s, type=type)
+            return [item.name for item in repo.list()]
+
+    # TODO type hints
+    def _find_item(self, s: Scenario, name: str):
+        # NOTE this currently assumes that `name` will only be present once among
+        # Tables, Parameters, Equations, Variables. This is in line with the assumption
+        # made in the Java backend, but ixmp4 enforces no such constraint.
+        for type in ("scalar", "indexset", "set", "par", "equ", "var"):
+            repo = self._get_repo(s=s, type=type)
+            item_list = repo.list(name=name)
+            if (
+                len(item_list) == 1
+            ):  # ixmp4 enforces names to be unique among individual item classes
+                return (type, item_list[0])
+
+    def _get_item(
+        self,
+        s: Scenario,
+        name: str,
+        type: Literal["scalar", "indexset", "set", "par", "equ", "var"],
+    ):
+        # TODO add try except here to always return using IndexError from repo.list()[0]
+        repo = self._get_repo(s=s, type=type)
+        item_list = repo.list(name=name)
+        if (
+            len(item_list) == 1
+        ):  # ixmp4 enforces names to be unique among individual item classes
+            return (type, item_list[0])
+
+    # TODO mypy says this function is missing a return statement. But why?
+    # AFAICT, items.items() will always contain something, so we will always return
+    # something (unless we raise). Am I missing something?
+    def item_index(  # type: ignore[return]
+        self, s: Scenario, name: str, sets_or_names: Literal["sets", "names"]
+    ) -> list[str]:
+        type, item = self._find_item(s=s, name=name)
+        if item is None:
+            raise LookupError(f"No item called {name} found on this Scenario!")
+        if type == "indexset":
+            return cast(list[str], [])
+        else:
+            return (
+                [column.name for column in item.columns]
+                if sets_or_names == "names"
+                else item.constrained_to_indexsets
+            )
+
+    def _add_data_to_set(
+        self, s: Scenario, name: str, key: str | list[str], comment: Optional[str]
+    ) -> None:
+        if comment:
+            log.warning(
+                "`comment` currently unused with ixmp4 when adding data to Tables."
+            )
+        # Assumption: if key is just one value, we're dealing with an IndexSet
+        if isinstance(key, str):
+            self.index[s].optimization.indexsets.get(name=name).add(key)
+        else:
+            table = self.index[s].optimization.tables.get(name=name)
+            data_to_add = {
+                table.constrained_to_indexsets[i]: key[i] for i in range(len(key))
+            }
+            table.add(data=data_to_add)
+
+    def _create_scalar(
+        self,
+        s: Scenario,
+        name: str,
+        value: float,
+        unit: Optional[str],
+        comment: Optional[str],
+    ) -> None:
+        scalar = self.index[s].optimization.scalars.create(
+            name=name, value=value, unit=unit
+        )
+        if comment:
+            scalar.docs = comment
+
+    ### TODO
+    ###
+    ### Currently, tests fail because they expect 'cases' to be predefined on the test_mp
+
+    def _add_data_to_parameter(
+        self,
+        s: Scenario,
+        name: str,
+        key: str | list[str],
+        value: float,
+        unit: str,
+        comment: Optional[str],
+    ) -> None:
+        if comment:
+            log.warning(
+                "`comment` currently unused with ixmp4 when adding data to "
+                "Parameters."
+            )
+        parameter = self.index[s].optimization.parameters.get(name=name)
+        # TODO there's got to be a better way for handling possible lists
+        if isinstance(key, str):
+            key = [key]
+        data_to_add: dict[str, Union[list[float], list[str]]] = {
+            parameter.constrained_to_indexsets[i]: [key[i]] for i in range(len(key))
+        }
+        data_to_add["values"] = [value]
+        data_to_add["units"] = [unit]
+        parameter.add(data=data_to_add)
+
+    def item_set_elements(
+        self,
+        s: Scenario,
+        type: Literal["par", "set"],
+        name: str,
+        elements: Iterable[tuple[Any, Optional[float], Optional[str], Optional[str]]],
+    ) -> None:
+        for key, value, unit, comment in elements:
+            if type == "set":
+                self._add_data_to_set(s=s, name=name, key=key, comment=comment)
+            else:
+                if key is None:
+                    assert value, "Creating a Scalar requires a value!"
+                    self._create_scalar(
+                        s=s, name=name, value=value, unit=unit, comment=comment
+                    )
+                else:
+                    assert value, "Adding data to a Parameter requires a value!"
+                    assert unit, "Adding data to a Parameter requires a unit!"
+                    self._add_data_to_parameter(
+                        s=s, name=name, key=key, value=value, unit=unit, comment=comment
+                    )
+
+    def _get_set_data(
+        self, s: Scenario, name: str, filters: Optional[dict[str, list[Any]]] = None
+    ) -> Union[pd.Series, pd.DataFrame]:
+        # TODO handle filters
+        from ixmp4.core import IndexSet, Table
+        from ixmp4.core.exceptions import NotFound
+
+        item: Union[IndexSet, Table]
+        try:
+            repo = self._get_repo(s=s, type="indexset")
+            item = cast(IndexSet, repo.get(name=name))
+        except NotFound:
+            repo = self._get_repo(s=s, type="set")
+            item = cast(Table, repo.get(name=name))
+
+        return (
+            pd.DataFrame(item.data) if isinstance(item, Table) else pd.Series(item.data)
+        )
+
+    def item_get_elements(
+        self,
+        s: Scenario,
+        type: Literal["equ", "par", "set", "var"],
+        name: str,
+        filters: Optional[dict[str, list[Any]]] = None,
+    ) -> Union[dict[str, Any], pd.Series, pd.DataFrame]:
+        # TODO handle filters
+        if type == "set":
+            return self._get_set_data(s=s, name=name, filters=filters)
+        # TODO this is not handling scalars at the moment, but maybe try with type,
+        # except NotFound, try scalar?
+        else:
+            # TODO this can really only be Equation, Parameter, or Variable, so cast
+            # as such?
+            _, item = self._get_item(s=s, name=name, type=type)
+            data = pd.DataFrame(item.data)
+            print(data)
+            if type == "par":
+                data.rename(columns={"values": "value", "units": "unit"}, inplace=True)
+            else:
+                data.rename(
+                    columns={"levels": "level", "marginals": "marginal"}, inplace=True
+                )
+            return data
 
     # The below methods of base.Backend are not yet implemented
     def _ni(self, *args, **kwargs):
@@ -88,38 +412,22 @@ class IXMP4Backend(CachingBackend):
     cat_get_elements = _ni
     cat_list = _ni
     cat_set_elements = _ni
-    check_out = _ni
-    clear_solution = _ni
     clone = _ni
-    commit = _ni
     delete = _ni
     delete_geo = _ni
     delete_item = _ni
     delete_meta = _ni
-    discard_changes = _ni
-    get = _ni
     get_data = _ni
     get_doc = _ni
     get_geo = _ni
     get_meta = _ni
-    get_nodes = _ni
     get_timeslices = _ni
     has_solution = _ni
-    init = _ni
-    init_item = _ni
-    is_default = _ni
     item_delete_elements = _ni
-    item_get_elements = _ni
-    item_index = _ni
-    item_set_elements = _ni
     last_update = _ni
-    list_items = _ni
     remove_meta = _ni
-    run_id = _ni
-    set_as_default = _ni
     set_data = _ni
     set_doc = _ni
     set_geo = _ni
     set_meta = _ni
-    set_node = _ni
     set_timeslice = _ni

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -1,8 +1,34 @@
+from typing import TYPE_CHECKING
+
 from ixmp.backend.base import CachingBackend
+
+if TYPE_CHECKING:
+    import ixmp4
 
 
 class IXMP4Backend(CachingBackend):
     """Backend using :mod:`ixmp4`."""
+
+    _platform: "ixmp4.Platform"
+
+    def __init__(self):
+        import ixmp4
+
+        # TODO Obtain `name` from the ixmp.Platform creating this Backend
+        name = "test"
+
+        # Add an ixmp4.Platform using ixmp4's own configuration code
+        # TODO Move this to a test fixture
+        import ixmp4.conf
+
+        dsn = "sqlite:///:memory:"
+        try:
+            ixmp4.conf.settings.toml.add_platform(name, dsn)
+        except ixmp4.core.exceptions.PlatformNotUnique:
+            pass
+
+        # Instantiate and store
+        self._platform = ixmp4.Platform(name)
 
     # The below methods of base.Backend are not yet implemented
     def _ni(self, *args, **kwargs):

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -3,3 +3,53 @@ from ixmp.backend.base import CachingBackend
 
 class IXMP4Backend(CachingBackend):
     """Backend using :mod:`ixmp4`."""
+
+    # The below methods of base.Backend are not yet implemented
+    def _ni(self, *args, **kwargs):
+        raise NotImplementedError
+
+    add_model_name = _ni
+    add_scenario_name = _ni
+    cat_get_elements = _ni
+    cat_list = _ni
+    cat_set_elements = _ni
+    check_out = _ni
+    clear_solution = _ni
+    clone = _ni
+    commit = _ni
+    delete = _ni
+    delete_geo = _ni
+    delete_item = _ni
+    delete_meta = _ni
+    discard_changes = _ni
+    get = _ni
+    get_data = _ni
+    get_doc = _ni
+    get_geo = _ni
+    get_meta = _ni
+    get_model_names = _ni
+    get_nodes = _ni
+    get_scenarios = _ni
+    get_scenario_names = _ni
+    get_timeslices = _ni
+    get_units = _ni
+    has_solution = _ni
+    init = _ni
+    init_item = _ni
+    is_default = _ni
+    item_delete_elements = _ni
+    item_get_elements = _ni
+    item_index = _ni
+    item_set_elements = _ni
+    last_update = _ni
+    list_items = _ni
+    remove_meta = _ni
+    run_id = _ni
+    set_as_default = _ni
+    set_data = _ni
+    set_doc = _ni
+    set_geo = _ni
+    set_meta = _ni
+    set_node = _ni
+    set_timeslice = _ni
+    set_unit = _ni

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -1,0 +1,5 @@
+from ixmp.backend.base import CachingBackend
+
+
+class IXMP4Backend(CachingBackend):
+    """Backend using :mod:`ixmp4`."""

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -81,9 +81,6 @@ class Platform:
         # Overwrite any platform config with explicit keyword arguments
         kwargs.update(backend_args)
 
-        if backend == "ixmp4":
-            kwargs["name"] = self.name
-
         # Retrieve the Backend class
         try:
             backend_class_name = kwargs.pop("class")

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -81,6 +81,9 @@ class Platform:
         # Overwrite any platform config with explicit keyword arguments
         kwargs.update(backend_args)
 
+        if backend == "ixmp4":
+            kwargs["name"] = self.name
+
         # Retrieve the Backend class
         try:
             backend_class_name = kwargs.pop("class")

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -9,6 +9,7 @@ import pandas as pd
 from ixmp._config import config
 from ixmp.backend import BACKENDS, FIELDS, ItemType
 from ixmp.util import as_str_list
+from ixmp.util.ixmp4 import WriteFiltersKwargs
 
 if TYPE_CHECKING:
     from ixmp.backend.base import Backend
@@ -236,15 +237,15 @@ class Platform:
                 "Invalid arguments: export_all_runs cannot be used when providing a "
                 "model or scenario."
             )
-        filters = {
-            "model": as_str_list(model),
-            "scenario": as_str_list(scenario),
-            "variable": as_str_list(variable),
-            "unit": as_str_list(unit),
-            "region": as_str_list(region),
-            "default": default,
-            "export_all_runs": export_all_runs,
-        }
+        filters = WriteFiltersKwargs(
+            scenario=as_str_list(scenario),
+            model=as_str_list(model),
+            variable=as_str_list(variable),
+            unit=as_str_list(unit),
+            region=as_str_list(region),
+            default=default,
+            export_all_runs=export_all_runs,
+        )
 
         self._backend.write_file(path, ItemType.TS, filters=filters)
 

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -406,6 +406,7 @@ def _setup_ixmp4_platform(mp: Platform) -> None:
     """Set up an ixmp4-backed Platform with things hardcoded in Java."""
     mp.add_unit("cases", comment="As pre-defined in Java.")
     mp.add_unit("km", comment="As pre-defined in Java.")
+    mp.add_region(region="World", hierarchy="common")
 
 
 def _platform_fixture(

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -410,7 +410,7 @@ def _platform_fixture(
             platform_name, backend, "hsqldb", url=f"jdbc:hsqldb:mem:{platform_name}"
         )
     elif backend == "ixmp4":
-        import ixmp4.conf
+        # import ixmp4.conf
 
         # Setup ixmp4 backend and run DB migrations
         sqlite = SqliteTestBackend(
@@ -418,13 +418,8 @@ def _platform_fixture(
         )
         sqlite.setup()
 
-        # Add DB to ixmp4 config
-        ixmp4.conf.settings.toml.add_platform(
-            name=platform_name, dsn="sqlite:///:memory:"
-        )
-
         # Add ixmp4 backend to ixmp platforms
-        ixmp_config.add_platform(platform_name, backend)
+        ixmp_config.add_platform(platform_name, backend, _backend=sqlite)
 
     # Launch Platform
     mp = Platform(name=platform_name, backend=backend)
@@ -444,4 +439,3 @@ def _platform_fixture(
         # Close DB connection and remove platform
         sqlite.close()
         sqlite.teardown()
-        ixmp4.conf.settings.toml.remove_platform(platform_name)

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -401,6 +401,13 @@ def create_test_platform(tmp_path, data_path, name, **properties):
 # Private utilities
 
 
+# TODO Check if this setup is necessary when running all tests (not just test_platform)
+def _setup_ixmp4_platform(mp: Platform) -> None:
+    """Set up an ixmp4-backed Platform with things hardcoded in Java."""
+    mp.add_unit("cases", comment="As pre-defined in Java.")
+    mp.add_unit("km", comment="As pre-defined in Java.")
+
+
 def _platform_fixture(
     request: pytest.FixtureRequest, tmp_env, test_data_path, backend: str
 ) -> Generator[Platform, Any, None]:
@@ -429,6 +436,8 @@ def _platform_fixture(
 
     # Launch Platform
     mp = Platform(name=platform_name, backend=backend)
+    if backend == "ixmp4":
+        _setup_ixmp4_platform(mp=mp)
     yield mp
 
     # Teardown: don't show log messages when destroying the platform, even if

--- a/ixmp/testing/data.py
+++ b/ixmp/testing/data.py
@@ -250,7 +250,7 @@ def make_dantzig(
     return scen
 
 
-def populate_test_platform(platform):
+def populate_test_platform(platform: Platform) -> None:
     """Populate `platform` with data for testing.
 
     Many of the tests in :mod:`ixmp.tests.core` depend on this set of data.

--- a/ixmp/testing/data.py
+++ b/ixmp/testing/data.py
@@ -11,6 +11,7 @@ import pytest
 
 from ixmp import Platform, Scenario, TimeSeries
 from ixmp.backend import IAMC_IDX
+from ixmp.backend.ixmp4 import IXMP4Backend
 
 if TYPE_CHECKING:
     from typing import TypedDict
@@ -182,6 +183,11 @@ def add_test_data(scen: Scenario):
     return t, t_foo, t_bar, x
 
 
+def _add_required_units(mp: Platform) -> None:
+    mp.add_unit("USD")
+    mp.add_unit("???")
+
+
 def make_dantzig(
     mp: Platform,
     solve: bool = False,
@@ -209,6 +215,9 @@ def make_dantzig(
     --------
     .DantzigModel
     """
+    if isinstance(mp._backend, IXMP4Backend):
+        _add_required_units(mp=mp)
+
     # Add custom units and region for time series data
     try:
         mp.add_unit("USD/km")

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from sys import getrefcount
-from typing import TYPE_CHECKING, Generator
+from typing import TYPE_CHECKING
 from weakref import getweakrefcount
 
 import pandas as pd
@@ -20,17 +20,6 @@ if TYPE_CHECKING:
 
 
 class TestPlatform:
-    @pytest.fixture(params=list(ixmp.BACKENDS))
-    def mp(self, request, test_mp) -> Generator[ixmp.Platform, None, None]:
-        """Fixture that yields 2 different platforms: one JDBC-backed, one ixmp4."""
-        backend = request.param
-
-        if backend == "jdbc":
-            yield test_mp
-        elif backend == "ixmp4":
-            # TODO Use a fixture similar to test_mp (with same contents) backed by ixmp4
-            yield ixmp.Platform(backend="ixmp4")
-
     def test_init0(self):
         with pytest.raises(
             ValueError,
@@ -46,7 +35,8 @@ class TestPlatform:
         "backend, backend_args",
         (
             ("jdbc", dict(driver="hsqldb", url="jdbc:hsqldb:mem:TestPlatform")),
-            ("ixmp4", dict()),
+            # TODO use this/default name for ixmp4 platforms without passing it manually
+            ("ixmp4", dict(name="ixmp4-local")),
         ),
     )
     def test_init1(self, backend, backend_args):
@@ -58,7 +48,7 @@ class TestPlatform:
         with pytest.raises(AttributeError):
             test_mp.not_a_direct_backend_method
 
-    def test_scenario_list(self, mp):
+    def test_scenario_list(self, mp: ixmp.Platform) -> None:
         scenario = mp.scenario_list()
         assert isinstance(scenario, pd.DataFrame)
 

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -20,7 +20,7 @@ if TYPE_CHECKING:
 
 
 class TestPlatform:
-    def test_init(self):
+    def test_init0(self):
         with pytest.raises(
             ValueError,
             match=re.escape("backend class 'foo' not among ['ixmp4', 'jdbc']"),
@@ -30,6 +30,17 @@ class TestPlatform:
         # name="default" is used, referring to "local"
         mp = ixmp.Platform()
         assert "local" == mp.name
+
+    @pytest.mark.parametrize(
+        "backend, backend_args",
+        (
+            ("jdbc", dict(driver="hsqldb", url="jdbc:hsqldb:mem:TestPlatform")),
+            ("ixmp4", dict()),
+        ),
+    )
+    def test_init1(self, backend, backend_args):
+        # Platform can be instantiated
+        ixmp.Platform(backend=backend, **backend_args)
 
     def test_getattr(self, test_mp):
         """Test __getattr__."""

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -2,6 +2,7 @@
 
 import logging
 import re
+import sys
 from sys import getrefcount
 from typing import TYPE_CHECKING
 from weakref import getweakrefcount
@@ -18,12 +19,16 @@ from ixmp.testing import DATA, assert_logs, models
 if TYPE_CHECKING:
     from ixmp import Platform
 
+min_ixmp4_version = pytest.mark.skipif(
+    sys.version_info < (3, 10), reason="ixmp4 requires Python 3.10 or higher"
+)
+
 
 class TestPlatform:
     def test_init0(self):
         with pytest.raises(
             ValueError,
-            match=re.escape("backend class 'foo' not among ['ixmp4', 'jdbc']"),
+            match=re.escape("backend class 'foo' not among"),
         ):
             ixmp.Platform(backend="foo")
 
@@ -35,7 +40,7 @@ class TestPlatform:
         "backend, backend_args",
         (
             ("jdbc", dict(driver="hsqldb", url="jdbc:hsqldb:mem:TestPlatform")),
-            ("ixmp4", dict()),
+            pytest.param("ixmp4", dict(), marks=min_ixmp4_version),
         ),
     )
     def test_init1(self, backend, backend_args):

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -3,7 +3,7 @@
 import logging
 import re
 from sys import getrefcount
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Generator
 from weakref import getweakrefcount
 
 import pandas as pd
@@ -20,6 +20,17 @@ if TYPE_CHECKING:
 
 
 class TestPlatform:
+    @pytest.fixture(params=list(ixmp.BACKENDS))
+    def mp(self, request, test_mp) -> Generator[ixmp.Platform, None, None]:
+        """Fixture that yields 2 different platforms: one JDBC-backed, one ixmp4."""
+        backend = request.param
+
+        if backend == "jdbc":
+            yield test_mp
+        elif backend == "ixmp4":
+            # TODO Use a fixture similar to test_mp (with same contents) backed by ixmp4
+            yield ixmp.Platform(backend="ixmp4")
+
     def test_init0(self):
         with pytest.raises(
             ValueError,

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -22,7 +22,8 @@ if TYPE_CHECKING:
 class TestPlatform:
     def test_init(self):
         with pytest.raises(
-            ValueError, match=re.escape("backend class 'foo' not among ['jdbc']")
+            ValueError,
+            match=re.escape("backend class 'foo' not among ['ixmp4', 'jdbc']"),
         ):
             ixmp.Platform(backend="foo")
 

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -58,6 +58,10 @@ class TestPlatform:
         with pytest.raises(AttributeError):
             test_mp.not_a_direct_backend_method
 
+    def test_scenario_list(self, mp):
+        scenario = mp.scenario_list()
+        assert isinstance(scenario, pd.DataFrame)
+
 
 @pytest.fixture
 def log_level_mp(test_mp):

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -35,8 +35,7 @@ class TestPlatform:
         "backend, backend_args",
         (
             ("jdbc", dict(driver="hsqldb", url="jdbc:hsqldb:mem:TestPlatform")),
-            # TODO use this/default name for ixmp4 platforms without passing it manually
-            ("ixmp4", dict(name="ixmp4-local")),
+            ("ixmp4", dict()),
         ),
     )
     def test_init1(self, backend, backend_args):

--- a/ixmp/util/ixmp4.py
+++ b/ixmp/util/ixmp4.py
@@ -1,0 +1,36 @@
+# TODO Import this from typing when dropping Python 3.11
+from typing import TYPE_CHECKING, Any, Optional
+
+from typing_extensions import TypedDict
+
+if TYPE_CHECKING:
+    from ixmp.core.scenario import Scenario
+
+
+# These are based on existing calls within ixmp
+class WriteFiltersKwargs(TypedDict, total=False):
+    scenario: "Scenario | list[str]"
+    model: list[str]
+    variable: list[str]
+    unit: list[str]
+    region: list[str]
+    default: bool
+    export_all_runs: bool
+
+
+class WriteKwargs(TypedDict, total=False):
+    filters: WriteFiltersKwargs
+    record_version_packages: list[str]
+
+
+class ReadKwargs(TypedDict, total=False):
+    filters: WriteFiltersKwargs
+    firstyear: Optional[Any]
+    lastyear: Optional[Any]
+    add_units: bool
+    init_items: bool
+    commit_steps: bool
+    check_solution: bool
+    comment: str
+    equ_list: list[str]
+    var_list: list[str]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,10 +57,11 @@ docs = [
   "sphinx_rtd_theme",
   "sphinxcontrib-bibtex",
 ]
+ixmp4 = ["ixmp4"]
 report = ["genno[compat,graphviz]"]
 tutorial = ["jupyter"]
 tests = [
-  "ixmp[report,tutorial]",
+  "ixmp[ixmp4,report,tutorial]",
   "memory_profiler",
   "nbclient >= 0.5",
   "pytest >= 5",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,8 +57,11 @@ docs = [
   "sphinx_rtd_theme",
   "sphinxcontrib-bibtex",
 ]
-# Change ixmp4 to new release after https://github.com/iiasa/ixmp4/pull/153 is merged
-ixmp4 = ["ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/expose-run-is-default"]
+# Change ixmp4 to new release after https://github.com/iiasa/ixmp4/pull/164 is merged
+ixmp4 = [
+  "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/make-equation-indexsets-optional", 
+  "gamsapi[core,transfer] >= 45.7.0",
+]
 report = ["genno[compat,graphviz]"]
 tutorial = ["jupyter"]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,7 +57,8 @@ docs = [
   "sphinx_rtd_theme",
   "sphinxcontrib-bibtex",
 ]
-ixmp4 = ["ixmp4"]
+# Change ixmp4 to new release after https://github.com/iiasa/ixmp4/pull/153 is merged
+ixmp4 = ["ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/expose-run-is-default"]
 report = ["genno[compat,graphviz]"]
 tutorial = ["jupyter"]
 tests = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,8 @@ ixmp4 = ["ixmp4"]
 report = ["genno[compat,graphviz]"]
 tutorial = ["jupyter"]
 tests = [
-  "ixmp[ixmp4,report,tutorial]",
+  "ixmp[report,tutorial]",
+  "ixmp[ixmp4]; python_version > '3.9'",
   "memory_profiler",
   "nbclient >= 0.5",
   "pytest >= 5",


### PR DESCRIPTION
This PR adds a little more functionality to the `IXMP4Backend`, which is enough to make `populate_test_platform()` pass. In turn, this includes `make_dantzig(solve=True)`, so this feels like quite a significant milestone. Enough, at least, to now turn to message_ix and see if I can't get `westeros_baseline` to run. After all, everything making that more fancy than the transport tutorial should be handled in message_ix, I think.

One item deserves special attention, maybe: the `JDBCBackend` has certain units pre-defined, it seems. For `make_dantzig()`, I've included a check for now: when we're on an `IXMP4Backend`, we quickly add the required units. However, this only covers this one test function and we probably want to come up with a solution that covers all cases. Which likely means:

1. Figure out which units are pre-defined
2. Set up a check in `Platform.__init__()` that defines all these units on an `IXMP4Backend`

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.
