### PR TITLE
Enable running the message_ix Westeros Baseline tutorial completely

### DIFF
--- a/ixmp/_config.py
+++ b/ixmp/_config.py
@@ -70,7 +70,11 @@ def _platform_default():
         },
         "ixmp4-local": {
             "class": "ixmp4",
-            "dsn": "sqlite:///:memory:",
+            "dsn": (
+                "sqlite:///"
+                f"{Path.home().joinpath('.local', 'share', 'ixmp4', 'databases')}"
+                "/ixmp4-local.sqlite3"
+            ),
         },
     }
 

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -570,7 +570,10 @@ class IXMP4Backend(CachingBackend):
                 data.rename(columns={"values": "value", "units": "unit"}, inplace=True)
             else:
                 data.rename(
-                    columns={"levels": "level", "marginals": "marginal"}, inplace=True
+                    # NOTE the ixmp.report(er) expects these names, unfortunately; see
+                    # ixmp.report.util::keys_for_quantity()
+                    columns={"levels": "lvl", "marginals": "mrg"},
+                    inplace=True,
                 )
             return data
 

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -60,6 +60,8 @@ class Platform:
         "set_meta",
     ]
 
+    _units_to_warn_about: Optional[list[str]] = None
+
     def __init__(
         self, name: Optional[str] = None, backend: Optional[str] = None, **backend_args
     ):

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -1,7 +1,7 @@
 import logging
 from collections.abc import Sequence
 from os import PathLike
-from typing import TYPE_CHECKING, Optional, Union
+from typing import TYPE_CHECKING, Literal, Optional, Union
 
 import numpy as np
 import pandas as pd
@@ -63,7 +63,10 @@ class Platform:
     _units_to_warn_about: Optional[list[str]] = None
 
     def __init__(
-        self, name: Optional[str] = None, backend: Optional[str] = None, **backend_args
+        self,
+        name: Optional[str] = None,
+        backend: Optional[Literal["ixmp4", "jdbc"]] = None,
+        **backend_args,
     ):
         if name is None:
             if backend is None and not len(backend_args):

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -705,6 +705,7 @@ class Scenario(TimeSeries):
         else:
             self._backend("item_delete_elements", "par", name, self._keys(name, key))
 
+    # FIXME What ensures that filters has the correct type?
     def var(self, name: str, filters=None, **kwargs):
         """Return a dataframe of (filtered) elements for a specific variable.
 

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -41,7 +41,7 @@ class Scenario(TimeSeries):
     """
 
     #: Scheme of the Scenario.
-    scheme = None
+    scheme: Optional[str] = None
 
     def __init__(
         self,

--- a/ixmp/report/reporter.py
+++ b/ixmp/report/reporter.py
@@ -1,5 +1,5 @@
 from itertools import chain, repeat
-from typing import Union, cast
+from typing import Literal, Union, cast
 
 import dask
 import pandas as pd
@@ -53,7 +53,7 @@ class Reporter(Computer):
         all_keys: list[Union[str, Key]] = []
 
         # List of parameters, equations, and variables
-        quantities = chain(
+        quantities: chain[tuple[Literal["par", "equ", "var"], str]] = chain(
             zip(repeat("par"), sorted(scenario.par_list())),
             zip(repeat("equ"), sorted(scenario.equ_list())),
             zip(repeat("var"), sorted(scenario.var_list())),

--- a/ixmp/report/util.py
+++ b/ixmp/report/util.py
@@ -1,12 +1,18 @@
 from functools import lru_cache, partial
+from typing import TYPE_CHECKING, Literal, Union
 
 import pandas as pd
 from genno import Key
 
 from ixmp.report import common
 
+if TYPE_CHECKING:
+    from genno.types import AnyQuantity
 
-def dims_for_qty(data):
+    from ixmp.core.scenario import Scenario
+
+
+def dims_for_qty(data: Union[list[str], pd.DataFrame]) -> list[str]:
     """Return the list of dimensions for *data*.
 
     If *data* is a :class:`pandas.DataFrame`, its columns are processed;
@@ -28,7 +34,9 @@ def dims_for_qty(data):
     return [common.RENAME_DIMS.get(d, d) for d in dims]
 
 
-def keys_for_quantity(ix_type, name, scenario):
+def keys_for_quantity(
+    ix_type: Literal["par", "equ", "var"], name: str, scenario: "Scenario"
+) -> list[tuple[Key, partial["AnyQuantity"], str, str]]:
     """Return keys for *name* in *scenario*."""
     from .operator import data_for_quantity
 
@@ -36,7 +44,7 @@ def keys_for_quantity(ix_type, name, scenario):
     dims = dims_for_qty(scenario.idx_names(name))
 
     # Column for retrieving data
-    column = "value" if ix_type == "par" else "lvl"
+    column: Literal["mrg", "lvl", "value"] = "value" if ix_type == "par" else "lvl"
 
     # A computation to retrieve the data
     result = [
@@ -63,11 +71,11 @@ def keys_for_quantity(ix_type, name, scenario):
 
 
 @lru_cache(1)
-def get_reversed_rename_dims():
+def get_reversed_rename_dims() -> dict[str, str]:
     return {v: k for k, v in common.RENAME_DIMS.items()}
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> dict[str, str]:
     if name == "RENAME_DIMS":
         return common.RENAME_DIMS
     else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,7 @@ docs = [
 ]
 # Change ixmp4 to new release after https://github.com/iiasa/ixmp4/pull/164 is merged
 ixmp4 = [
-  "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/make-equation-indexsets-optional", 
+  "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/remove-linked-items-when-removing-indexset-items", 
   "gamsapi[core,transfer] >= 45.7.0",
 ]
 report = ["genno[compat,graphviz]"]


### PR DESCRIPTION
This PR adds the remaining changes required to run the whole Westeros Baseline tutorial from message_ix on an `IXMP4Backend`.

Switching to a persistent local ixmp4 DB might require the `alembic.ini` file from ixmp4 to be present at a specific location (I've reached out to @meksor and @danielhuppmann to inquire if that's on purpose). The easiest option to achieve that right now seems to be:

1. `git clone` ixmp4
2. Set up a venv (preferably using poetry) and install ixmp4 there
3. Activate the venv and `ixmp4 platforms add ixmp4-local`

This should register the DB correctly and run all migrations so that it's up-to-date.

A persistent DB is needed because otherwise, the follow-up tutorials will start from an empty in-memory DB again, i.e. not seeing the solved baseline scenario, which is always used as the basis to make a clone from.

## How to review

- Read the diff.
- Run a westeros baseline tutorial in message_ix based on this branch and see that it works :)

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.
