### PR TITLE
Adjust dependency on ixmp4

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -92,8 +92,13 @@ jobs:
       shell: bash
 
     - name: Install the package and dependencies
-      # [docs] requires [tests] which requires [report,tutorial]
-      run: uv pip install .[docs]
+      # [docs] → [tests] → [report,tutorial]
+      # TODO Remove ixmp4 line once https://github.com/iiasa/ixmp4/pull/164 is merged
+      run: |
+        uv pip install \
+          "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/remove-linked-items-when-removing-indexset-items; python_version > '3.9'" \
+          .[docs]
+      shell: bash
 
     - name: "Install libpng-dev"  # for R 'png', required by reticulate
       if: startsWith(matrix.os, 'ubuntu-')
@@ -139,4 +144,4 @@ jobs:
     - run: |
         uvx --with=pre-commit-uv \
           pre-commit run \
-            --all-files --color=always --show-diff-on-failure --verbose
+          --all-files --color=always --show-diff-on-failure --verbose

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -4,7 +4,7 @@ Next release
 All changes
 -----------
 
-- Add :class:`.IXMP4Backend` as an alternative to :class:`.JDBCBackend` (:pull:`552`, :pull:`568`).
+- Add :class:`.IXMP4Backend` as an alternative to :class:`.JDBCBackend` (:pull:`552`, :pull:`568`. :pull:`570`).
   Please note:
 
   - This requires ixmp4, which is only compatible with Python 3.10 and above.

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -35,7 +35,7 @@ class Platform:
     ----------
     name : str
         Name of a specific :ref:`configured <configuration>` backend.
-    backend : 'jdbc'
+    backend
         Storage backend type. 'jdbc' corresponds to the built-in :class:`.JDBCBackend`;
         see :func:`.get_backend`.
     backend_args
@@ -65,7 +65,7 @@ class Platform:
     def __init__(
         self,
         name: Optional[str] = None,
-        backend: Optional[Literal["ixmp4", "jdbc"]] = None,
+        backend: Union[Literal["ixmp4", "jdbc"], str, None] = None,
         **backend_args,
     ):
         from ixmp.backend import get_class

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -28,7 +28,7 @@ class TestPlatform:
             ValueError, match=re.escape("backend class 'foo' not among")
         ):
             # Testing the wrong type on purpose
-            ixmp.Platform(backend="foo")  # type: ignore[arg-type]
+            ixmp.Platform(backend="foo")
 
         # name="default" is used, referring to "local"
         mp = ixmp.Platform()

--- a/ixmp/types.py
+++ b/ixmp/types.py
@@ -1,0 +1,13 @@
+"""Types for type hinting and checking of :mod:`ixmp` and downstream code."""
+
+from typing import NotRequired, TypedDict, Union
+
+
+class PlatformArgs(TypedDict, total=False):
+    """Arguments to :class:`.Platform`."""
+
+    name: NotRequired[Union[str, None]]
+    # NB The class itself has Literal["ixmp4", "jdbc"] first as an aid to completion in
+    #    IDE/interactive use, but for downstream code any str is valid, though may raise
+    #    in get_backend().
+    backend: NotRequired[Union[str, None]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -57,9 +57,8 @@ docs = [
   "sphinx_rtd_theme",
   "sphinxcontrib-bibtex",
 ]
-# Change ixmp4 to new release after https://github.com/iiasa/ixmp4/pull/164 is merged
 ixmp4 = [
-  "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/remove-linked-items-when-removing-indexset-items ; python_version > '3.9'",
+  "ixmp4; python_version > '3.9'",
   "gamsapi[core,transfer] >= 45.7.0",
 ]
 report = ["genno[compat,graphviz]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -84,8 +84,9 @@ exclude_also = [
   "if TYPE_CHECKING:",
 ]
 omit = [
-  "ixmp/util/sphinx_linkcode_github.py",
   ".venv/*",
+  "ixmp/types.py",
+  "ixmp/util/sphinx_linkcode_github.py",
 ]
 
 [tool.mypy]


### PR DESCRIPTION
This PR adjusts how the ixmp4 dependency is expressed and enacted. In particular:

- In pyproject.toml, the Git URL of a branch is not used; simply `ixmp4`.
  - The current form caused problems downstream; see [“Transitive URL dependencies”](https://docs.astral.sh/uv/pip/compatibility/#transitive-url-dependencies) in the uv docs, which says:
    > Note that PyPI does not allow published packages to depend on URL dependencies; other registries may be more permissive.
  - With the change on this branch, the dependency has the same form as it will in the next release.
- In pytest.yaml, the specific development branch containing the needed version of `ixmp4` is specified in the call to `uv pip install`.

This mirrors the pattern used in message_ix, message_ix_models, etc. where a development/pre-release version of an upstream dependency (e.g. ixmp) is not added to pyproject.toml directly.

Also:
- Add .types.PlatformArgs as a shorthand for downstream code that handles `dict()` eventually passed as keyword arguments to `ixmp.Platform()`.

## How to review

- Read the diff.
- Note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ Packaging changes only.
- [x] Update release notes.