### PR TITLE
Clone Scenario.scheme on all clone() calls

### DIFF
--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -349,6 +349,7 @@ class IXMP4Backend(CachingBackend):
             model,
             scenario,
             version=cloned_run.version,
+            scheme=s.scheme,
         )
         self._index_and_set_attrs(cloned_run, cloned_s)
         return cloned_s

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -144,6 +144,30 @@ class TestScenario:
         # Value is changed only in the clone
         assert scen2.scalar("f") == {"unit": "USD/km", "value": 95}
 
+    def test_clone_scheme(self, request, test_mp) -> None:
+        """:attr:`.Scenario.scheme` is preserved on clone."""
+        # Create a string to be used as scheme name
+        # NB this fails with JDBCBackend when using .nodeid directly, e.g.
+        #    "ixmp tests core test_scenario.py::TestScenario::test_clone_scheme[jdbc]".
+        #    This may indicate some (undocumented) restriction in values that this
+        #    back end can handle.
+        scheme = str(hash(request.node.nodeid))
+
+        s0 = ixmp.Scenario(
+            test_mp,
+            model="test_clone_scheme",
+            scenario="s",
+            version="new",
+            scheme=scheme,
+        )
+
+        s0.commit("")
+
+        s1 = s0.clone()
+
+        # Clone has same scheme as original scenario
+        assert s1.scheme == s0.scheme == scheme
+
     # Initialize items
     # NOTE IXMP4Backend doesn't handle commits yet
     @pytest.mark.jdbc


### PR DESCRIPTION
Some of the tests on https://github.com/iiasa/message_ix/pull/894 fail because the `.scheme` property of a Scenario is not cloned when calling `clone()` on an IXMP4Backend (and instead set to "IXMP4-MESSAGE"), which message_ix doesn't expect. It expects "MESSAGE", but we can't hardcode that either because some ixmp tests expect something else (and we generally want to avoid hardcoding things, of course). 

So this PR adjusts the `clone()` call on IXMP4Backend to also clone the `.scheme`. 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just a small internal fix.
- ~[ ] Update release notes.~ Just a small internal fix.
