### PR TITLE
Adjust to ixmp4 changelog and attribute name change

### DIFF
--- a/ixmp/backend/ixmp4_io.py
+++ b/ixmp/backend/ixmp4_io.py
@@ -35,7 +35,7 @@ def _domain(item: Item4) -> Optional[list[str]]:
     if isinstance(item, (IndexSet, Scalar)):
         return None
     else:
-        return item.indexsets
+        return item.indexset_names
 
 
 def _records(
@@ -107,7 +107,7 @@ def _align_records_and_domain(
     assert isinstance(item, (Table, Parameter, Variable, Equation))
 
     # `records` may contain keys that are column_names, but not indexsets
-    domain_order = item.column_names or item.indexsets
+    domain_order = item.column_names or item.indexset_names
 
     if not domain_order:
         # This could happen for Variables or Equations
@@ -311,7 +311,7 @@ def _set_columns_to_read_from_records(
     # Prepare columns to select from container.data
     # DF also includes lower, upper, scale
     columns = ["levels", "marginals"]
-    item_columns = item.column_names or item.indexsets
+    item_columns = item.column_names or item.indexset_names
     if item_columns:
         item_columns.extend(columns)
 
@@ -346,7 +346,7 @@ def _read_variables_to_run(
                 columns_of_interest + ["lower", "upper", "scale"]
             )
             run.backend.optimization.variables.add_data(
-                variable_id=variable.id, data=records[columns_of_interest]
+                id=variable.id, data=records[columns_of_interest]
             )
 
 
@@ -373,7 +373,7 @@ def _read_equations_to_run(
                 columns_of_interest + ["lower", "upper", "scale"]
             )
             run.backend.optimization.equations.add_data(
-                equation_id=equation.id, data=records[columns_of_interest]
+                id=equation.id, data=records[columns_of_interest]
             )
 
 


### PR DESCRIPTION
While I was working on getting the tutorials to run, @meksor implemented the changelog and versioning in ixmp4. This still has to be done for all optimization items, which I will do soon, but not before the 3.11 release. So there will be more adjustment which will likely introduce a proper `commit()` structure in the shim layer. 

For the time being, it's mainly iamc/timeseries data that is versioned. This seems to affect only one function here, `IXMP4Backend.set_data()`, but let's see what the message_ix test suite reveals, too, before merging this PR. 
For that function, I was wondering whether acquiring the lock (or calling `transact()` should not rather be part of the test functions calling this function, but the test functions only interact with `Scenario` objects, which are only under their hood mapped to `Run` objects. That's why I put the `run.transact()` inside `set_data()` for now, please let me know if that's correct.

In addition, the ixmp4 API changed to more clearly reflect what type we're dealing with when looking at e.g. `Parameter.indexsets`: this return a `list[str]` and has thus changed to `Parameter.indexset_names` (in line with `Parameter.column_names`).

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just internal adaptation.
- ~[ ] Update release notes.~ Just internal adaptation.

