### PR TITLE
Adjust for message-ix test suite and tutorials

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,6 +5,9 @@ All changes
 -----------
 
 - Add :class:`.IXMP4Backend` as an alternative to :class:`.JDBCBackend` (:pull:`552`, :pull:`568`. :pull:`570`).
+
+  - Improve :program:`ixmp platform add` to support adding :class:`.Platform` with :class:`.IXMP4Backend` (:pull:`575`).
+
   Please note:
 
   - This requires ixmp4, which is only compatible with Python 3.10 and above.

--- a/ixmp/_config.py
+++ b/ixmp/_config.py
@@ -81,7 +81,9 @@ def _platform_default():
         },
         "ixmp4-local": {
             "class": "ixmp4",
-            "dsn": f"sqlite:///{ixmp4_databases.joinpath('ixmp4-local.sqlite3')}",
+            "dsn": f"sqlite:///{ixmp4_databases.joinpath('local.sqlite3')}",
+            "ixmp4_name": "local",
+            "jdbc_compat": True,
         },
     }
 

--- a/ixmp/backend/__init__.py
+++ b/ixmp/backend/__init__.py
@@ -23,9 +23,13 @@ def get_class(name: str) -> type["ixmp.backend.base.Backend"]:
     instance.
     """
     if name == "ixmp4":
+        from ixmp.util.ixmp4 import configure_logging_and_warnings
+
         from . import ixmp4
 
         BACKENDS[name] = ixmp4.IXMP4Backend
+
+        configure_logging_and_warnings()
     elif name == "jdbc":
         from . import jdbc
 

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -108,6 +108,12 @@ class Options:
                 "databases", f"{self.ixmp4_name}.sqlite3"
             )
             self.dsn = f"sqlite:///{path}"
+        # Handle str value, e.g. from the command line
+        if isinstance(self.jdbc_compat, str):
+            val = self.jdbc_compat.title()
+            self.jdbc_compat = bool(
+                {"0": False, "False": False, "No": False, "True": True}.get(val, val)
+            )
 
     @classmethod
     def handle_config(cls, args: Sequence, kwargs: MutableMapping) -> dict[str, Any]:
@@ -144,7 +150,7 @@ class Options:
             result = ixmp4.conf.settings.toml.get_platform(key=self.ixmp4_name)
         except AssertionError:  # pragma: no cover
             log.error(f"From ixmp4: {result}")
-            log.error(f"From ixmp: name = {self.ixmp4_name!r}, dsn = {self.dsn!r}")
+            log.error(f"From ixmp: name={self.ixmp4_name!r}, dsn={self.dsn!r}")
             raise
 
         return result

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -205,7 +205,7 @@ class IXMP4Backend(CachingBackend):
         self._platform = ixmp4_platform(_backend=self._backend)
 
         if opts.jdbc_compat:
-            for u in "???", "GWa", "USD/kWa", "cases", "kg", "km":
+            for u in "???", "GWa", "USD/km", "USD/kWa", "cases", "kg", "km":
                 try:
                     self.set_unit(u, "For compatibility with ixmp.JDBCBackend")
                 except NotUnique:

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -907,10 +907,10 @@ class IXMP4Backend(CachingBackend):
                 _align_dtypes_for_filters(filters=filters, data=data)
                 filters = _remove_empty_lists(filters=filters)
 
-                if bool(filters):
+                if filters:
                     data = data[
                         data.isin(values=filters)[filters.keys()].all(axis=1)
-                    ].reset_index()
+                    ].reset_index(drop=True)
 
             # Rename columns
             data.rename(columns=renames, inplace=True)

--- a/ixmp/testing/jupyter.py
+++ b/ixmp/testing/jupyter.py
@@ -127,6 +127,8 @@ def get_cell_output(nb, name_or_index, kind="data"):
         Kind of cell output to retrieve. For 'data', the data in format 'text/plain' is
         run through :func:`eval`. To retrieve an exception message, use 'evalue'.
     """
+    import numpy
+
     if isinstance(name_or_index, int):
         cell = nb.cells[name_or_index]
     else:
@@ -143,4 +145,5 @@ def get_cell_output(nb, name_or_index, kind="data"):
     except NameError:  # pragma: no cover
         raise ValueError(f"no cell named {name_or_index}")
     else:
-        return eval(result["text/plain"]) if kind == "data" else result
+        # NB eval(…, globals=…) as a keyword argument is only possible with Python ≥3.13
+        return eval(result["text/plain"], {"np": numpy}) if kind == "data" else result

--- a/ixmp/tests/backend/test_ixmp4.py
+++ b/ixmp/tests/backend/test_ixmp4.py
@@ -207,7 +207,7 @@ class TestIxmp4Functions:
             f"Discarding parent parameter {parent}; unused in ixmp4.",
             f"Discarding synonym parameter {synonym}; unused in ixmp4.",
             "IXMP4Backend.set_node() requires to specify 'hierarchy'! "
-            "Using 'None' as the meaningsless default.",
+            "Using 'None' as a (meaningless) default.",
         ]
         assert caplog.messages == expected
 

--- a/ixmp/tests/backend/test_ixmp4.py
+++ b/ixmp/tests/backend/test_ixmp4.py
@@ -330,3 +330,27 @@ class TestIxmp4Functions:
                 init_items=True,
                 filters={"scenario": scenario},
             )
+
+
+class TestOptions:
+    @pytest.mark.parametrize(
+        "exp, jdbc_compat_arg",
+        (
+            (False, "0"),
+            (False, "false"),
+            (False, "False"),
+            (False, "no"),
+            (False, "NO"),
+            (True, "1"),
+            (True, "FOO"),
+            (True, "true"),
+            (True, "True"),
+            (True, "yes"),
+            (True, "YES"),
+        ),
+    )
+    def test_init(self, exp: bool, jdbc_compat_arg) -> None:
+        from ixmp.backend.ixmp4 import Options
+
+        opts = Options(ixmp4_name="foo", jdbc_compat=jdbc_compat_arg)
+        assert exp is opts.jdbc_compat

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -304,13 +304,21 @@ class TestScenario:
         assert scen.idx_sets("d") == ["i", "j"]
         assert scen.idx_names("d") == ["i", "j"]
 
-    # FIXME IXMP4-backed par doesn't have 0 as a key; avoid this hardcoding
-    @pytest.mark.jdbc
-    def test_par(self, scen):
-        # Parameter data can be retrieved with filters
+    def test_par(self, scen: "ixmp.Scenario") -> None:
+        """Parameter data can be retrieved with filters."""
         df = scen.par("d", filters={"i": ["seattle"]})
+
+        # Data frame has the expected columns
+        assert ["i", "j", "value", "unit"] == list(df.columns)
+
+        # The expected number of values are retrieved
+        assert 3 == len(df)
+
         # Units are as expected
-        assert df.loc[0, "unit"] == "km"
+        # NB This test is insensitive to the contents of df.index since (as of #575) we
+        #    are not certain if a RangeIndex is promised for data frames returned by
+        #    Scenario.par()
+        assert "km" == df["unit"].iloc[0]
 
         with pytest.warns(DeprecationWarning, match="ignored kwargs"):
             scen.par("d", i=["seattle"])

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -1,6 +1,7 @@
 import re
 from pathlib import Path
 from shutil import copyfile
+from typing import TYPE_CHECKING
 
 import numpy.testing as npt
 import pandas as pd
@@ -9,6 +10,11 @@ from pandas.testing import assert_frame_equal
 
 import ixmp
 from ixmp.testing import assert_logs, make_dantzig, models
+
+if TYPE_CHECKING:
+    from pytest import FixtureRequest
+
+    from ixmp.core.platform import Platform
 
 
 # Fixtures
@@ -144,7 +150,7 @@ class TestScenario:
         # Value is changed only in the clone
         assert scen2.scalar("f") == {"unit": "USD/km", "value": 95}
 
-    def test_clone_scheme(self, request, test_mp) -> None:
+    def test_clone_scheme(self, request: "FixtureRequest", test_mp: "Platform") -> None:
         """:attr:`.Scenario.scheme` is preserved on clone."""
         # Create a string to be used as scheme name
         # NB this fails with JDBCBackend when using .nodeid directly, e.g.
@@ -153,15 +159,20 @@ class TestScenario:
         #    back end can handle.
         scheme = str(hash(request.node.nodeid))
 
-        s0 = ixmp.Scenario(
-            test_mp,
-            model="test_clone_scheme",
-            scenario="s",
-            version="new",
-            scheme=scheme,
-        )
-
+        m_s = dict(model="test_clone_scheme", scenario="s")
+        s0 = ixmp.Scenario(test_mp, **m_s, version="new", scheme=scheme)
         s0.commit("")
+
+        # FIXME The test fails on IXMP4Backend without this statement, but passes on
+        #       JDBCBackend. Adjust the behaviour of the former to match.
+        s0.set_as_default()
+
+        # Discard the reference to `s0` and load again as a new instance of Scenario
+        del s0
+        s0 = ixmp.Scenario(test_mp, **m_s)
+
+        # New instance has same scheme as the original instance
+        assert scheme == s0.scheme
 
         s1 = s0.clone()
 

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -7,6 +7,7 @@ from click.exceptions import BadParameter, UsageError
 from pandas.testing import assert_frame_equal
 
 import ixmp
+from ixmp.backend import available
 from ixmp.cli import VersionType
 from ixmp.testing import models, populate_test_platform
 
@@ -153,6 +154,11 @@ def test_platform(ixmp_cli, tmp_path):
     rel = "./foo"
     r = call("add", "p3", "jdbc", "hsqldb", rel)
     assert Path(rel).resolve() == ixmp.config.get_platform_info("p3")[1]["path"]
+
+    if "ixmp4" in available():
+        # IXMP4 platform can be added using keyword arguments
+        r = call("add", "p4", "ixmp4", "ixmp4_name=p4", "jdbc_compat=true")
+        assert r.exit_code == 0
 
     # Platform can be removed
     r = call("remove", "p3")

--- a/ixmp/tests/test_tutorials.py
+++ b/ixmp/tests/test_tutorials.py
@@ -5,6 +5,7 @@ import sys
 import numpy as np
 import pytest
 
+from ixmp.backend import available
 from ixmp.testing import get_cell_output, run_notebook
 
 group_base_name = platform.system() + platform.python_version()
@@ -29,9 +30,18 @@ def default_args():
 
 @FLAKY
 @pytest.mark.xdist_group(name=f"{group_base_name}-0")
-def test_py_transport(tutorial_path, tmp_path, tmp_env, default_args):
-    fname = tutorial_path / "transport" / "py_transport.ipynb"
-    nb, errors = run_notebook(fname, tmp_path, tmp_env, **default_args)
+@pytest.mark.parametrize("ixmp_backend", available())
+def test_py_transport(tmp_path, tmp_env, tutorial_path, default_args, ixmp_backend):
+    fname = tutorial_path.joinpath("transport", "py_transport.ipynb")
+
+    # Set the "default" platform to be either the platform named "local" or
+    # "ixmp4-local", according to the ixmp_backend parameter
+    p = {"jdbc": "local", "ixmp4": "ixmp4-local"}[ixmp_backend]
+
+    # Notebook runs without error
+    nb, errors = run_notebook(
+        fname, tmp_path, tmp_env, default_platform=p, **default_args
+    )
     assert errors == []
 
     # FIXME use get_cell_by_name instead of assuming cell count/order is fixed

--- a/ixmp/util/ixmp4.py
+++ b/ixmp/util/ixmp4.py
@@ -56,3 +56,41 @@ class ReadKwargs(TypedDict, total=False):
     comment: str
     equ_list: list[str]
     var_list: list[str]
+
+
+def configure_logging_and_warnings() -> None:
+    """Quiet verbose log and warning messages from :mod:`ixmp4`.
+
+    These include:
+
+    1. Log messages with level WARNING on logger ixmp4.data.db.base: “Dispatching a
+       versioned insert statement on an 'sqlite' backend. This might be very slow!”
+    2. :py:`PydanticDeprecatedSince211` (a subclass of :class:`DeprecationWarning`) in
+       :py:`ixmp4.db.filters`: “Accessing the 'model_fields' attribute on the instance
+       is deprecated.”
+    3. :class:`pandas.errors.SettingWithCopyWarning` in :py:`ixmp4.data.db.base` at
+       L589, L590, L621.
+    4. :class:`DeprecationWarning` for calling :meth:`datetime.datetime.now`.
+    """
+    import logging
+    import warnings
+
+    from pandas.errors import SettingWithCopyWarning
+
+    logging.getLogger("ixmp4.data.db.base").setLevel(logging.WARNING + 1)
+
+    warnings.filterwarnings(
+        "ignore",
+        ".*Accessing the 'model_fields' attribute on the instance.*",
+        DeprecationWarning,  # Actually pydantic.PydanticDeprecatedSince211
+        "ixmp4.db.filters",
+    )
+    warnings.filterwarnings(
+        "ignore",
+        ".*A value is trying to be set on a copy of a slice from a DataFrame.*",
+        SettingWithCopyWarning,
+        "ixmp4.data.db.base",
+    )
+    warnings.filterwarnings(
+        "ignore", "datetime.datetime.now", DeprecationWarning, "sqlalchemy.sql.schema"
+    )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -114,6 +114,14 @@ addopts = """
   -p no:faulthandler
   --benchmark-skip
   --cov=ixmp --cov-report="""
+# Parallel to .util.ixmp4.configure_logging_and_warnings(), prevent warnings
+# from appearing in the test output
+filterwarnings = [
+  "ignore:Accessing the 'model_fields' :DeprecationWarning:ixmp4.db.filters",
+  # NB The following don't work if a message regex is added
+  "ignore::pandas.errors.SettingWithCopyWarning:ixmp4.data.db.base",
+  "ignore::DeprecationWarning:sqlalchemy.sql.schema",
+]
 markers = [
   "rixmp: test of the ixmp R interface.",
   "performance: ixmp performance test.",


### PR DESCRIPTION
This PR includes a few small changes necessary for #894:

- With non-empty filters, IXMP4Backend.item_get_elements(…) returns a data frame with a column named "index". This becomes a dimension via .report.operator.data_for_quantity(), and prevents alignment in reporting calculations like:
  ```
  - 'out:nl-t-yv-ya-m-nd-c-l-h-hd':
    - mul
    - 'output:nl-t-yv-ya-m-nd-c-l-h-hd':
      - data_for_quantity('par', 'output', 'value', ...)
    - 'ACT:nl-t-yv-ya-m-h':
      …
  ```
  As a result the line `rep.get("plot activity")` errors.
- The default configuration of the platform named "ixmp4-local" needs the ixmp4_name parameter.
- [x] The line https://github.com/iiasa/ixmp/blob/cee9fe314b74f0344e0fb25309127c6ad72d7154/ixmp/backend/ixmp4.py#L330-L334 results in an AssertionError in `message_ix.Scenario.__init__()` during a clone operation: https://github.com/iiasa/message_ix/blob/3b896d3e40ed7a70f82b08c1bcb409b84e22d284/message_ix/core.py#L60
  This is resolved by storing the Scenario.scheme attribute in ixmp4.Run.meta.

Some other small improvements:
- The `ixmp platform add` CLI (thus also `message-ix platform add`) is updated to handle configuration for IXMP4Backend.

## How to review

- Read the diff.
- Note that the CI checks all pass.
- Confirm that #894 CI jobs pass when running against this branch.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.