### PR TITLE
Depend on released ixmp4 v0.10

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -57,9 +57,6 @@ jobs:
         fetch-depth: ${{ env.depth }}
         fetch-tags: true
 
-    - name: TEMPORARY Work around actions/checkout#2041
-      run: git fetch --tags
-
     - name: Set up uv, Python
       uses: astral-sh/setup-uv@v6
       with:

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -11,6 +11,10 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
 
+defaults:
+  run:
+    shell: bash
+
 env:
   depth: 100
 
@@ -89,12 +93,10 @@ jobs:
     - name: Set RETICULATE_PYTHON
       # Retrieve the Python executable set up above
       run: echo "RETICULATE_PYTHON=$(uv python find)" >> $GITHUB_ENV
-      shell: bash
 
     - name: Install the package and dependencies
       # [docs] → [tests] → [ixmp4,report,tutorial]
       run: uv pip install .[docs]
-      shell: bash
 
     - name: "Install libpng-dev"  # for R 'png', required by reticulate
       if: startsWith(matrix.os, 'ubuntu-')
@@ -118,7 +120,6 @@ jobs:
           --color=yes --durations=20 -rA --verbose \
           --cov-report=xml \
           --numprocesses=auto --dist=loadgroup
-      shell: bash
 
     - name: Upload test coverage to Codecov.io
       uses: codecov/codecov-action@v5

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -92,12 +92,8 @@ jobs:
       shell: bash
 
     - name: Install the package and dependencies
-      # [docs] → [tests] → [report,tutorial]
-      # TODO Remove ixmp4 line once https://github.com/iiasa/ixmp4/pull/164 is merged
-      run: |
-        uv pip install \
-          "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/remove-linked-items-when-removing-indexset-items; python_version > '3.9'" \
-          .[docs]
+      # [docs] → [tests] → [ixmp4,report,tutorial]
+      run: uv pip install .[docs]
       shell: bash
 
     - name: "Install libpng-dev"  # for R 'png', required by reticulate

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     additional_dependencies:
     - genno
     - GitPython
-    - "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/remove-linked-items-when-removing-indexset-items"
+    - "ixmp4 >= 0.10, < 0.11"
     - nbclient
     - pandas-stubs
     - pytest

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -5,13 +5,11 @@ All changes
 -----------
 
 - Add :class:`.IXMP4Backend` as an alternative to :class:`.JDBCBackend` (:pull:`552`, :pull:`568`. :pull:`570`).
+  Please read the usage notes at :mod:`.backend.ixmp4` and :class:`.IXMP4Backend`,
+  and the linked `support roadmap for ixmp4 <https://github.com/iiasa/message_ix/discussions/939>`_.
 
-  - Improve :program:`ixmp platform add` to support adding :class:`.Platform` with :class:`.IXMP4Backend` (:pull:`575`).
-
-  Please note:
-
-  - This requires ixmp4, which is only compatible with Python 3.10 and above.
-  - :class:`.IXMP4Backend` is still missing several features and documentation, which will be added in subsequent PRs.
+  - New optional dependencies set ``ixmp[ixmp4]`` including ixmp4 version 0.10 (:pull:`552`, :pull:`576`).
+  - Improve the :program:`ixmp platform add` :doc:`command <cli>` to support adding :class:`.Platform` with :class:`.IXMP4Backend` (:pull:`575`).
 
 - Refine the method of locating the GAMS :attr:`~.GAMSInfo.executable` (:pull:`564`, :issue:`456`, :issue:`523`, :issue:`563`).
 

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -12,7 +12,10 @@ BUILDDIR      = _build
 help:
 	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
 
-.PHONY: help Makefile
+clean-autosummary:
+	find . -name "$(BUILDDIR)" -prune -o -iname _autosummary -print0 | xargs -0 rm -rf
+
+.PHONY: help clean-autosummary Makefile
 
 # Catch-all target: route all unknown targets to Sphinx using the new
 # "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).

--- a/doc/api-backend.rst
+++ b/doc/api-backend.rst
@@ -1,11 +1,20 @@
 .. currentmodule:: ixmp.backend
 
 Storage back ends (:mod:`ixmp.backend`)
-=======================================
+***************************************
 
-:mod:`ixmp` includes :class:`ixmp.backend.jdbc.JDBCBackend`, which can store data in many types of relational database management systems (RDBMS) that have Java DataBase Connector (JDBC) interfaces—hence its name.
+:mod:`ixmp` includes two storage back ends:
 
-:mod:`ixmp` is extensible to support other methods of storing data: in non-JDBC RDBMS, non-relational databases, local files, memory, or other ways.
+- :class:`ixmp.backend.jdbc.JDBCBackend`,
+  which can store data in many types of relational database management systems (RDBMS)
+  that have Java DataBase Connector (JDBC) interfaces—hence its name.
+- :class:`ixmp.backend.ixmp4.IXMP4Backend`,
+  which uses the `ixmp4 <https://docs.ece.iiasa.ac.at/projects/ixmp4/>`_ package
+  and in turn its storage options,
+  including the SQLite and PostgreSQL RDBMS.
+
+:mod:`ixmp` is extensible to support other methods of storing data:
+in non-JDBC or -ixmp4 RDBMS, non-relational databases, local files, memory, or other ways.
 Developers wishing to add such capabilities may subclass :class:`ixmp.backend.base.Backend` and implement its methods.
 
 .. contents::
@@ -13,11 +22,15 @@ Developers wishing to add such capabilities may subclass :class:`ixmp.backend.ba
    :backlinks: none
 
 Provided backends
------------------
+=================
 
 .. autodata:: ixmp.backend.BACKENDS
 
+
 .. currentmodule:: ixmp.backend.jdbc
+
+JDBCBackend
+-----------
 
 .. autoclass:: ixmp.backend.jdbc.JDBCBackend
    :members: handle_config, read_file, write_file
@@ -63,28 +76,65 @@ Provided backends
 
 .. currentmodule:: ixmp.backend.ixmp4
 
-.. warning::
-   `ixmp4 <https://github.com/iiasa/ixmp4/>`_ only supports Python 3.10 and above. 
-   Please ensure you are using a sufficiently recent Python version if you want to use IXMP4Backend.
-   If you are restricted to Python 3.9 and below, please use JDBCBackend instead.
+IXMP4Backend
+------------
+
+.. note::
+   As of version 0.10, `ixmp4 <https://github.com/iiasa/ixmp4/>`_ supports only Python 3.10 and above.
+
+   - If you want to use IXMP4Backend,
+     please ensure you are using a sufficiently recent Python version.
+   - If you are restricted to Python 3.9 and below,
+     please use JDBCBackend instead.
+
+.. automodule:: ixmp.backend.ixmp4
+   :members:
+   :exclude-members: IXMP4Backend
 
 .. autoclass:: ixmp.backend.ixmp4.IXMP4Backend
 
+   .. note::
+      As of ixmp version 3.11,
+      IXMP4Backend has only *partial* support for the APIs of :class:`ixmp.Platform`,
+      :class:`ixmp.TimeSeries`, :class:`ixmp.Scenario`, and :py:`message_ix.Scenario`,
+      and may not be as performant as JDBCBackend.
+      See `Support roadmap for ixmp4 <https://github.com/iiasa/message_ix/discussions/939>`_
+      and `issues labeled 'backend.ixmp4' <https://github.com/iiasa/ixmp/labels/backend.ixmp4>`_
+      for details of future work to expand support and improve performance.
+
+      Because IXMP4Backend uses ixmp4 version 0.10 (that is, prior to a 1.0 'stable' release):
+
+      - The ixmp4 API is not yet finalized and may change at any time.
+      - Complete documentation of the ixmp4 API itself is not yet available.
+
+      Consequently you **may** but probably **should not** use it for 'production' scientific scenario work.
+
+   IXMP4Backend supports storage in local, SQLite databases.
 
 .. currentmodule:: ixmp.backend
 
 Backend API
------------
+===========
+
+.. autosummary::
+
+   available
+   get_class
+
+.. currentmodule:: ixmp.backend.common
+
+.. autosummary::
+
+   ItemType
+   FIELDS
+   IAMC_IDX
 
 .. currentmodule:: ixmp.backend.base
 
 .. autosummary::
 
-   ixmp.backend.base.Backend
-   ixmp.backend.base.CachingBackend
-   ixmp.backend.ItemType
-   ixmp.backend.FIELDS
-   ixmp.backend.IAMC_IDX
+   Backend
+   CachingBackend
 
 - :class:`ixmp.Platform` implements a *user-friendly* API for scientific programming.
   This means its methods can take many types of arguments, check, and transform them—in a way that provides modeler-users with easy, intuitive workflows.
@@ -208,9 +258,13 @@ Backend API
 
    Subclasses **must** call :meth:`cache`, :meth:`cache_get`, and :meth:`cache_invalidate` as appropriate to manage the cache; CachingBackend does not enforce any such logic.
 
-
 .. automodule:: ixmp.backend
-   :members: FIELDS, IAMC_IDX
+   :members:
+   :exclude-members: ItemType
+
+.. automodule:: ixmp.backend.common
+   :members:
+   :exclude-members: ItemType
 
 .. autoclass:: ixmp.backend.ItemType
    :members:

--- a/ixmp/backend/__init__.py
+++ b/ixmp/backend/__init__.py
@@ -9,6 +9,8 @@ if TYPE_CHECKING:
 
 __all__ = [
     "ItemType",
+    "available",
+    "get_class",
 ]
 
 #: Mapping from names to available backends. To register additional backends, add

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -96,8 +96,8 @@ class Options:
     #: certain units and regions that are automatically added to any
     #: :class:`.JDBCBackend`. These include:
     #:
-    #: - Units: "???", "GWa", "USD/kWa", "cases", "kg", "km". Of these, only "cases" and
-    #:   "km" are used by the :mod:`message_ix` tutorials.
+    #: - Units: "???", "GWa", "USD/km", "USD/kWa", "cases", "kg", "km". Of these, only
+    #:   "cases" and "km" are used by the :mod:`message_ix` tutorials.
     #: - Regions: "World", in hierarchy "common".
     jdbc_compat: bool = False
 

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -37,7 +37,7 @@ class Platform:
         Name of a specific :ref:`configured <configuration>` backend.
     backend
         Storage backend type. 'jdbc' corresponds to the built-in :class:`.JDBCBackend`;
-        see :func:`.get_backend`.
+        see :func:`~.backend.get_class`.
     backend_args
         Keyword arguments to specific to the `backend`. See :class:`.JDBCBackend`.
     """

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -88,11 +88,12 @@ __all__ = [
     "tmp_env",
 ]
 
+GHA = "GITHUB_ACTIONS" in os.environ
+
 # Provide a skip marker since ixmp4 is not published for Python 3.9
 min_ixmp4_version = pytest.mark.skipif(
     sys.version_info < (3, 10), reason="ixmp4 requires Python 3.10 or higher"
 )
-
 
 # Pytest hooks
 

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -12,7 +12,7 @@ from pytest import raises
 import ixmp
 import ixmp.backend.jdbc
 from ixmp.backend.jdbc import DRIVER_CLASS, java
-from ixmp.testing import DATA, add_random_model_data, bool_param_id, make_dantzig
+from ixmp.testing import DATA, GHA, add_random_model_data, bool_param_id, make_dantzig
 from ixmp.testing.resource import memory_usage
 
 log = logging.getLogger(__name__)
@@ -386,10 +386,7 @@ def test_verbose_exception(test_mp, exception_verbose_true):
 
 
 @pytest.mark.flaky(
-    reruns=5,
-    rerun_delay=2,
-    condition="GITHUB_ACTIONS" in os.environ and platform.system() == "Windows",
-    reason="Flaky; see iiasa/ixmp#543",
+    reruns=5, rerun_delay=2, condition=GHA, reason="Flaky; see iiasa/ixmp#543"
 )
 def test_del_ts(request):
     mp = ixmp.Platform(

--- a/ixmp/types.py
+++ b/ixmp/types.py
@@ -9,5 +9,5 @@ class PlatformArgs(TypedDict, total=False):
     name: NotRequired[Union[str, None]]
     # NB The class itself has Literal["ixmp4", "jdbc"] first as an aid to completion in
     #    IDE/interactive use, but for downstream code any str is valid, though may raise
-    #    in get_backend().
+    #    in get_class().
     backend: NotRequired[Union[str, None]]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,7 +58,7 @@ docs = [
   "sphinxcontrib-bibtex",
 ]
 ixmp4 = [
-  "ixmp4; python_version > '3.9'",
+  "ixmp4 >= 0.10, < 0.11; python_version > '3.9'",
   "gamsapi[core,transfer] >= 45.7.0",
 ]
 report = ["genno[compat,graphviz]"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,12 +10,12 @@ maintainers = [
   { name = "Paul Natsuo Kishimoto", email = "mail@paul.kishimoto.name" },
   { name = "Fridolin Glatter", email = "glatter@iiasa.ac.at" },
 ]
+license = "Apache-2.0"
 readme = "README.md"
 classifiers = [
   "Development Status :: 5 - Production/Stable",
   "Intended Audience :: Developers",
   "Intended Audience :: Science/Research",
-  "License :: OSI Approved :: Apache Software License",
   "Natural Language :: English",
   "Operating System :: OS Independent",
   "Programming Language :: Python",
@@ -43,9 +43,11 @@ dependencies = [
 ]
 
 [project.urls]
-homepage = "https://github.com/iiasa/ixmp"
-repository = "https://github.com/iiasa/ixmp"
-documentation = "https://docs.messageix.org/ixmp"
+Documentation = "https://docs.messageix.org/ixmp"
+"Release notes" = "https://docs.messageix.org/projects/ixmp/en/stable/whatsnew.html"
+Repository = "https://github.com/iiasa/ixmp"
+"Issue tracker" = "https://github.com/iiasa/ixmp/issues"
+
 
 [project.optional-dependencies]
 docs = [


### PR DESCRIPTION
- Remove temporary code to use the branch from iiasa/ixmp4#171 prior to its merge.
- Set `ixmp4 >= 0.10, < 0.11`:
  - Per [SemVer item 4](https://semver.org/#spec-item-4), the 0.x release is not intended to have a stable API, it
  - Keeping to 0.10.x with only bug fixes allows the `ixmp4` CI to be stable and useful.
  - The range can be moved (`ixmp4 >= 0.11, < 0.12`) or widened (`ixmp4 >= 0.10, < 0.12`) in future PRs that also make any necessary adjustments to the shim layer.
  - Once ixmp4 1.0 released, the next following version of ixmp can depend on `ixmp4 >= 1` or possibly `ixmp4 >= 1, < 2`. (A major version bump from 1 → 2 would indicate breaking changes *somewhere*, but not necessarily in the model-related features used by message_ix through the shim. So it's possible that there could be no breakage in the shim or message_ix, such that e.g. ixmp4 2.0 released *after* ixmp 3.x depending on `ixmp4 >= 1` would be a working combination. To be seen!)

Other small/housekeeping changes including:
- Adjust project metadata per https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license and https://docs.pypi.org/project_metadata/

## How to review

- Read the diff.
- Note that the CI checks all pass.
- View the preview build of the docs and ensure that the following are clear:
  - [What's new](https://iiasa-energy-program-message-ix--576.com.readthedocs.build/projects/ixmp/en/576/whatsnew.html)
  - ['IXMP4Backend' section on the 'Storage back ends' page](https://iiasa-energy-program-message-ix--576.com.readthedocs.build/projects/ixmp/en/576/api-backend.html#ixmp4backend), especially the two "(!) Note" admonition boxes.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.