### PR TITLE
Quiet ixmp4/pandera warnings

### DIFF
--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -1,8 +1,10 @@
-.. Next release
-.. ============
+Next release
+============
 
-.. All changes
-.. -----------
+All changes
+-----------
+
+- Quiet warnings occurring with ixmp4 v0.10.0 and pandera v0.24 (:pull:`579`).
 
 .. _v3.11.0:
 

--- a/ixmp/_config.py
+++ b/ixmp/_config.py
@@ -62,6 +62,10 @@ def _locate(filename=None):
 def _platform_default():
     """Default values for the `platform` setting on BaseValues."""
     try:
+        from ixmp.util.ixmp4 import configure_logging_and_warnings
+
+        configure_logging_and_warnings()
+
         import ixmp4.conf
 
         # Use configured ixmp4 storage directory

--- a/ixmp/backend/__init__.py
+++ b/ixmp/backend/__init__.py
@@ -27,11 +27,11 @@ def get_class(name: str) -> type["ixmp.backend.base.Backend"]:
     if name == "ixmp4":
         from ixmp.util.ixmp4 import configure_logging_and_warnings
 
+        configure_logging_and_warnings()
+
         from . import ixmp4
 
         BACKENDS[name] = ixmp4.IXMP4Backend
-
-        configure_logging_and_warnings()
     elif name == "jdbc":
         from . import jdbc
 

--- a/ixmp/util/__init__.py
+++ b/ixmp/util/__init__.py
@@ -587,7 +587,12 @@ def show_versions(file=sys.stdout, *, packages: Optional[Iterable[str]] = None) 
     SHOW_VERSION_PACKAGES
     """
     from importlib import import_module
-    from importlib.metadata import PackageNotFoundError, packages_distributions, version
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        from importlib.metadata import packages_distributions
+    except ImportError:  # Python 3.9
+        from importlib_metadata import packages_distributions  # type: ignore [no-redef]
     from subprocess import DEVNULL, check_output
 
     from xarray.util.print_versions import get_sys_info

--- a/ixmp/util/ixmp4.py
+++ b/ixmp/util/ixmp4.py
@@ -70,7 +70,8 @@ def configure_logging_and_warnings() -> None:
        is deprecated.”
     3. :class:`pandas.errors.SettingWithCopyWarning` in :py:`ixmp4.data.db.base` at
        L589, L590, L621.
-    4. :class:`DeprecationWarning` for calling :meth:`datetime.datetime.now`.
+    4. :class:`FutureWarning` for top-level imports from :py:`pandera`.
+    5. :class:`DeprecationWarning` for calling :meth:`datetime.datetime.now`.
     """
     import logging
     import warnings
@@ -90,6 +91,12 @@ def configure_logging_and_warnings() -> None:
         ".*A value is trying to be set on a copy of a slice from a DataFrame.*",
         SettingWithCopyWarning,
         "ixmp4.data.db.base",
+    )
+    warnings.filterwarnings(
+        "ignore",
+        r"Importing pandas-specific classes .* from the\s+top-level pandera module",
+        FutureWarning,
+        "pandera",
     )
     warnings.filterwarnings(
         "ignore", "datetime.datetime.now", DeprecationWarning, "sqlalchemy.sql.schema"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ requires-python = ">=3.9"
 dependencies = [
   "click",
   "genno >= 1.20",
+  "importlib_metadata; python_version < '3.10'",
   "JPype1 >= 1.2.1",
   "JPype1 <= 1.4.0; python_version < '3.11'",
   "openpyxl",


### PR DESCRIPTION
Importing `ixmp4.conf` and possibly other submodules prints warnings from pandera. These obscure the output from ixmp and message_ix command-line tools, and also appear when running Jupyter/IPython notebooks using either package. For example:
```
$ message-ix config show
/opt/anaconda3/envs/ixmp4_tutorial/lib/python3.13/site-packages/pandera/_pandas_deprecated.py:157: FutureWarning: Importing pandas-specific classes and functions from the
top-level pandera module will be **removed in a future version of pandera**.
If you're using pandera to validate pandas objects, we highly recommend updating
your import:

``
# old import
import pandera as pa

# new import
import pandera.pandas as pa
``

If you're using pandera to validate objects from other compatible libraries
like pyspark or polars, see the supported libraries section of the documentation
for more information on how to import pandera:

https://pandera.readthedocs.io/en/stable/supported_libraries.html

To disable this warning, set the environment variable:

``
export DISABLE_PANDERA_IMPORT_WARNING=True
``

  warnings.warn(_future_warning, FutureWarning)
Configuration path: /Users/username/.local/share/ixmp/config.json

{
  "platform": {
    "default": "ixmp4-local",
    "local": {
      "class": "jdbc",
      "driver": "hsqldb",
      "path": "/Users/username/.local/share/ixmp/localdb/default"
    },
    "ixmp4-local": {
      "class": "ixmp4",
      "dsn": "sqlite:////Users/username/.local/share/ixmp4/databases/local.sqlite3",
      "ixmp4_name": "local",
      "jdbc_compat": true
    }
  },
  "message_model_dir": "/opt/anaconda3/envs/ixmp4_tutorial/lib/python3.13/site-packages/message_ix/model",
  "message_solve_options": null
}
```

This appears to be new in [pandera 0.24 (2025-05-15)](https://github.com/unionai-oss/pandera/releases/tag/v0.24.0).

This PR expands `.util.ixmp4.configure_logging_and_warnings()` added in #575 to also ignore these warnings, and ensures the function is called earlier and in more places.

It also contains some minor modernization of the `show_versions()` function.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~
- [x] Update release notes.