### PR TITLE
Enable strict mypy settings

### DIFF
--- a/ixmp/__init__.py
+++ b/ixmp/__init__.py
@@ -1,11 +1,13 @@
 import logging
 import sys
 from importlib.metadata import PackageNotFoundError, version
+from typing import Any, Optional
 
 from ixmp._config import config
 from ixmp.backend.common import IAMC_IDX, ItemType
 from ixmp.core.platform import Platform
-from ixmp.core.scenario import Scenario, TimeSeries
+from ixmp.core.scenario import Scenario
+from ixmp.core.timeseries import TimeSeries
 from ixmp.model.base import ModelError
 from ixmp.report import Reporter
 from ixmp.util import DeprecatedPathFinder, show_versions
@@ -50,10 +52,11 @@ log.addHandler(handler)
 log.setLevel(logging.WARNING)
 
 
-def __getattr__(name):
+# TODO What's the proper type hint for a Module?
+def __getattr__(name: str) -> Optional[Any]:
     if name == "utils":
         # Import via the old name to trigger DeprecatedPathFinder
-        import ixmp.utils as util  # type: ignore [import-not-found]
+        import ixmp.utils as util
 
         return util
     else:

--- a/ixmp/backend/__init__.py
+++ b/ixmp/backend/__init__.py
@@ -1,11 +1,12 @@
 """Backend API."""
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Union
 
 from .common import ItemType
 
 if TYPE_CHECKING:
-    import ixmp.backend.base
+    from ixmp.backend.ixmp4 import IXMP4Backend
+    from ixmp.backend.jdbc import JDBCBackend
 
 __all__ = [
     "ItemType",
@@ -15,10 +16,10 @@ __all__ = [
 
 #: Mapping from names to available backends. To register additional backends, add
 #: entries to this dictionary.
-BACKENDS: dict[str, type["ixmp.backend.base.Backend"]] = {}
+BACKENDS: dict[str, Union[type["IXMP4Backend"], type["JDBCBackend"]]] = {}
 
 
-def get_class(name: str) -> type["ixmp.backend.base.Backend"]:
+def get_class(name: str) -> Union[type["IXMP4Backend"], type["JDBCBackend"]]:
     """Return a reference to a :class:`~.base.Backend` subclass.
 
     Note that unlike :func:`.model.get_class`, this function does not create a new

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -4,20 +4,45 @@ import os
 import platform
 import re
 from collections import ChainMap
-from collections.abc import Generator, Iterable, Mapping, Sequence
+from collections.abc import (
+    Callable,
+    Generator,
+    Iterable,
+    Mapping,
+    MutableMapping,
+    Sequence,
+)
 from contextlib import contextmanager
 from copy import copy
 from functools import lru_cache
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
-from typing import Optional, cast
+from typing import (
+    Any,
+    Literal,
+    Optional,
+    Union,
+    Unpack,
+    cast,
+    overload,
+    override,
+)
 from weakref import WeakKeyDictionary
 
 import jpype
 import numpy as np
 import pandas as pd
 
+from ixmp.core.platform import Platform
 from ixmp.core.scenario import Scenario
+from ixmp.core.timeseries import TimeSeries
+from ixmp.types import (
+    ItemTypeNames,
+    JDBCBackendInitKwargs,
+    ReadKwargs,
+    VersionType,
+    WriteKwargs,
+)
 from ixmp.util import as_str_list, filtered
 
 from .base import CachingBackend
@@ -76,13 +101,20 @@ DRIVER_CLASS = {
 }
 
 
-def _create_properties(driver=None, path=None, url=None, user=None, password=None):
+def _create_properties(
+    driver: Optional[str] = None,
+    path: Optional[Union[str, Path]] = None,
+    url: Optional[str] = None,
+    user: Optional[str] = None,
+    password: Optional[str] = None,
+) -> Any:
     """Create a database Properties from arguments."""
     properties = java.Properties()
 
     # Handle arguments
     try:
-        properties.setProperty("jdbc.driver", DRIVER_CLASS[driver])
+        # FIXME Improve handling of None driver value
+        properties.setProperty("jdbc.driver", DRIVER_CLASS[driver])  # type:ignore[index]
     except KeyError:
         raise ValueError(f"unrecognized/unsupported JDBC driver {repr(driver)}")
 
@@ -101,6 +133,8 @@ def _create_properties(driver=None, path=None, url=None, user=None, password=Non
             else:
                 raise ValueError(url)
         else:
+            # path can not also be None due to the check above, convince type checker
+            assert path is not None
             # Convert Windows paths to use forward slashes per HyperSQL JDBC URL spec
             url_path = str(PurePosixPath(Path(path).resolve())).replace("\\", "")
             full_url = f"jdbc:hsqldb:file:{url_path}"
@@ -114,7 +148,7 @@ def _create_properties(driver=None, path=None, url=None, user=None, password=Non
     return properties
 
 
-def _read_properties(file):
+def _read_properties(file: Path) -> dict[str, str]:
     """Read database properties from *file*, returning :class:`dict`."""
     properties = dict()
     for line in file.read_text().split("\n"):
@@ -124,7 +158,7 @@ def _read_properties(file):
     return properties
 
 
-def _raise_jexception(exc, msg="unhandled Java exception: "):
+def _raise_jexception(exc: Any, msg: str = "unhandled Java exception: ") -> None:
     """Convert Java/JPype exceptions to ordinary Python RuntimeError."""
     # Try to re-raise as a ValueError for bad model or scenario name
     arg = exc.args[0] if isinstance(exc.args[0], str) else ""
@@ -143,7 +177,7 @@ def _raise_jexception(exc, msg="unhandled Java exception: "):
 
 
 @contextmanager
-def _handle_jexception():
+def _handle_jexception() -> Generator[None, Any, None]:
     """Context manager form of :func:`_raise_jexception`."""
     try:
         yield
@@ -164,34 +198,50 @@ def _fixed_index_sets(scheme: str) -> Mapping[str, list[str]]:
         return {}
 
 
-def _domain_enum(domain):
+def _domain_enum(domain: str) -> str:
     domain_enum = java.DocumentationKey.DocumentationDomain
     try:
-        return domain_enum.valueOf(domain.upper())
+        # NOTE in truth, _domain seems to only be a compatible Java type
+        _domain: str = domain_enum.valueOf(domain.upper())
+        return _domain
     except java.IllegalArgumentException:
         domains = ", ".join([d.name().lower() for d in domain_enum.values()])
         raise ValueError(f"No such domain: {domain}, existing domains: {domains}")
 
 
-def _unwrap(v):
+@overload
+def _unwrap(v: list[Union[bool, float, str]]) -> list[Union[bool, float, str]]: ...
+
+
+@overload
+def _unwrap(v: Union[bool, float, str]) -> Union[bool, float, str]: ...
+
+
+def _unwrap(v: Any) -> Union[bool, float, str, list[Union[bool, float, str]]]:
     """Unwrap meta numeric value or list of values (BigDecimal -> Double)."""
     if isinstance(v, java.BigDecimal):
-        return v.doubleValue()
+        _v: float = v.doubleValue()
+        return _v
     elif isinstance(v, java.ArrayList):
         return [_unwrap(elt) for elt in v]
     else:
-        return v
+        # NOTE In truth, this value might only be a compatible Java type
+        else_v: Union[bool, str] = v
+        return else_v
 
 
-def _wrap(value):
+def _wrap(value: Any) -> Union[bool, float, int, str, list[Union[bool, float, str]]]:
     if isinstance(value, (str, bool)):
         return value
     elif isinstance(value, (int, float)):
-        return java.BigDecimal(value)
+        # NOTE In truth, BigDecimal seems to return a Java type compatible with both
+        # float and int
+        _value: Union[float, int] = java.BigDecimal(value)
+        return _value
     elif isinstance(value, (Sequence, Iterable)):
         jlist = java.ArrayList()
         jlist.addAll([_wrap(elt) for elt in value])
-        return jlist
+        return cast(list[Union[bool, float, str]], jlist)
     else:
         raise ValueError(f"Cannot use value {value} as metadata")
 
@@ -240,36 +290,45 @@ class JDBCBackend(CachingBackend):
     #    - s_clone() is only supported when target_backend is JDBCBackend.
 
     #: Reference to the at.ac.iiasa.ixmp.Platform Java object.
-    jobj: jpype.JObject = None
+    jobj: jpype.JObject = None  # type: ignore[no-any-unimported]
 
     #: Mapping from ixmp.TimeSeries object to the underlying at.ac.iiasa.ixmp.Scenario
     #: object (or subclasses of either).
-    jindex: Mapping[object, jpype.JObject] = WeakKeyDictionary()
+    jindex: MutableMapping[Union[TimeSeries, Scenario], jpype.JObject] = (  # type: ignore[no-any-unimported]
+        WeakKeyDictionary()
+    )
 
-    def __init__(self, jvmargs=None, **kwargs):
-        properties = None
+    def __init__(
+        self,
+        jvmargs: Optional[Union[str, list[str]]] = None,
+        dbprops: Optional[os.PathLike[str]] = None,
+        cache: bool = True,
+        log_level: Optional[Union[int, str]] = None,
+        **kwargs: Unpack[JDBCBackendInitKwargs],
+    ) -> None:
+        properties: Optional[Any] = None
 
         # Handle arguments
-        if "dbprops" in kwargs:
+        if dbprops:
             # Use an existing file
-            dbprops = Path(kwargs.pop("dbprops"))
-            if dbprops.exists() and dbprops.is_file():
+            _dbprops = Path(dbprops)
+            if _dbprops.exists() and _dbprops.is_file():
                 # Existing properties file
-                properties = _read_properties(dbprops)
+                properties = _read_properties(_dbprops)
                 if "jdbc.url" not in properties:
                     raise ValueError("Config file contains no database URL")
             else:
-                raise FileNotFoundError(dbprops)
+                raise FileNotFoundError(_dbprops)
 
         start_jvm(jvmargs)
 
         # Invoke the parent constructor to initialize the cache
-        super().__init__(cache_enabled=kwargs.pop("cache", True))
+        super().__init__(cache_enabled=cache)
 
         # Extract a log_level keyword argument before _create_properties(). By default,
         # use the same level as the 'ixmp' logger, whatever that has been set to.
         ixmp_logger = logging.getLogger("ixmp")
-        log_level = kwargs.pop("log_level", ixmp_logger.getEffectiveLevel())
+        log_level = log_level or ixmp_logger.getEffectiveLevel()
 
         # Create a database properties object
         if properties:
@@ -284,6 +343,9 @@ class JDBCBackend(CachingBackend):
             except TypeError as e:
                 msg = e.args[0].replace("_create_properties", "JDBCBackend")
                 raise TypeError(msg)
+
+        # We seem to assume this
+        assert properties is not None
 
         log.info(
             "launching ixmp.Platform connected to {}".format(
@@ -306,7 +368,9 @@ class JDBCBackend(CachingBackend):
             jclass = e.__class__.__name__
             if jclass.endswith("HikariPool.PoolInitializationException"):
                 redacted = copy(kwargs)
-                redacted.update(user="(HIDDEN)", password="(HIDDEN)")
+                # See https://github.com/python/mypy/issues/6019 for why we need a dict
+                # here
+                redacted.update({"user": "(HIDDEN)", "password": "(HIDDEN)"})
                 msg = f"unable to connect to database:\n{repr(redacted)}"
             elif jclass.endswith("FlywayException"):
                 msg = "when initializing database:"
@@ -323,11 +387,11 @@ class JDBCBackend(CachingBackend):
         # Set the log level
         self.set_log_level(log_level)
 
-    def __del__(self):
+    def __del__(self) -> None:
         self.close_db()
 
     @classmethod
-    def gc(cls):
+    def gc(cls) -> None:
         """Collect garbage."""
         if _GC_AGGRESSIVE:
             # log.debug('Collect garbage')
@@ -341,7 +405,9 @@ class JDBCBackend(CachingBackend):
 
     # Platform methods
     @classmethod
-    def handle_config(cls, args, kwargs):
+    def handle_config(
+        cls, args: Sequence[Any], kwargs: dict[str, Any]
+    ) -> dict[str, Any]:
         """Handle platform/backend config arguments.
 
         `args` will overwrite any `kwargs`, and may be one of:
@@ -397,7 +463,7 @@ class JDBCBackend(CachingBackend):
 
         return info
 
-    def set_log_level(self, level):
+    def set_log_level(self, level: Union[int, str]) -> None:
         # Set the level of the 'ixmp.backend.jdbc' logger. Messages are handled by the
         # 'ixmp' logger; see ixmp/__init__.py.
         log.setLevel(level)
@@ -407,11 +473,13 @@ class JDBCBackend(CachingBackend):
             level = logging.getLevelName(level)
         self.jobj.setLogLevel(LOG_LEVELS[level])
 
-    def get_log_level(self):
+    def get_log_level(self) -> str:
         levels = {v: k for k, v in LOG_LEVELS.items()}
         return levels.get(self.jobj.getLogLevel(), "UNKNOWN")
 
-    def set_doc(self, domain, docs):
+    def set_doc(
+        self, domain: str, docs: Union[dict[str, str], Iterable[tuple[str, str]]]
+    ) -> None:
         dd = _domain_enum(domain)
         jdata = java.LinkedHashMap()
         if isinstance(docs, dict):
@@ -420,19 +488,23 @@ class JDBCBackend(CachingBackend):
             jdata.put(str(k), str(v))
         self.jobj.setDoc(dd, jdata)
 
-    def get_doc(self, domain, name=None):
+    def get_doc(
+        self, domain: str, name: Optional[str] = None
+    ) -> Union[str, dict[str, str]]:
         dd = _domain_enum(domain)
         if name is None:
             doc = self.jobj.getDoc(dd)
             return {entry.getKey(): entry.getValue() for entry in doc.entrySet()}
         else:
-            return self.jobj.getDoc(dd, str(name))
+            doc = self.jobj.getDoc(dd, str(name))
+            assert isinstance(doc, str)
+            return doc
 
-    def open_db(self):
+    def open_db(self) -> None:
         """(Re-)open the database connection."""
         self.jobj.openDB()
 
-    def close_db(self):
+    def close_db(self) -> None:
         """Close the database connection.
 
         A HyperSQL database can only be used by one :class:`Backend` instance at a time.
@@ -447,33 +519,43 @@ class JDBCBackend(CachingBackend):
             # - JVM has already shut down, e.g. on program exit
             pass
 
-    def get_auth(self, user, models, kind):
-        return self.jobj.checkModelAccess(user, kind, to_jlist(models))
+    def get_auth(self, user: str, models: Iterable[str], kind: str) -> dict[str, bool]:
+        model_access = self.jobj.checkModelAccess(user, kind, to_jlist(models))
+        # NOTE Can't isinstance()-check parametrized generic yet; java HasMap is
+        # returned in truth, but unusable as return type (becomes Any)
+        assert isinstance(model_access, Mapping)
+        return cast(dict[str, bool], model_access)
 
-    def set_node(self, name, parent=None, hierarchy=None, synonym=None):
+    def set_node(
+        self,
+        name: str,
+        parent: Optional[str] = None,
+        hierarchy: Optional[str] = None,
+        synonym: Optional[str] = None,
+    ) -> None:
         if parent and hierarchy and not synonym:
             self.jobj.addNode(name, parent, hierarchy)
         elif synonym and not (parent or hierarchy):
             self.jobj.addNodeSynonym(synonym, name)
 
-    def get_nodes(self):
+    def get_nodes(self) -> Generator[tuple[str, Optional[str], str, str]]:
         for r in self.jobj.listNodes("%"):
             n, p, h = r.getName(), r.getParent(), r.getHierarchy()
             yield (n, None, p, h)
             yield from [(s, n, p, h) for s in (r.getSynonyms() or [])]
 
-    def get_timeslices(self):
+    def get_timeslices(self) -> Generator[tuple[str, str, float], Any, None]:
         for r in self.jobj.getTimeslices():
             name, category, duration = (r.getName(), r.getCategory(), r.getDuration())
             yield name, category, duration
 
-    def set_timeslice(self, name, category, duration):
+    def set_timeslice(self, name: str, category: str, duration: float) -> None:
         self.jobj.addTimeslice(name, category, java.Double(duration))
 
-    def add_model_name(self, name):
+    def add_model_name(self, name: str) -> None:
         self.jobj.addModel(str(name))
 
-    def add_scenario_name(self, name):
+    def add_scenario_name(self, name: str) -> None:
         self.jobj.addScenario(str(name))
 
     def get_model_names(self) -> Generator[str, None, None]:
@@ -484,7 +566,9 @@ class JDBCBackend(CachingBackend):
         for scenario in self.jobj.listScenarios():
             yield str(scenario)
 
-    def get_scenarios(self, default, model, scenario):
+    def get_scenarios(
+        self, default: bool, model: Optional[str], scenario: Optional[str]
+    ) -> Generator[list[Union[bool, int, str]], Any, None]:
         # List<Map<String, Object>>
         with _handle_jexception():
             scenarios = self.jobj.getScenarioList(default, model, scenario)
@@ -495,7 +579,7 @@ class JDBCBackend(CachingBackend):
                 data.append(int(s[field]) if field == "version" else s[field])
             yield data
 
-    def set_unit(self, name, comment):
+    def set_unit(self, name: str, comment: str) -> None:
         try:
             self.jobj.addUnitToDB(name, comment)
         except Exception as e:  # pragma: no cover
@@ -505,10 +589,16 @@ class JDBCBackend(CachingBackend):
             else:
                 _raise_jexception(e)
 
-    def get_units(self):
+    def get_units(self) -> list[str]:
         return to_pylist(self.jobj.getUnitList())
 
-    def read_file(self, path, item_type: ItemType, **kwargs):
+    @override
+    def read_file(
+        self,
+        path: Path,  # type: ignore[override]
+        item_type: ItemType,
+        **kwargs: Unpack[ReadKwargs],
+    ) -> None:
         """Read Platform, TimeSeries, or Scenario data from file.
 
         JDBCBackend supports reading from:
@@ -573,7 +663,13 @@ class JDBCBackend(CachingBackend):
         else:
             raise NotImplementedError(path, item_type)
 
-    def write_file(self, path, item_type: ItemType, **kwargs):
+    @override
+    def write_file(
+        self,
+        path: os.PathLike[str],
+        item_type: ItemType,
+        **kwargs: Unpack[WriteKwargs],
+    ) -> None:
         """Write Platform, TimeSeries, or Scenario data to file.
 
         JDBCBackend supports writing to:
@@ -605,16 +701,18 @@ class JDBCBackend(CachingBackend):
         else:
             return
 
+        _path = Path(path)
+
         ts, filters = self._handle_rw_filters(kwargs.pop("filters", {}))
-        if path.suffix == ".gdx" and item_type is ItemType.SET | ItemType.PAR:
+        if _path.suffix == ".gdx" and item_type is ItemType.SET | ItemType.PAR:
             if len(filters) > 1:  # pragma: no cover
                 raise NotImplementedError("write to GDX with filters")
             elif not isinstance(ts, Scenario):  # pragma: no cover
                 raise ValueError("write to GDX requires a Scenario object")
 
             # include_var_equ=False -> do not include variables/equations in GDX
-            self.jindex[ts].toGDX(str(path.parent), path.name, False)
-        elif path.suffix == ".csv" and item_type is ItemType.TS:
+            self.jindex[ts].toGDX(str(_path.parent), _path.name, False)
+        elif _path.suffix == ".csv" and item_type is ItemType.TS:
             models = set(filters.pop("model"))
             # NOTE this is what we get for not differentiating e.g. scenario vs
             # scenarios in filters...
@@ -638,7 +736,7 @@ class JDBCBackend(CachingBackend):
                 to_jlist(variables),
                 to_jlist(units),
                 to_jlist(regions),
-                str(path),
+                str(_path),
                 export_all_runs,
             )
         else:
@@ -646,7 +744,7 @@ class JDBCBackend(CachingBackend):
 
     # Timeseries methods
 
-    def _index_and_set_attrs(self, jobj, ts):
+    def _index_and_set_attrs(self, jobj: jpype.JObject, ts: TimeSeries) -> None:  # type: ignore[no-any-unimported]
         """Add *jobj* to index and update attributes of *ts*.
 
         Helper for init and get.
@@ -673,7 +771,12 @@ class JDBCBackend(CachingBackend):
 
             ts.scheme = s
 
-    def _validate_meta_args(self, model, scenario, version):
+    def _validate_meta_args(
+        self,
+        model: Optional[str],
+        scenario: Optional[str],
+        version: Optional[Union[int, str]],
+    ) -> None:
         """Validate arguments for getting/setting/deleting meta"""
         valid = False
         if model and not scenario and version is None:
@@ -690,7 +793,7 @@ class JDBCBackend(CachingBackend):
                 "(model, scenario), (model, scenario, version)"
             )
 
-    def init(self, ts, annotation):
+    def init(self, ts: TimeSeries, annotation: str) -> None:
         klass = ts.__class__.__name__
 
         # Final arguments: scheme only for Scenarios
@@ -703,8 +806,8 @@ class JDBCBackend(CachingBackend):
 
         self._index_and_set_attrs(jobj, ts)
 
-    def get(self, ts):
-        args = [ts.model, ts.scenario]
+    def get(self, ts: TimeSeries) -> None:
+        args: list[Union[int, str]] = [ts.model, ts.scenario]
         if ts.version is not None:
             # Load a TimeSeries of specific version
             args.append(ts.version)
@@ -727,18 +830,18 @@ class JDBCBackend(CachingBackend):
 
         self._index_and_set_attrs(jobj, ts)
 
-    def del_ts(self, ts):
+    def del_ts(self, ts: TimeSeries) -> None:
         super().del_ts(ts)
 
         # Aggressively free memory
         self.gc()
         self.jindex.pop(ts, None)
 
-    def check_out(self, ts, timeseries_only):
+    def check_out(self, ts: TimeSeries, timeseries_only: bool) -> None:
         with _handle_jexception():
             self.jindex[ts].checkOut(timeseries_only)
 
-    def commit(self, ts, comment):
+    def commit(self, ts: TimeSeries, comment: str) -> None:
         try:
             self.jindex[ts].commit(comment)
         except java.Exception as e:
@@ -750,29 +853,38 @@ class JDBCBackend(CachingBackend):
         if ts.version == 0:
             ts.version = self.jindex[ts].getVersion()
 
-    def discard_changes(self, ts):
+    def discard_changes(self, ts: TimeSeries) -> None:
         self.jindex[ts].discardChanges()
 
-    def set_as_default(self, ts):
+    def set_as_default(self, ts: TimeSeries) -> None:
         self.jindex[ts].setAsDefaultVersion()
 
-    def is_default(self, ts):
+    def is_default(self, ts: TimeSeries) -> bool:
         return bool(self.jindex[ts].isDefault())
 
-    def last_update(self, ts):
+    def last_update(self, ts: TimeSeries) -> Optional[str]:
         timestamp = self.jindex[ts].getLastUpdateTimestamp()
         if timestamp is not None:
-            return timestamp.toString()
+            return cast(str, timestamp.toString())
         else:
             return timestamp  # None
 
-    def run_id(self, ts):
-        return self.jindex[ts].getRunId()
+    def run_id(self, ts: TimeSeries) -> int:
+        id = self.jindex[ts].getRunId()
+        assert isinstance(id, int)
+        return id
 
-    def preload(self, ts):
+    def preload(self, ts: TimeSeries) -> None:
         self.jindex[ts].preloadAllTimeseries()
 
-    def get_data(self, ts, region, variable, unit, year):
+    def get_data(
+        self,
+        ts: TimeSeries,
+        region: Sequence[str],
+        variable: Sequence[str],
+        unit: Sequence[str],
+        year: Union[Sequence[int], Sequence[str]],
+    ) -> Generator[tuple[str, str, str, int, float], Any, None]:
         # Convert the selectors to Java lists
         r = to_jlist(region)
         v = to_jlist(variable)
@@ -793,12 +905,14 @@ class JDBCBackend(CachingBackend):
                 for f in FIELDS["ts_get"]
             )
 
-    def get_geo(self, ts):
+    def get_geo(
+        self, ts: TimeSeries
+    ) -> Generator[tuple[str, str, int, str, str, str, bool], Any, None]:
         # NB the return type of getGeoData() requires more processing than
         #    getTimeseries. It also accepts no selectors.
 
         # Field types
-        ftype = {
+        ftype: dict[str, Callable[..., Any]] = {
             "meta": int,
             "year": lambda obj: obj,  # Pass through; handled later
         }
@@ -837,7 +951,16 @@ class JDBCBackend(CachingBackend):
                 # Construct a row with a single value
                 yield tuple(cm[f] for f in FIELDS["ts_get_geo"])
 
-    def set_data(self, ts, region, variable, data, unit, subannual, meta):
+    def set_data(
+        self,
+        ts: TimeSeries,
+        region: str,
+        variable: str,
+        data: dict[int, float],
+        unit: str,
+        subannual: str,
+        meta: bool,
+    ) -> None:
         # Oracle is unable to handle ±∞ (issue #442)
         if self._properties["jdbc.driver"] == DRIVER_CLASS["oracle"] and any(
             map(np.isinf, data.values())
@@ -862,16 +985,42 @@ class JDBCBackend(CachingBackend):
             else:
                 raise
 
-    def set_geo(self, ts, region, variable, subannual, year, value, unit, meta):
+    def set_geo(
+        self,
+        ts: TimeSeries,
+        region: str,
+        variable: str,
+        subannual: str,
+        year: int,
+        value: str,
+        unit: str,
+        meta: bool,
+    ) -> None:
         self.jindex[ts].addGeoData(
             region, variable, subannual, java.Integer(year), value, unit, meta
         )
 
-    def delete(self, ts, region, variable, subannual, years, unit):
+    def delete(
+        self,
+        ts: TimeSeries,
+        region: str,
+        variable: str,
+        subannual: str,
+        years: Iterable[int],
+        unit: str,
+    ) -> None:
         years = to_jlist(years, java.Integer)
         self.jindex[ts].removeTimeseries(region, variable, subannual, years, unit)
 
-    def delete_geo(self, ts, region, variable, subannual, years, unit):
+    def delete_geo(
+        self,
+        ts: TimeSeries,
+        region: str,
+        variable: str,
+        subannual: str,
+        years: Iterable[int],
+        unit: str,
+    ) -> None:
         years = to_jlist(years, java.Integer)
         self.jindex[ts].removeGeoData(region, variable, subannual, years, unit)
 
@@ -879,14 +1028,14 @@ class JDBCBackend(CachingBackend):
 
     def clone(
         self,
-        s,
-        platform_dest,
-        model,
-        scenario,
-        annotation,
-        keep_solution,
-        first_model_year=None,
-    ):
+        s: Scenario,
+        platform_dest: Platform,
+        model: str,
+        scenario: str,
+        annotation: Optional[str],
+        keep_solution: bool,
+        first_model_year: Optional[int] = None,
+    ) -> Scenario:
         # Raise exceptions for limitations of JDBCBackend
         if not isinstance(platform_dest._backend, self.__class__):
             raise NotImplementedError(  # pragma: no cover
@@ -917,13 +1066,22 @@ class JDBCBackend(CachingBackend):
             scheme=jclone.getScheme(),
         )
 
-    def has_solution(self, s):
-        return self.jindex[s].hasSolution()
+    def has_solution(self, s: Scenario) -> bool:
+        result = self.jindex[s].hasSolution()
+        assert isinstance(result, bool)
+        return result
 
-    def list_items(self, s, type):
+    def list_items(self, s: Scenario, type: ItemTypeNames) -> list[str]:
         return to_pylist(getattr(self.jindex[s], f"get{type.title()}List")())
 
-    def init_item(self, s, type, name, idx_sets, idx_names):
+    def init_item(
+        self,
+        s: Scenario,
+        type: ItemTypeNames,
+        name: str,
+        idx_sets: Sequence[str],
+        idx_names: Optional[Sequence[str]],
+    ) -> None:
         # Check `idx_sets` against values hard-coded in ixmp_source
         try:
             sets = _fixed_index_sets(s.scheme)[name]
@@ -940,8 +1098,8 @@ class JDBCBackend(CachingBackend):
                 )
 
         # Convert to Java data structures
-        idx_sets = to_jlist(idx_sets) if len(idx_sets) else None
-        idx_names = to_jlist(idx_names) if idx_names else idx_sets
+        java_idx_sets = to_jlist(idx_sets) if len(idx_sets) else None
+        java_idx_names = to_jlist(idx_names) if idx_names else java_idx_sets
 
         # Retrieve the method that initializes the Item, something like "initializePar"
         func = getattr(self.jindex[s], f"initialize{type.title()}")
@@ -949,14 +1107,16 @@ class JDBCBackend(CachingBackend):
         # The constructor returns a reference to the Java Item, but these aren't exposed
         # by Backend, so don't return here
         try:
-            func(name, idx_sets, idx_names)
+            func(name, java_idx_sets, java_idx_names)
         except java.Exception as e:
             if "already exists" in e.args[0]:
                 raise ValueError(f"{repr(name)} already exists")
             else:
                 _raise_jexception(e)
 
-    def delete_item(self, s, type, name):
+    def delete_item(
+        self, s: Scenario, type: Literal["set", "par", "equ"], name: str
+    ) -> None:
         try:
             getattr(self.jindex[s], f"remove{type.title()}")(name)
         except jpype.JException as e:
@@ -966,35 +1126,77 @@ class JDBCBackend(CachingBackend):
                 _raise_jexception(e)
         self.cache_invalidate(s, type, name)
 
-    def item_index(self, s, name, sets_or_names):
+    def item_index(
+        self, s: Scenario, name: str, sets_or_names: Literal["sets", "names"]
+    ) -> list[str]:
         jitem = self._get_item(s, "item", name, load=False)
         return list(getattr(jitem, f"getIdx{sets_or_names.title()}")())
 
+    @overload
+    def item_get_elements(
+        self,
+        s: Scenario,
+        ix_type: Literal["set"],
+        name: str,
+        filters: Optional[Mapping[str, Iterable[object]]] = None,
+    ) -> Union["pd.Series[Union[float, int, str]]", pd.DataFrame]: ...
+
+    @overload
+    def item_get_elements(
+        self,
+        s: Scenario,
+        ix_type: Literal["par"],
+        name: str,
+        filters: Optional[Mapping[str, Iterable[object]]] = None,
+    ) -> Union[dict[str, Union[float, str]], pd.DataFrame]: ...
+
+    @overload
+    def item_get_elements(
+        self,
+        s: Scenario,
+        ix_type: Literal["equ", "var"],
+        name: str,
+        filters: Optional[Mapping[str, Iterable[object]]] = None,
+    ) -> Union[dict[str, float], pd.DataFrame]: ...
+
     # FIXME reduce complexity 18 → ≤13
-    def item_get_elements(self, s, type, name, filters=None):  # noqa: C901
+    def item_get_elements(  # noqa: C901
+        self,
+        s: Scenario,
+        ix_type: ItemTypeNames,
+        name: str,
+        filters: Optional[Mapping[str, Iterable[object]]] = None,
+    ) -> Union[
+        dict[str, Union[float, str]],
+        dict[str, float],
+        "pd.Series[Union[float, int, str]]",
+        pd.DataFrame,
+    ]:
         if filters:
             # Convert filter elements to strings
             filters = {dim: as_str_list(ele) for dim, ele in filters.items()}
 
         try:
             # Retrieve the cached value with this exact set of filters
-            return self.cache_get(s, type, name, filters)
+            return self.cache_get(s, ix_type, name, filters)
         except KeyError:
             pass  # Cache miss
 
         try:
             # Retrieve a cached, unfiltered value of the same item
-            unfiltered = self.cache_get(s, type, name, None)
+            unfiltered = self.cache_get(s, ix_type, name, None)
         except KeyError:
             pass  # Cache miss
         else:
             # Success; filter and return
+            # We seem to rely on this
+            assert isinstance(unfiltered, pd.DataFrame)
             return filtered(unfiltered, filters)
 
         # Failed to load item from cache
 
         # Retrieve the item
-        item = self._get_item(s, type, name, load=True)
+        item = self._get_item(s, ix_type, name, load=True)
         idx_names = list(item.getIdxNames())
         idx_sets = list(item.getIdxSets())
 
@@ -1004,8 +1206,10 @@ class JDBCBackend(CachingBackend):
 
             for idx_name, values in filters.items():
                 # Retrieve the elements of the index set as a list
-                idx_set = idx_sets[idx_names.index(idx_name)]
-                elements = self.item_get_elements(s, "set", idx_set).tolist()
+                idx_set_name = idx_sets[idx_names.index(idx_name)]
+                idx_set = self.item_get_elements(s, "set", idx_set_name)
+                assert isinstance(idx_set, pd.Series)
+                elements = idx_set.tolist()
 
                 # Filter for only included values and store
                 filtered_elements = filter(lambda e: e in values, elements)
@@ -1015,12 +1219,19 @@ class JDBCBackend(CachingBackend):
         else:
             jList = item.getElements()
 
+        result: Union[
+            pd.DataFrame,
+            "pd.Series[Union[float, int, str]]",
+            dict[str, float],
+            dict[str, Union[float, str]],
+        ]
+
         if item.getDim() > 0:
             # Mapping set or multi-dimensional equation, parameter, or variable
             columns = copy(idx_names)
 
             # Prepare dtypes for index columns
-            dtypes = {}
+            dtypes: dict[str, Union[type[float], type[int], type[str]]] = {}
             for idx_name, idx_set in zip(columns, idx_sets):
                 # NB using categoricals could be more memory-efficient, but requires
                 #    adjustment of tests/documentation. See
@@ -1030,19 +1241,19 @@ class JDBCBackend(CachingBackend):
                 dtypes[idx_name] = str
 
             # Prepare dtypes for additional columns
-            if type == "par":
+            if ix_type == "par":
                 columns.extend(["value", "unit"])
                 dtypes.update(value=float, unit=str)
                 # Same as above
                 # dtypes['unit'] = CategoricalDtype(self.jobj.getUnitList())
-            elif type in ("equ", "var"):
+            elif ix_type in ("equ", "var"):
                 columns.extend(["lvl", "mrg"])
                 dtypes.update(lvl=float, mrg=float)
 
             # Copy vectors from Java into pd.Series to form DataFrame columns
             columns = []
 
-            def _get(method, name, *args):
+            def _get(method: str, name: str, *args: Any) -> None:
                 columns.append(
                     pd.Series(
                         # NB [:] causes JPype to use a faster code path
@@ -1057,25 +1268,29 @@ class JDBCBackend(CachingBackend):
                 _get("Col", idx_name, i)
 
             # Data columns
-            if type == "par":
+            if ix_type == "par":
                 _get("Values", "value")
                 _get("Units", "unit")
-            elif type in ("equ", "var"):
+            elif ix_type in ("equ", "var"):
                 _get("Levels", "lvl")
                 _get("Marginals", "mrg")
 
             result = pd.concat(columns, axis=1, copy=False)
-        elif type == "set":
+        elif ix_type == "set":
             # Index sets
             # dtype=object is to silence a warning in pandas 1.0
             result = pd.Series(item.getCol(0, jList)[:], dtype=object)
-        elif type == "par":
+        elif ix_type == "par":
             # Scalar parameter
-            result = dict(
-                value=float(item.getScalarValue().floatValue()),
-                unit=str(item.getScalarUnit()),
+            # NOTE Not sure why we have to tell mypy this cast
+            result = cast(
+                dict[str, Union[float, str]],
+                dict(
+                    value=float(item.getScalarValue().floatValue()),
+                    unit=str(item.getScalarUnit()),
+                ),
             )
-        elif type in ("equ", "var"):
+        elif ix_type in ("equ", "var"):
             # Scalar equation or variable
             result = dict(
                 lvl=float(item.getScalarLevel().floatValue()),
@@ -1083,11 +1298,17 @@ class JDBCBackend(CachingBackend):
             )
 
         # Store cache
-        self.cache(s, type, name, filters, result)
+        self.cache(s, ix_type, name, filters, result)
 
         return result
 
-    def item_set_elements(self, s, type, name, elements):
+    def item_set_elements(
+        self,
+        s: Scenario,
+        type: Literal["par", "set"],
+        name: str,
+        elements: Iterable[tuple[Any, Optional[float], Optional[str], Optional[str]]],
+    ) -> None:
         jobj = self._get_item(s, type, name)
 
         try:
@@ -1117,7 +1338,13 @@ class JDBCBackend(CachingBackend):
 
         self.cache_invalidate(s, type, name)
 
-    def item_delete_elements(self, s, type, name, keys):
+    def item_delete_elements(
+        self,
+        s: Scenario,
+        type: Literal["par", "set"],
+        name: str,
+        keys: Iterable[Iterable[str]],
+    ) -> None:
         jitem = self._get_item(s, type, name, load=False)
         for key in keys:
             jitem.removeElement(to_jlist(key))
@@ -1132,9 +1359,9 @@ class JDBCBackend(CachingBackend):
         self,
         model: Optional[str] = None,
         scenario: Optional[str] = None,
-        version: Optional[int] = None,
+        version: VersionType = None,
         strict: bool = False,
-    ) -> dict:
+    ) -> dict[str, Any]:
         self._validate_meta_args(model, scenario, version)
         if version is not None:
             version = java.Long(version)
@@ -1146,7 +1373,7 @@ class JDBCBackend(CachingBackend):
 
     def set_meta(
         self,
-        meta: dict,
+        meta: dict[str, Union[bool, float, int, str]],
         model: Optional[str] = None,
         scenario: Optional[str] = None,
         version: Optional[int] = None,
@@ -1164,17 +1391,17 @@ class JDBCBackend(CachingBackend):
 
     def remove_meta(
         self,
-        names,
+        names: list[str],
         model: Optional[str] = None,
         scenario: Optional[str] = None,
         version: Optional[int] = None,
-    ):
+    ) -> None:
         self._validate_meta_args(model, scenario, version)
         if version is not None:
             version = java.Long(version)
-        return self.jobj.removeMeta(model, scenario, version, to_jlist(names))
+        self.jobj.removeMeta(model, scenario, version, to_jlist(names))
 
-    def clear_solution(self, s, from_year=None):
+    def clear_solution(self, s: Scenario, from_year: Optional[int] = None) -> None:
         if from_year:
             if type(s) is not Scenario:
                 raise TypeError(
@@ -1189,18 +1416,31 @@ class JDBCBackend(CachingBackend):
 
     # MsgScenario methods
 
-    def cat_list(self, ms, name):
+    def cat_list(self, ms: Scenario, name: str) -> list[str]:
         return to_pylist(self.jindex[ms].getTypeList(name))
 
-    def cat_get_elements(self, ms, name, cat):
+    def cat_get_elements(self, ms: Scenario, name: str, cat: str) -> list[str]:
         return to_pylist(self.jindex[ms].getCatEle(name, cat))
 
-    def cat_set_elements(self, ms, name, cat, keys, is_unique):
+    def cat_set_elements(
+        self,
+        ms: Scenario,
+        name: str,
+        cat: str,
+        keys: Union[str, Sequence[str]],
+        is_unique: bool,
+    ) -> None:
         self.jindex[ms].addCatEle(name, cat, to_jlist(keys), is_unique)
 
     # Helpers; not part of the Backend interface
 
-    def _get_item(self, s, ix_type, name, load=True):
+    def _get_item(
+        self,
+        s: Scenario,
+        ix_type: Literal["set", "par", "equ", "var", "item"],
+        name: str,
+        load: bool = True,
+    ) -> Any:
         """Return the Java object for item `name` of `ix_type`.
 
         Parameters
@@ -1223,8 +1463,29 @@ class JDBCBackend(CachingBackend):
             else:  # pragma: no cover
                 _raise_jexception(e)
 
+    # Functions to override type hints of CachingBackend
 
-def start_jvm(jvmargs=None):
+    def cache_get(
+        self,
+        ts: TimeSeries,
+        ix_type: str,
+        name: str,
+        filters: Optional[Mapping[str, Iterable[Any]]],
+    ) -> Union[
+        dict[str, Union[float, str]], "pd.Series[Union[float, int, str]]", pd.DataFrame
+    ]:
+        # NOTE Based on how we use self.cache() above, cache will only have these values
+        return cast(
+            Union[
+                dict[str, Union[float, str]],
+                "pd.Series[Union[float, int, str]]",
+                pd.DataFrame,
+            ],
+            super().cache_get(ts, ix_type, name, filters),
+        )
+
+
+def start_jvm(jvmargs: Optional[Union[str, list[str]]] = None) -> None:
     """Start the Java Virtual Machine via JPype_.
 
     Parameters
@@ -1293,7 +1554,7 @@ def start_jvm(jvmargs=None):
 # Conversion methods
 
 
-def to_pylist(jlist) -> list:
+def to_pylist(jlist: Any) -> list[Any]:
     """Convert Java list types to :class:`list`."""
     try:
         return list(jlist[:])
@@ -1302,7 +1563,10 @@ def to_pylist(jlist) -> list:
         return list(jlist.toArray()[:])
 
 
-def to_jlist(arg, convert=None):
+def to_jlist(
+    arg: Union[str, Iterable[Union[float, int, str]]],
+    convert: Optional[Callable[..., Any]] = None,
+) -> Any:
     """Convert :class:`list` *arg* to java.LinkedList.
 
     Parameters

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -1,8 +1,13 @@
+from collections.abc import Iterable
 from pathlib import Path
+from re import Pattern
+from typing import Any, Literal, Optional, Union, overload
 
 import click
 
 import ixmp
+from ixmp.types import PlatformInitKwargs
+from ixmp.types import VersionType as VersionTypeAlias
 
 ScenarioClass: type[ixmp.Scenario] = ixmp.Scenario
 
@@ -12,10 +17,32 @@ class VersionType(click.ParamType):
 
     name = "version"  # https://github.com/pallets/click/issues/411
 
-    def convert(self, value, param, ctx):
-        """Fail if `value` is not :class:`int` or 'all'."""
+    @overload
+    def convert(
+        self,
+        value: int,
+        param: Optional[click.Parameter],
+        ctx: Optional[click.Context],
+    ) -> int: ...
+
+    @overload
+    def convert(
+        self,
+        value: str,
+        param: Optional[click.Parameter],
+        ctx: Optional[click.Context],
+    ) -> Union[int, Literal["new"]]: ...
+
+    def convert(
+        self,
+        value: Union[int, str],
+        param: Optional[click.Parameter],
+        ctx: Optional[click.Context],
+    ) -> Union[int, Literal["new"]]:
+        """Fail if `value` is not :class:`int` or 'new'."""
         if value == "new":
-            return value
+            # FIXME Not sure why mypy doesn't recognize this as Literal["new"]
+            return value  # type: ignore[return-value]
         elif isinstance(value, int):
             return value
         else:
@@ -39,7 +66,15 @@ class VersionType(click.ParamType):
 @click.option("--scenario", help="Scenario name.")
 @click.option("--version", type=VersionType(), help="Scenario version.")
 @click.pass_context
-def main(ctx, url, platform, dbprops, model, scenario, version):
+def main(
+    ctx: click.Context,
+    url: Optional[str],
+    platform: Optional[str],
+    dbprops: Optional[Path],
+    model: Optional[str],
+    scenario: Optional[str],
+    version: VersionTypeAlias,
+) -> None:
     ctx.obj = dict()
 
     # Load the indicated Platform
@@ -84,7 +119,9 @@ def main(ctx, url, platform, dbprops, model, scenario, version):
 @click.option("--config", help="Path to reporting configuration file.")
 @click.argument("key")
 @click.pass_obj
-def report(context, config, key):
+def report(
+    context: dict[str, Any], config: Optional[Union[str, Path]], key: Optional[str]
+) -> None:
     """Run reporting for KEY."""
     # Import here to avoid importing reporting dependencies when running other commands
     from ixmp import Reporter
@@ -101,11 +138,12 @@ def report(context, config, key):
     r.configure(config)
 
     # Print the target
-    print(r.get(key).to_series().sort_index())
+    # TODO Remove once genno adds annotation
+    print(r.get(key).to_series().sort_index())  # type: ignore[no-untyped-call]
 
 
 @main.command("show-versions")
-def show_versions_cmd():
+def show_versions_cmd() -> None:
     """Print versions of ixmp and its dependencies."""
     ixmp.show_versions()
 
@@ -118,7 +156,7 @@ def show_versions_cmd():
     help="Remove any existing model solution data.",
 )
 @click.pass_context
-def solve(context, remove_solution):
+def solve(context: click.Context, remove_solution: bool) -> None:
     """Solve a Scenario and store results on the Platform.
 
     The scenario indicated by --url or --platform/--model/--scenario/--version is
@@ -131,7 +169,7 @@ def solve(context, remove_solution):
 
     print("Load scenario")
 
-    scen = context.obj.get("scen")
+    scen: ixmp.Scenario = context.obj.get("scen")
 
     if scen is None:
         context.fail("not found")
@@ -151,20 +189,22 @@ def solve(context, remove_solution):
 
 
 @main.group("config")
-def config_group():
+def config_group() -> None:
     """Get and set configuration keys."""
 
 
 @config_group.command()
 @click.argument("key", metavar="KEY")
-def get(key):
+def get(key: str) -> None:
     """Get configuration KEY."""
     print(ixmp.config.get(key))
 
 
 @config_group.command()
-def show():
+def show() -> None:
     """Show all configuration."""
+    # NOTE We could avoid this by not setting None as default
+    assert ixmp.config.path
     print(
         f"Configuration path: {ixmp.config.path}",
         ixmp.config.path.read_text(),
@@ -175,7 +215,7 @@ def show():
 @config_group.command()
 @click.argument("key", metavar="KEY")
 @click.argument("value", nargs=-1)
-def set(key, value):
+def set(key: str, value: Any) -> None:
     """Set configuration KEY to VALUE."""
     try:
         ixmp.config.set(key, value[0])
@@ -192,7 +232,9 @@ def set(key, value):
 @click.argument("path", type=click.Path(writable=True))
 @click.argument("filter_args", metavar="[--] FILTERS", nargs=-1)
 @click.pass_obj
-def export(context, path, filter_args, max_row):
+def export(
+    context: dict[str, Any], path: Path, filter_args: Iterable[str], max_row: int
+) -> None:
     """Export scenario data to PATH.
 
     To export only part of the parameter data, e.g. for inspection, provide FILTERS in
@@ -219,7 +261,7 @@ def export(context, path, filter_args, max_row):
 
 @main.group("import")
 @click.pass_obj
-def import_group(context):
+def import_group(context: dict[str, Any]) -> None:
     """Import time series or scenario data.
 
     DATA is the path to a file containing input data in CSV (time series only) or Excel
@@ -236,7 +278,12 @@ def import_group(context):
 @click.option("--lastyear", type=int, help="Final year of data to include.")
 @click.argument("file", type=click.Path(exists=True, dir_okay=False))
 @click.pass_obj
-def import_timeseries(context, file, firstyear, lastyear):
+def import_timeseries(
+    context: dict[str, Any],
+    file: Path,
+    firstyear: Optional[int],
+    lastyear: Optional[int],
+) -> None:
     """Import time series data."""
     context["scen"].read_file(Path(file), firstyear, lastyear)
 
@@ -251,8 +298,13 @@ def import_timeseries(context, file, firstyear, lastyear):
 @click.argument("file", type=click.Path(exists=True, dir_okay=False))
 @click.pass_obj
 def import_scenario(
-    context, file, discard_solution, add_units, init_items, commit_steps
-):
+    context: dict[str, Any],
+    file: Path,
+    discard_solution: Optional[bool],
+    add_units: Optional[bool],
+    init_items: Optional[bool],
+    commit_steps: Optional[bool],
+) -> None:
     """Import scenario data."""
     scenario = context["scen"]
 
@@ -281,13 +333,13 @@ def import_scenario(
 
 
 @main.group("platform")
-def platform_group():
+def platform_group() -> None:
     """Configure platforms and storage backends."""
 
 
 @platform_group.command()
 @click.argument("name", metavar="PLATFORM")
-def remove(name):
+def remove(name: str) -> None:
     """Remove existing PLATFORM."""
     ixmp.config.remove_platform(name)
     print(f"Removed platform config for {repr(name)}")
@@ -296,7 +348,7 @@ def remove(name):
 @platform_group.command()
 @click.argument("platform_name", metavar="PLATFORM")
 @click.argument("args", nargs=-1)
-def add(platform_name, args):
+def add(platform_name: str, args: Union[str, Iterable[str]]) -> None:
     """Add PLATFORM, configured with ARGS.
 
     If PLATFORM is 'default', ARGS must be the name of another platform.
@@ -338,7 +390,7 @@ def add(platform_name, args):
 
 
 @platform_group.command("list")
-def list_platforms():
+def list_platforms() -> None:
     """List configured platforms."""
     for key, info in ixmp.config.values["platform"].items():
         print(f"{key}: {info}")
@@ -348,7 +400,7 @@ def list_platforms():
 @click.option("--go", is_flag=True, help="Actually manipulate files.")
 @click.argument("name_source", metavar="SRC")
 @click.argument("name_dest", metavar="DEST")
-def copy_platform(go, name_source, name_dest):
+def copy_platform(go: Optional[bool], name_source: str, name_dest: str) -> None:
     """Create the local JDBCBackend/HyperSQL platform DEST as a copy of SRC.
 
     Any existing data at DEST are overwritten. Without --go, no action occurs.
@@ -356,7 +408,7 @@ def copy_platform(go, name_source, name_dest):
     import shutil
     from copy import deepcopy
 
-    def _check(name):
+    def _check(name: str) -> PlatformInitKwargs:
         """Retrieve platform configuration and check."""
         _, cfg = ixmp.config.get_platform_info(name)
 
@@ -378,10 +430,17 @@ def copy_platform(go, name_source, name_dest):
     except ValueError:
         # Target platform does not exist; construct its configuration
         cfg_dest = deepcopy(cfg_source)
+        # NOTE We seem to rely on this
+        assert cfg_dest["path"]
         cfg_dest["path"] = Path(cfg_dest["path"]).parent.joinpath(name_dest)
         add_platform = True
 
     # Base paths for file operations
+    # NOTE We seem to rely on 'path' being not-None and populated. This seems to
+    # indicate the function is only supposed to handle local/hsqldb platforms, which is
+    # tricky to explain to mypy.
+    assert cfg_source["path"]
+    assert cfg_dest["path"]
     path_source = Path(cfg_source["path"])
     dir_dest = Path(cfg_dest["path"]).parent
 
@@ -421,7 +480,12 @@ def copy_platform(go, name_source, name_dest):
 )
 @click.option("--as-url", is_flag=True, help="Display outputs as ixmp URLs.")
 @click.pass_obj
-def list_scenarios(context, **kwargs):
+def list_scenarios(
+    context: dict[str, Any],
+    match: Optional[Pattern[str]],
+    default_only: bool,
+    as_url: bool,
+) -> None:
     """List scenarios on the --platform."""
     from ixmp.util import format_scenario_list
 
@@ -436,7 +500,9 @@ def list_scenarios(context, **kwargs):
                 platform=context["mp"],
                 model=context.get("model name", None),
                 scenario=context.get("scenario name", None),
-                **kwargs,
+                match=match,
+                default_only=default_only,
+                as_url=as_url,
             )
         )
     )

--- a/ixmp/core/platform.py
+++ b/ixmp/core/platform.py
@@ -1,18 +1,30 @@
 import logging
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from os import PathLike
-from typing import TYPE_CHECKING, Literal, Optional, Union
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Literal,
+    Optional,
+    Union,
+    Unpack,
+    cast,
+)
 
 import numpy as np
 import pandas as pd
 
 from ixmp._config import config
 from ixmp.backend.common import FIELDS, ItemType
+from ixmp.types import (
+    PlatformInitKwargs,
+    WriteFiltersKwargs,
+)
 from ixmp.util import as_str_list
-from ixmp.util.ixmp4 import WriteFiltersKwargs
 
 if TYPE_CHECKING:
-    from ixmp.backend.base import Backend
+    from ixmp.backend.ixmp4 import IXMP4Backend
+    from ixmp.backend.jdbc import JDBCBackend
 
 
 log = logging.getLogger(__name__)
@@ -43,7 +55,7 @@ class Platform:
     """
 
     # Storage back end for the platform
-    _backend: "Backend"
+    _backend: Union["JDBCBackend", "IXMP4Backend"]
 
     # List of method names which are handled directly by the backend
     _backend_direct = [
@@ -66,8 +78,8 @@ class Platform:
         self,
         name: Optional[str] = None,
         backend: Union[Literal["ixmp4", "jdbc"], str, None] = None,
-        **backend_args,
-    ):
+        **backend_args: Unpack[PlatformInitKwargs],
+    ) -> None:
         from ixmp.backend import get_class
 
         if name is None:
@@ -77,7 +89,7 @@ class Platform:
             elif backend is None:
                 # Only backend_args given
                 log.info("Using default JDBC backend")
-                kwargs = {"class": "jdbc"}
+                kwargs: PlatformInitKwargs = {"class": "jdbc"}
             else:
                 # Backend and maybe backend_args were given
                 kwargs = {"class": backend}
@@ -93,12 +105,17 @@ class Platform:
         backend_class = get_class(kwargs.pop("class"))
 
         # Instantiate the backend
-        self._backend = backend_class(**kwargs)
+        # FIXME We should clean up the use of one variable called 'kwargs' for various
+        # purposes. In this case, what ensures that if backend_class is an instance of
+        # JDBCBackend, kwargs is JDBCBackendInitKwargs (i.e. compatible with it)?
+        # And same for ixmp4. In the interest of time, I'm skipping this for now.
+        self._backend = backend_class(**kwargs)  # type: ignore[misc]
 
-    def __getattr__(self, name):
+    def __getattr__(self, name: str) -> Callable[..., Any]:
         """Convenience for methods of Backend."""
         if name in self._backend_direct:
-            return getattr(self._backend, name)
+            # All entries in that list are Callables
+            return cast(Callable[..., Any], getattr(self._backend, name))
         else:
             raise AttributeError(name)
 
@@ -186,13 +203,13 @@ class Platform:
 
     def export_timeseries_data(
         self,
-        path: PathLike,
+        path: PathLike[str],
         default: bool = True,
         model: Optional[str] = None,
         scenario: Optional[str] = None,
-        variable=None,
-        unit=None,
-        region=None,
+        variable: Optional[Union[str, list[str]]] = None,
+        unit: Optional[Union[str, list[str]]] = None,
+        region: Optional[Union[str, list[str]]] = None,
         export_all_runs: bool = False,
     ) -> None:
         """Export time series data to CSV file across multiple :class:`.TimeSeries`.
@@ -223,11 +240,11 @@ class Platform:
             Only return data for this model name.
         scenario: str, optional
             Only return data for this scenario name.
-        variable: list of str, optional
+        variable: str or list of str, optional
             Only return data for variable name(s) in this list.
-        unit: list of str, optional
+        unit: str or list of str, optional
             Only return data for unit name(s) in this list.
-        region: list of str, optional
+        region: str or list of str, optional
             Only return data for region(s) in this list.
         export_all_runs: bool, optional
             Export all existing model+scenario run combinations.
@@ -284,7 +301,7 @@ class Platform:
         """
         return pd.DataFrame(self._backend.get_nodes(), columns=FIELDS["get_nodes"])
 
-    def _existing_node(self, name):
+    def _existing_node(self, name: str) -> bool:
         """Check whether the node `name` has been defined.
 
         If :obj:`True`, log a warning and return True. Otherwise, return False.

--- a/ixmp/model/__init__.py
+++ b/ixmp/model/__init__.py
@@ -1,21 +1,26 @@
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING, Optional, Union, Unpack
 
 from .dantzig import DantzigModel
 from .gams import GAMSModel
 
 if TYPE_CHECKING:
-    import ixmp.model.base
+    from ixmp.types import GamsModelInitKwargs
+
 
 #: Mapping from names to available models. To register additional models, add elements
 #: to this variable.
-MODELS: dict[str, type["ixmp.model.base.Model"]] = {
+MODELS: dict[
+    str, Union[type[GAMSModel], type[DantzigModel]]
+] = {  # type["ixmp.model.base.Model"]
     "default": GAMSModel,
     "gams": GAMSModel,
     "dantzig": DantzigModel,
 }
 
 
-def get_model(name: Optional[str], **model_options) -> "ixmp.model.base.Model":
+def get_model(
+    name: Optional[str], **model_options: Unpack["GamsModelInitKwargs"]
+) -> Union[GAMSModel, DantzigModel]:
     """Return a model instance for `name` (or the default) with `model_options`.
 
     Note that unlike :func:`.backend.get_class`, this function creates a new instance.
@@ -32,5 +37,5 @@ def get_model(name: Optional[str], **model_options) -> "ixmp.model.base.Model":
         cls = MODELS[name]
     except (AssertionError, KeyError):
         cls = MODELS["default"]
-        model_options.setdefault("name", name)
+        model_options.setdefault("name_", name)
     return cls(**model_options)

--- a/ixmp/model/dantzig.py
+++ b/ixmp/model/dantzig.py
@@ -1,13 +1,19 @@
 from collections import ChainMap
 from pathlib import Path
+from typing import TYPE_CHECKING
 
 import pandas as pd
 
+from ixmp.types import InitializeItemsKwargs
 from ixmp.util import maybe_check_out, maybe_commit, update_par
 
 from .gams import GAMSModel
 
-ITEMS = {
+if TYPE_CHECKING:
+    from ixmp.core.scenario import Scenario
+
+
+ITEMS: dict[str, InitializeItemsKwargs] = {
     # Plants
     "i": dict(ix_type="set"),
     # Markets
@@ -28,9 +34,12 @@ ITEMS = {
     "supply": dict(ix_type="equ", idx_sets=["i"]),
 }
 
-DATA = {
+INDEXSET_DATA: dict[str, list[str]] = {
     "i": ["seattle", "san-diego"],
     "j": ["new-york", "chicago", "topeka"],
+}
+
+TABLE_DATA: dict[str, pd.DataFrame] = {
     "a": pd.DataFrame(
         [
             ["seattle", 350, "cases"],
@@ -57,8 +66,9 @@ DATA = {
         ],
         columns="i j value unit".split(),
     ),
-    "f": (90.0, "USD/km"),
 }
+
+SCALAR_DATA: dict[str, tuple[float, str]] = {"f": (90.0, "USD/km")}
 
 
 class DantzigModel(GAMSModel):
@@ -78,7 +88,7 @@ class DantzigModel(GAMSModel):
     )
 
     @classmethod
-    def initialize(cls, scenario, with_data=False):
+    def initialize(cls, scenario: "Scenario", with_data: bool = False) -> None:
         """Initialize the problem.
 
         If *with_data* is :obj:`True` (default: :obj:`False`), the set and parameter
@@ -94,15 +104,15 @@ class DantzigModel(GAMSModel):
         checkout = maybe_check_out(scenario)
 
         # Add set elements
-        scenario.add_set("i", DATA["i"])
-        scenario.add_set("j", DATA["j"])
+        scenario.add_set("i", INDEXSET_DATA["i"])
+        scenario.add_set("j", INDEXSET_DATA["j"])
 
         # Add parameter values
-        update_par(scenario, "a", DATA["a"])
-        update_par(scenario, "b", DATA["b"])
-        update_par(scenario, "d", DATA["d"])
+        update_par(scenario, "a", TABLE_DATA["a"])
+        update_par(scenario, "b", TABLE_DATA["b"])
+        update_par(scenario, "d", TABLE_DATA["d"])
 
         # TODO avoid overwriting the existing value
-        scenario.change_scalar("f", *DATA["f"])
+        scenario.change_scalar("f", *SCALAR_DATA["f"])
 
         maybe_commit(scenario, checkout, f"{cls.__name__}.initialize")

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -3,15 +3,16 @@ import os
 import re
 import shutil
 import tempfile
-from collections.abc import MutableMapping
+from collections.abc import MutableMapping, Sequence
 from copy import copy
 from pathlib import Path
 from subprocess import CalledProcessError, check_output, run
 from tempfile import TemporaryDirectory
-from typing import Any, Optional, Union
+from typing import Any, Optional, Union, Unpack
 
 from ixmp.backend.common import ItemType
 from ixmp.core.scenario import Scenario
+from ixmp.types import GamsModelInitKwargs, RunKwargs, WriteFiltersKwargs
 from ixmp.util import as_str_list
 from ixmp.util.ixmp4 import ContainerData
 
@@ -209,10 +210,10 @@ class GAMSModel(Model):
     """  # noqa: E501
 
     # Make attributes known to self
-    model_file: str
+    model_file: os.PathLike[str]
     case: str
-    in_file: os.PathLike
-    out_file: os.PathLike
+    in_file: os.PathLike[str]
+    out_file: os.PathLike[str]
     solve_args: list[str]
     gams_args: list[str]
     check_solution: bool
@@ -221,7 +222,7 @@ class GAMSModel(Model):
     var_list: Optional[list[str]]
     quiet: bool
     use_temp_dir: bool
-    record_version_packages: list[str]
+    record_version_packages: Sequence[str]
     container_data: list[ContainerData]
 
     #: Model name.
@@ -246,7 +247,8 @@ class GAMSModel(Model):
         "container_data": [],
     }
 
-    def __init__(self, name_=None, **model_options):
+    def __init__(self, **model_options: Unpack[GamsModelInitKwargs]) -> None:
+        name_ = model_options.get("name_", None)
         self.model_name = self.clean_path(name_ or self.name)
 
         # Store options from `model_options`, otherwise from `defaults`
@@ -291,11 +293,11 @@ class GAMSModel(Model):
 
         return ModelError("\n".join(msg))
 
-    def format_option(self, name):
+    def format_option(self, name: str) -> Any:
         """Retrieve the option `name` and format it."""
         return self.format(getattr(self, name))
 
-    def format(self, value):
+    def format(self, value: Any) -> Any:
         """Helper for recursive formatting of model options.
 
         `value` is formatted with replacements from the attributes of `self`.
@@ -306,7 +308,7 @@ class GAMSModel(Model):
             # Something like a Path; don't format it
             return value
 
-    def record_versions(self):
+    def record_versions(self) -> None:
         """Store Python package versions as set elements to be written to GDX.
 
         The values are stored in a 2-dimensional set named ``ixmp_version``, where the
@@ -337,7 +339,7 @@ class GAMSModel(Model):
                 # Add to the set
                 self.scenario.add_set(name, (package, package_version))
 
-    def remove_temp_dir(self, msg="after run()"):
+    def remove_temp_dir(self, msg: str = "after run()") -> None:
         """Remove the temporary directory, if any."""
         try:
             if self.use_temp_dir and self.cwd.exists():
@@ -348,7 +350,7 @@ class GAMSModel(Model):
             log.debug(f"Could not delete {repr(self.cwd)} {msg}")
             log.debug(str(e))
 
-    def __del__(self):
+    def __del__(self) -> None:
         # Try once more to remove the temporary directory.
         # This appears to still fail on Windows.
         self.remove_temp_dir("at GAMSModel teardown")
@@ -411,7 +413,7 @@ class GAMSModel(Model):
         delattr(self, "scenario")
 
         # Common argument for write_file and read_file
-        s_arg: dict[str, object] = dict(filters=dict(scenario=scenario))
+        s_arg = RunKwargs(filters=WriteFiltersKwargs(scenario=scenario))
 
         # Instruct ixmp4 to record package versions
         if backend_type == "ixmp4":
@@ -439,7 +441,7 @@ class GAMSModel(Model):
                 # Remove ixmp_version set entirely
                 with scenario.transact():
                     scenario.remove_set("ixmp_version")
-            else:  # backend_type == "ixmp4"
+            elif backend_type == "ixmp4":
                 # Clean up s_arg for use in read_file()
                 s_arg.pop("record_version_packages")
                 s_arg.pop("container_data")
@@ -448,10 +450,13 @@ class GAMSModel(Model):
             run(command, shell=os.name == "nt", cwd=self.cwd, check=True)
 
             # Read model solution
+            # NOTE We get this error because we use s_arg for both backends and write()
+            # and read(). We could avoid this with dedicated "s_arg"s; but for the
+            # offending keys are only added for ixmp4, which also always removes them
             scenario.platform._backend.read_file(
                 self.out_file,
                 ItemType.MODEL,
-                **s_arg,
+                **s_arg,  # type: ignore[misc]
                 check_solution=self.check_solution,
                 comment=self.comment or "",
                 equ_list=as_str_list(self.equ_list) or [],
@@ -480,6 +485,6 @@ def gams_info() -> GAMSInfo:
     return _GAMS_INFO
 
 
-def gams_version() -> Optional[str]:
+def gams_version() -> str:
     """Return :attr:`.GAMSInfo.version`."""
     return gams_info().version

--- a/ixmp/report/__init__.py
+++ b/ixmp/report/__init__.py
@@ -1,3 +1,5 @@
+from typing import Any, Optional
+
 import genno.config
 from genno import (
     ComputationError,
@@ -26,8 +28,9 @@ __all__ = [
 ]
 
 
-@genno.config.handles("filters", iterate=False)
-def filters(c: Computer, filters: dict):
+# TODO Remove once genno adds annotation
+@genno.config.handles("filters", iterate=False)  # type: ignore[misc]
+def filters(c: Computer, filters: dict[str, Any]) -> None:
     """Handle the entire ``filters:`` config section."""
     # Ensure a filters dict exists
     c.graph["config"].setdefault("filters", dict())
@@ -45,20 +48,20 @@ def filters(c: Computer, filters: dict):
             c.graph["config"]["filters"].pop(key, None)
 
 
-@genno.config.handles("rename_dims", iterate=False)
-def rename_dims(c: Computer, info: dict):
+@genno.config.handles("rename_dims", iterate=False)  # type: ignore[misc]
+def rename_dims(c: Computer, info: dict[str, str]) -> None:
     """Handle the entire ``rename_dims:`` config section."""
     common.RENAME_DIMS.update(info)
 
 
 # keep=True is different vs. genno.config
-@genno.config.handles("units", iterate=False, discard=False)
-def units(c: Computer, info: dict):
+@genno.config.handles("units", iterate=False, discard=False)  # type: ignore[misc]
+def units(c: Computer, info: dict[str, str]) -> None:
     """Handle the entire ``units:`` config section."""
     genno.config.units(c, info)
 
 
-def __getattr__(name: str):
+def __getattr__(name: str) -> Optional[dict[str, str]]:
     if name == "RENAME_DIMS":
         return common.RENAME_DIMS
     else:

--- a/ixmp/testing/data.py
+++ b/ixmp/testing/data.py
@@ -2,7 +2,7 @@
 import sys
 from itertools import product
 from math import ceil
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any, Optional, Union
 
 import genno
 import numpy as np
@@ -13,26 +13,14 @@ import pytest
 from ixmp import IAMC_IDX, Platform, Scenario, TimeSeries
 
 if TYPE_CHECKING:
-    from typing import TypedDict
+    from ixmp.types import ScenarioIdentifiers, ScenarioInfo
 
-    class ScenarioIdentifiers(TypedDict):
-        """Identifiers of a Scenario.
-
-        Used only for type checking in this file, so version is omitted.
-        """
-
-        model: str
-        scenario: str
-
-    class ScenarioKwargs(TypedDict, total=False):
+    class ScenarioKwargs(ScenarioInfo, total=False):
         """Keyword arguments to Scenario.__init__()."""
 
-        model: str
-        scenario: str
-        version: str
         scheme: str
         annotation: str
-        with_data: Optional[bool]
+        with_data: bool
 
 
 #: Common (model name, scenario name) pairs for testing.
@@ -134,7 +122,7 @@ DATA = {
 }
 
 
-def add_random_model_data(scenario, length):
+def add_random_model_data(scenario: Scenario, length: int) -> int:
     """Add a set and parameter with given *length* to *scenario*.
 
     The set is named 'random_set'. The parameter is named 'random_par', and has two
@@ -152,7 +140,9 @@ def add_random_model_data(scenario, length):
     return len(par_data)
 
 
-def add_test_data(scen: Scenario):
+def add_test_data(
+    scen: Scenario,
+) -> tuple[list[str], list[str], list[str], genno.Quantity]:
     """Populate `scen` with test data."""
     # New sets
     t_foo = ["foo{}".format(i) for i in (1, 2, 3)]
@@ -167,13 +157,14 @@ def add_test_data(scen: Scenario):
     scen.add_set("y", y)
 
     # Data
-    ureg = pint.get_application_registry()
+    ureg = pint.get_application_registry()  # type: ignore[no-untyped-call]
     x = genno.Quantity(
         np.random.rand(len(t), len(y)), coords={"t": t, "y": y}, units=ureg.kg
     )
 
     # As a pd.DataFrame with units
-    x_df = x.to_series().rename("value").reset_index()
+    # TODO Remove once genno adds annotation
+    x_df = x.to_series().rename("value").reset_index()  # type: ignore[no-untyped-call]
     x_df["unit"] = "kg"
 
     scen.init_par("x", ["t", "y"])
@@ -299,7 +290,7 @@ def populate_test_platform(platform: Platform) -> None:
     s4.set_as_default()
 
 
-def random_model_data(length):
+def random_model_data(length: int) -> tuple[list[str], pd.DataFrame]:
     """Random (set, parameter) data with at least *length* elements.
 
     See also
@@ -328,7 +319,7 @@ def random_model_data(length):
     return set_data, par_data
 
 
-def random_ts_data(length):
+def random_ts_data(length: Union[float, int]) -> pd.DataFrame:
     """A :class:`pandas.DataFrame` of time series data with `length` rows.
 
     Suitable for passage to :meth:`.TimeSeries.add_timeseries`.

--- a/ixmp/tests/backend/test_ixmp4.py
+++ b/ixmp/tests/backend/test_ixmp4.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Any, Literal, cast
+from typing import Any, Literal, Union, cast
 
 import pandas as pd
 import pytest
@@ -12,12 +12,12 @@ pytestmark = min_ixmp4_version
 
 
 def test__ensure_filters_values_are_lists() -> None:
-    from ixmp.backend.ixmp4 import _ensure_filters_values_are_lists
+    from ixmp.backend.ixmp4 import _convert_filters_values_to_lists
 
     filters = {"foo": [1, 2], "bar": 3}
     expected = {"foo": [1, 2], "bar": [3]}
-    _ensure_filters_values_are_lists(filters=filters)
-    assert filters == expected
+    clean_filters = _convert_filters_values_to_lists(filters=filters)
+    assert clean_filters == expected
 
 
 def test__align_dtypes_for_filters() -> None:
@@ -49,11 +49,11 @@ class TestIxmp4Functions:
     # that's also used by JDBC, and is always called for Backend.init() and
     # Backend.get(), so is tested already.
 
-    def test__ni(self, ixmp4_backend) -> None:
+    def test__ni(self, ixmp4_backend: Any) -> Any:
         with pytest.raises(NotImplementedError):
             ixmp4_backend._ni()
 
-    def test__get_repo(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test__get_repo(self, ixmp4_backend: Any, scenario: Scenario) -> None:
         from ixmp4.core.optimization.equation import EquationRepository
         from ixmp4.core.optimization.indexset import IndexSetRepository
         from ixmp4.core.optimization.parameter import ParameterRepository
@@ -75,7 +75,7 @@ class TestIxmp4Functions:
             repo = ixmp4_backend._get_repo(s=scenario, type=type)
             assert isinstance(repo, expected_repo)
 
-    def test__find_item(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test__find_item(self, ixmp4_backend: Any, scenario: Scenario) -> None:
         # Test unknown item name raises
         with pytest.raises(KeyError, match="No item called 'NotFound' found"):
             ixmp4_backend._find_item(s=scenario, name="NotFound")
@@ -89,7 +89,7 @@ class TestIxmp4Functions:
         )
         assert (_type, name) == (return_type, return_item.name)
 
-    def test__get_item(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test__get_item(self, ixmp4_backend: Any, scenario: Scenario) -> None:
         # Test getting an item
         name = "foo"
         _type: Literal["indexset"] = "indexset"
@@ -97,7 +97,9 @@ class TestIxmp4Functions:
         indexset = ixmp4_backend._get_item(s=scenario, name=name, type=_type)
         assert indexset.name == name
 
-    def test__get_indexset_or_table(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test__get_indexset_or_table(
+        self, ixmp4_backend: Any, scenario: Scenario
+    ) -> None:
         # Test getting an item of "unknown" type (either 'indexset' or 'table');
         # getting a Table first tests getting an IndexSet, too
         indexset_name = "foo"
@@ -107,7 +109,7 @@ class TestIxmp4Functions:
         table = ixmp4_backend._get_indexset_or_table(s=scenario, name=table_name)
         assert table.name == table_name
 
-    def test__add_data_to_set(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test__add_data_to_set(self, ixmp4_backend: Any, scenario: Scenario) -> None:
         # Test adding to an Indexset and warning about `comment`
         indexset_name = "Indexset"
         scenario.init_set(name=indexset_name)
@@ -129,7 +131,7 @@ class TestIxmp4Functions:
             pd.DataFrame({indexset_name: [key]}),
         )
 
-    def test__create_scalar(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test__create_scalar(self, ixmp4_backend: Any, scenario: Scenario) -> None:
         # Test creating a scalar with a comment
         name = "Scalar"
         value = 3.141592653589793238462643383279502884197169399375105820
@@ -142,7 +144,9 @@ class TestIxmp4Functions:
         assert scalar.value == value
         assert scalar.docs == comment
 
-    def test__add_data_to_parameter(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test__add_data_to_parameter(
+        self, ixmp4_backend: Any, scenario: Scenario
+    ) -> None:
         # Set up auxiliary items
         unit_name = "Unit"
         ixmp4_backend.set_unit(name=unit_name, comment="Create test unit")
@@ -166,7 +170,7 @@ class TestIxmp4Functions:
             "units": [unit_name],
         }
 
-    def test__get_set_data(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test__get_set_data(self, ixmp4_backend: Any, scenario: Scenario) -> None:
         indexset_name = "Indexset"
         scenario.init_set(name=indexset_name)
         table_name = "Table"
@@ -175,7 +179,11 @@ class TestIxmp4Functions:
         # Test getting empty data (other cases tested in integration tests)
         indexset_data = ixmp4_backend._get_set_data(s=scenario, name=indexset_name)
         # We can assume this return type for Indexsets
-        pd.testing.assert_series_equal(cast(pd.Series, indexset_data), pd.Series([]))
+        # TODO But we could first figure out if we're dealing with indexset or table and
+        # overload _get_set_data to eliminate the need for cast()
+        pd.testing.assert_series_equal(
+            cast("pd.Series[Union[float, int, str]]", indexset_data), pd.Series([])
+        )
         table_data = ixmp4_backend._get_set_data(s=scenario, name=table_name)
         # We can assume this return type for Tables
         pd.testing.assert_frame_equal(
@@ -183,7 +191,7 @@ class TestIxmp4Functions:
         )
 
     # Test some edge cases for standard functions
-    def test_handle_config(self, ixmp4_backend) -> None:
+    def test_handle_config(self, ixmp4_backend: Any) -> None:
         # Test raising for unhandled positional args
         with pytest.raises(ValueError, match="Unhandled positional args"):
             ixmp4_backend.handle_config(["test arg"], {"foo": "bar"})
@@ -192,7 +200,9 @@ class TestIxmp4Functions:
         with pytest.raises(ValueError, match="'ixmp4_name' keyword argument"):
             ixmp4_backend.handle_config([], {"foo": "bar"})
 
-    def test_set_node(self, ixmp4_backend, caplog: pytest.LogCaptureFixture) -> None:
+    def test_set_node(
+        self, ixmp4_backend: Any, caplog: pytest.LogCaptureFixture
+    ) -> None:
         from ixmp.backend.ixmp4 import log
 
         # Test logging warnings for unused/required parameters
@@ -212,7 +222,7 @@ class TestIxmp4Functions:
         assert caplog.messages == expected
 
     def test_clone(
-        self, ixmp4_backend, caplog: pytest.LogCaptureFixture, scenario: Scenario
+        self, ixmp4_backend: Any, caplog: pytest.LogCaptureFixture, scenario: Scenario
     ) -> None:
         from ixmp.backend.ixmp4 import log
 
@@ -234,7 +244,7 @@ class TestIxmp4Functions:
         assert expected in caplog.messages
 
     def test_clear_solution(
-        self, ixmp4_backend, caplog: pytest.LogCaptureFixture, scenario: Scenario
+        self, ixmp4_backend: Any, caplog: pytest.LogCaptureFixture, scenario: Scenario
     ) -> None:
         from ixmp.backend.ixmp4 import log
 
@@ -247,12 +257,12 @@ class TestIxmp4Functions:
         )
         assert expected in caplog.messages
 
-    def test_run_id(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test_run_id(self, ixmp4_backend: Any, scenario: Scenario) -> None:
         # NOTE Depending on what run_id() should actually fetch, this needs adapting
         # scenario sets up a new Run, which has version 1
         assert ixmp4_backend.run_id(ts=scenario) == 1
 
-    def test_item_delete_elements(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test_item_delete_elements(self, ixmp4_backend: Any, scenario: Scenario) -> None:
         # Prepare some data
         run = ixmp4_backend.index[scenario]
         indexset_data = "foo"
@@ -277,7 +287,7 @@ class TestIxmp4Functions:
         assert isinstance(new_data, pd.DataFrame)
         assert new_data.empty
 
-    def test_delete_item(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test_delete_item(self, ixmp4_backend: Any, scenario: Scenario) -> None:
         # Create a 'set' to delete
         run = ixmp4_backend.index[scenario]
         indexset = run.optimization.indexsets.create("Indexset")
@@ -286,7 +296,7 @@ class TestIxmp4Functions:
         # Test there are no 'sets' on scenario anymore
         assert ixmp4_backend.list_items(s=scenario, type="set") == []
 
-    def test_write_file(self, ixmp4_backend) -> None:
+    def test_write_file(self, ixmp4_backend: Any) -> None:
         # Test raising an error for unknown file extension
         with pytest.raises(NotImplementedError):
             ixmp4_backend.write_file(
@@ -299,7 +309,7 @@ class TestIxmp4Functions:
                 path=Path("none.gdx"), item_type=ItemType.EQU, filters={}
             )
 
-    def test_read_file(self, ixmp4_backend, scenario: Scenario) -> None:
+    def test_read_file(self, ixmp4_backend: Any, scenario: Scenario) -> None:
         # Test raising an error for unknown file extension
         with pytest.raises(NotImplementedError):
             ixmp4_backend.read_file(
@@ -349,7 +359,7 @@ class TestOptions:
             (True, "YES"),
         ),
     )
-    def test_init(self, exp: bool, jdbc_compat_arg) -> None:
+    def test_init(self, exp: bool, jdbc_compat_arg: str) -> None:
         from ixmp.backend.ixmp4 import Options
 
         opts = Options(ixmp4_name="foo", jdbc_compat=jdbc_compat_arg)

--- a/ixmp/tests/backend/test_ixmp4_io.py
+++ b/ixmp/tests/backend/test_ixmp4_io.py
@@ -1,5 +1,5 @@
 from pathlib import Path
-from typing import Literal, Union
+from typing import Any, Literal, Union
 
 import pandas as pd
 import pytest
@@ -11,15 +11,15 @@ from ixmp.util.ixmp4 import ContainerData
 pytestmark = min_ixmp4_version
 
 
-# NOTE No return type for Python 3.9 compliance
+# NOTE Generic return type for Python 3.9 compliance
 @pytest.fixture
-def container():
+def container() -> Any:
     from gams.transfer import Container
 
     return Container(system_directory=str(gams_info().system_dir))
 
 
-def test__record_versions(container) -> None:
+def test__record_versions(container: Any) -> None:
     from ixmp.backend.ixmp4_io import _record_versions
 
     # Test recording the package version of something that's always present
@@ -45,7 +45,7 @@ def test__record_versions(container) -> None:
     )
 
 
-def test__update_item_in_container(container) -> None:
+def test__update_item_in_container(container: Any) -> None:
     from ixmp.backend.ixmp4_io import _update_item_in_container
 
     item_list = [
@@ -63,7 +63,7 @@ def test__update_item_in_container(container) -> None:
     assert all(container.hasSymbols(symbols=[item.name for item in item_list]))
 
 
-def test__add_items_to_container(container) -> None:
+def test__add_items_to_container(container: Any) -> None:
     from ixmp.backend.ixmp4_io import _add_items_to_container
 
     # Test handling of empty list
@@ -103,7 +103,7 @@ def backend() -> Literal["ixmp4"]:
 class TestIxmp4IOFunctions:
     """Test group for all IO functions touching ixmp4 directly."""
 
-    def test__domain(self, run) -> None:
+    def test__domain(self, run: Any) -> None:
         from ixmp.backend.ixmp4_io import _domain
 
         indexset = run.optimization.indexsets.create("Indexset")
@@ -114,7 +114,7 @@ class TestIxmp4IOFunctions:
         assert _domain(indexset) is None
         assert _domain(table) == [indexset.name]
 
-    def test__records(self, run) -> None:
+    def test__records(self, run: Any) -> None:
         from ixmp.backend.ixmp4_io import _records
 
         run.backend.units.create("unit")
@@ -145,7 +145,7 @@ class TestIxmp4IOFunctions:
         expected.pop("units")
         assert _records(parameter) == expected
 
-    def test__ensure_correct_item_order(self, run) -> None:
+    def test__ensure_correct_item_order(self, run: Any) -> None:
         from ixmp.backend.ixmp4_io import _ensure_correct_item_order
 
         years = run.optimization.indexsets.create("years")
@@ -158,7 +158,7 @@ class TestIxmp4IOFunctions:
             repo=run.optimization.indexsets,
         ) == [years, nodes, type_years, type_nodes]
 
-    def test__align_records_and_domain(self, run) -> None:
+    def test__align_records_and_domain(self, run: Any) -> None:
         from ixmp.backend.ixmp4_io import _align_records_and_domain
 
         # Test item without domain order
@@ -187,7 +187,7 @@ class TestIxmp4IOFunctions:
 
         assert _align_records_and_domain(item=parameter, records=records) == expected
 
-    def test__convert_ixmp4_items_to_containerdata(self, run) -> None:
+    def test__convert_ixmp4_items_to_containerdata(self, run: Any) -> None:
         from ixmp.backend.ixmp4_io import _convert_ixmp4_items_to_containerdata
 
         # Test handling of empty list
@@ -213,7 +213,7 @@ class TestIxmp4IOFunctions:
         assert table.name == table_data.name
         assert table.data == table_data.records
 
-    def test_write_run_to_gdx(self, run, tmp_path: Path) -> None:
+    def test_write_run_to_gdx(self, run: Any, tmp_path: Path) -> None:
         from gams.transfer import Container
 
         from ixmp.backend.ixmp4_io import write_run_to_gdx
@@ -236,7 +236,7 @@ class TestIxmp4IOFunctions:
         assert len(container.data) == 1
         assert "ixmp_version" in container.data.keys()
 
-    def test__set_columns_to_read_from_records(self, run) -> None:
+    def test__set_columns_to_read_from_records(self, run: Any) -> None:
         from ixmp.backend.ixmp4_io import _set_columns_to_read_from_records
 
         default_columns = ["levels", "marginals"]
@@ -269,7 +269,7 @@ class TestIxmp4IOFunctions:
     # NOTE Keeping the read_equ()/read_var() tests separate because the read_*()
     # functions are separate
 
-    def test__read_variables_to_run(self, run, container) -> None:
+    def test__read_variables_to_run(self, run: Any, container: Any) -> None:
         from ixmp.backend.ixmp4_io import _read_variables_to_run
 
         indexset = run.optimization.indexsets.create("Indexset")
@@ -301,7 +301,7 @@ class TestIxmp4IOFunctions:
         )
         assert variable.data == expected
 
-    def test__read_equations_to_run(self, run, container) -> None:
+    def test__read_equations_to_run(self, run: Any, container: Any) -> None:
         from ixmp.backend.ixmp4_io import _read_equations_to_run
 
         indexset = run.optimization.indexsets.create("Indexset")
@@ -335,7 +335,7 @@ class TestIxmp4IOFunctions:
         )
         assert equation.data == expected
 
-    def test_read_gdx_to_run(self, run, tmp_path: Path) -> None:
+    def test_read_gdx_to_run(self, run: Any, tmp_path: Path) -> None:
         from ixmp.backend.ixmp4_io import read_gdx_to_run, write_run_to_gdx
 
         # NOTE Names without space to produce "valid GAMS names"

--- a/ixmp/tests/core/test_meta.py
+++ b/ixmp/tests/core/test_meta.py
@@ -3,7 +3,7 @@
 #      behaviour they actually test.
 
 import copy
-from typing import Any, Generator
+from typing import Any, Generator, Union
 
 import pytest
 
@@ -46,7 +46,11 @@ def mp(test_mp_f: ixmp.Platform) -> Generator[ixmp.Platform, Any, None]:
 @pytest.mark.jdbc
 class TestMeta:
     @pytest.mark.parametrize("meta", META_ENTRIES)
-    def test_set_meta_missing_argument(self, mp: ixmp.Platform, meta) -> None:
+    def test_set_meta_missing_argument(
+        self,
+        mp: ixmp.Platform,
+        meta: dict[str, Union[bool, int, str, list[Union[bool, float, int, str]]]],
+    ) -> None:
         with pytest.raises(ValueError):
             mp.set_meta(meta)
         with pytest.raises(ValueError):
@@ -55,14 +59,22 @@ class TestMeta:
             mp.set_meta(meta, scenario=DANTZIG["scenario"], version=0)
 
     @pytest.mark.parametrize("meta", META_ENTRIES)
-    def test_set_get_meta(self, mp: ixmp.Platform, meta) -> None:
+    def test_set_get_meta(
+        self,
+        mp: ixmp.Platform,
+        meta: dict[str, Union[bool, int, str, list[Union[bool, float, int, str]]]],
+    ) -> None:
         """Assert that storing+retrieving meta yields expected values."""
         mp.set_meta(meta, model=DANTZIG["model"])
         obs = mp.get_meta(model=DANTZIG["model"])
         assert obs == meta
 
     @pytest.mark.parametrize("meta", META_ENTRIES)
-    def test_unique_meta(self, mp: ixmp.Platform, meta) -> None:
+    def test_unique_meta(
+        self,
+        mp: ixmp.Platform,
+        meta: dict[str, Union[bool, int, str, list[Union[bool, float, int, str]]]],
+    ) -> None:
         """
         When setting a meta category on two distinct levels, a uniqueness error is
         expected.
@@ -91,14 +103,22 @@ class TestMeta:
             mp.set_meta(meta, **DANTZIG, version=scenario.version)
 
     @pytest.mark.parametrize("meta", META_ENTRIES)
-    def test_set_get_meta_equals(self, mp: ixmp.Platform, meta) -> None:
+    def test_set_get_meta_equals(
+        self,
+        mp: ixmp.Platform,
+        meta: dict[str, Union[bool, int, str, list[Union[bool, float, int, str]]]],
+    ) -> None:
         initial_meta = mp.get_meta(scenario=DANTZIG["scenario"])
         mp.set_meta(meta, model=DANTZIG["model"])
         obs_meta = mp.get_meta(scenario=DANTZIG["scenario"])
         assert obs_meta == initial_meta
 
     @pytest.mark.parametrize("meta", META_ENTRIES)
-    def test_unique_meta_model_scenario(self, mp: ixmp.Platform, meta) -> None:
+    def test_unique_meta_model_scenario(
+        self,
+        mp: ixmp.Platform,
+        meta: dict[str, Union[bool, int, str, list[Union[bool, float, int, str]]]],
+    ) -> None:
         """
         When setting a meta key for a Model, it shouldn't be possible to set it
         for a Model+Scenario then.
@@ -119,18 +139,22 @@ class TestMeta:
             mp.set_meta(meta, **dantzig2)
 
     @pytest.mark.parametrize("meta", META_ENTRIES)
-    def test_get_meta_strict(self, mp: ixmp.Platform, meta) -> None:
+    def test_get_meta_strict(
+        self,
+        mp: ixmp.Platform,
+        meta: dict[str, Union[bool, int, str, list[Union[bool, float, int, str]]]],
+    ) -> None:
         """
         Set meta indicators on several model/scenario/version levels and test
         the 'strict' parameter of get_meta().
         """
         # set meta on various levels
-        model_meta = {
+        model_meta: dict[str, Union[bool, int, str]] = {
             "model_int": 3,
             "model_string": "string_value",
             "model_bool": False,
         }
-        scenario_meta = {
+        scenario_meta: dict[str, Union[bool, int, str]] = {
             "scenario_int": 3,
             "scenario_string": "string_value",
             "scenario_bool": False,
@@ -219,7 +243,11 @@ class TestMeta:
         assert obs6_strict == meta_scen
 
     @pytest.mark.parametrize("meta", META_ENTRIES)
-    def test_unique_meta_scenario(self, mp: ixmp.Platform, meta) -> None:
+    def test_unique_meta_scenario(
+        self,
+        mp: ixmp.Platform,
+        meta: dict[str, Union[bool, int, str, list[Union[bool, float, int, str]]]],
+    ) -> None:
         """
         When setting a meta key on a specific Scenario run, setting the same key
         on an higher level (Model or Model+Scenario) should fail.

--- a/ixmp/tests/core/test_platform.py
+++ b/ixmp/tests/core/test_platform.py
@@ -5,7 +5,7 @@ import re
 from collections.abc import Generator
 from pathlib import Path
 from sys import getrefcount
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, Optional
 from weakref import getweakrefcount
 
 import pandas as pd
@@ -18,7 +18,7 @@ from ixmp.backend.common import FIELDS
 from ixmp.testing import DATA, assert_logs, min_ixmp4_version, models
 
 if TYPE_CHECKING:
-    pass
+    from ixmp.types import PlatformInitKwargs
 
 
 @pytest.mark.usefixtures("tmp_env")
@@ -45,7 +45,7 @@ class TestPlatform:
         ),
     )
     def test_init1(
-        self, _backend: Literal["jdbc", "ixmp4"], backend_args: dict[str, str]
+        self, _backend: Literal["jdbc", "ixmp4"], backend_args: "PlatformInitKwargs"
     ) -> None:
         # Platform can be instantiated
         ixmp.Platform(backend=_backend, **backend_args)
@@ -83,7 +83,9 @@ def log_level_mp(test_mp: ixmp.Platform) -> Generator[ixmp.Platform, Any, None]:
         ("FOO", ValueError),
     ],
 )
-def test_log_level(log_level_mp: ixmp.Platform, level: str, exc) -> None:
+def test_log_level(
+    log_level_mp: ixmp.Platform, level: str, exc: Optional[type[ValueError]]
+) -> None:
     """Log level can be set and retrieved."""
     if exc is None:
         log_level_mp.set_log_level(level)
@@ -260,7 +262,9 @@ def test_add_timeslice(test_mp: ixmp.Platform) -> None:
 
 # TODO Not yet implemented on IXMP4Backend
 @pytest.mark.jdbc
-def test_add_timeslice_duplicate(caplog, test_mp: ixmp.Platform) -> None:
+def test_add_timeslice_duplicate(
+    caplog: pytest.LogCaptureFixture, test_mp: ixmp.Platform
+) -> None:
     test_mp.add_timeslice("foo_slice", "foo_category", 0.2)
 
     # Adding same name with different duration raises an error

--- a/ixmp/tests/test_access.py
+++ b/ixmp/tests/test_access.py
@@ -1,13 +1,18 @@
 import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Union
 
 import pytest
 
 import ixmp
 from ixmp.testing import create_test_platform
 
+if TYPE_CHECKING:
+    from pytest_httpserver import HTTPServer
+
 
 @pytest.fixture
-def mock(httpserver):
+def mock(httpserver: "HTTPServer") -> "HTTPServer":
     """Mock server with responses for both tests."""
     from werkzeug import Request, Response
 
@@ -38,7 +43,12 @@ def mock(httpserver):
 
 
 @pytest.fixture
-def test_props(mock, request, tmp_path, test_data_path):
+def test_props(
+    mock: "HTTPServer",
+    request: pytest.FixtureRequest,
+    tmp_path: Path,
+    test_data_path: Path,
+) -> Path:
     return create_test_platform(
         tmp_path, test_data_path, "test_access", auth_url=mock.url_for("")
     )
@@ -58,7 +68,12 @@ M = ["test_model", "non_existing_model"]
         ("non_existing_user", M, {"test_model": False, "non_existing_model": False}),
     ),
 )
-def test_check_access(test_props, user, models, exp):
+def test_check_access(
+    test_props: Path,
+    user: str,
+    models: Union[str, list[str]],
+    exp: Union[bool, dict[str, bool]],
+) -> None:
     """:meth:`.check_access` correctly handles certain arguments and responses."""
     mp = ixmp.Platform(backend="jdbc", dbprops=test_props)
     assert exp == mp.check_access(user, models)

--- a/ixmp/tests/test_compat.py
+++ b/ixmp/tests/test_compat.py
@@ -1,21 +1,29 @@
 """Tests for compatibility with other packages, especially :mod:`message_ix`."""
 
+import os
+from collections.abc import Generator
 from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
 from ixmp import config
 
+if TYPE_CHECKING:
+    from ixmp.testing import Runner
+
 
 @pytest.fixture()
-def tmp_path(tmp_path_factory):
+def tmp_path(tmp_path_factory: pytest.TempPathFactory) -> Generator[Path, Any, None]:
     p0 = tmp_path_factory.mktemp("foo")
     p1 = p0.joinpath("bar", "baz")
     p1.mkdir(exist_ok=True, parents=True)
     yield p1
 
 
-def test_message_model_dir(ixmp_cli, tmp_env, tmp_path):
+def test_message_model_dir(
+    ixmp_cli: "Runner", tmp_env: os._Environ[str], tmp_path: Path
+) -> None:
     """Configuration keys like 'message model dir' can be registered, set, and used."""
     value = tmp_path
 

--- a/ixmp/tests/test_integration.py
+++ b/ixmp/tests/test_integration.py
@@ -1,6 +1,9 @@
 import logging
+from pathlib import Path
+from typing import TYPE_CHECKING, Union
 
 import numpy as np
+import pandas as pd
 import pytest
 from numpy.testing import assert_array_equal
 from pandas.testing import assert_frame_equal
@@ -8,13 +11,21 @@ from pandas.testing import assert_frame_equal
 import ixmp
 from ixmp.testing import HIST_DF, TS_DF, make_dantzig, models
 
+if TYPE_CHECKING:
+    from ixmp.core.platform import Platform
+    from ixmp.core.scenario import Scenario
+
 TS_DF_CLEARED = TS_DF.copy()
 TS_DF_CLEARED.loc[0, 2005] = np.nan
 
 
 # FIXME IXMP4Backend seems to return columns with no/wrong names for scen.timeseries()
 @pytest.mark.jdbc
-def test_run_clone(caplog, test_mp, request):
+def test_run_clone(
+    caplog: pytest.LogCaptureFixture,
+    test_mp: "Platform",
+    request: pytest.FixtureRequest,
+) -> None:
     caplog.set_level(logging.WARNING)
 
     # this test is designed to cover the full functionality of the GAMS API
@@ -28,7 +39,7 @@ def test_run_clone(caplog, test_mp, request):
     assert np.isclose(scen.var("z")["lvl"], 153.675)
     assert_frame_equal(
         scen.timeseries(iamc=True),
-        TS_DF.assign(scenario=[scen.scenario, scen.scenario]),
+        TS_DF.assign(scenario=pd.Series([scen.scenario, scen.scenario])),
     )
 
     # cloning with `keep_solution=True` keeps all timeseries and the solution
@@ -36,10 +47,11 @@ def test_run_clone(caplog, test_mp, request):
     assert np.isclose(scen2.var("z")["lvl"], 153.675)
     assert_frame_equal(
         scen2.timeseries(iamc=True),
-        TS_DF.assign(scenario=[scen.scenario, scen.scenario]),
+        TS_DF.assign(scenario=pd.Series([scen.scenario, scen.scenario])),
     )
 
     # version attribute of the clone increments the original (GitHub #211)
+    assert scen.version is not None
     assert scen2.version == scen.version + 1
 
     # cloning with `keep_solution=True` and `first_model_year` raises a warning
@@ -64,13 +76,15 @@ def test_run_clone(caplog, test_mp, request):
     assert np.isnan(scen4.var("z")["lvl"])
     assert_frame_equal(
         scen4.timeseries(iamc=True),
-        TS_DF_CLEARED.assign(scenario=[scen.scenario, scen.scenario]),
+        TS_DF_CLEARED.assign(scenario=pd.Series([scen.scenario, scen.scenario])),
     )
 
 
 # FIXME Fix IXMP4Backend return value for s.var()["lvl"] so that np.isnan() accepts it
 @pytest.mark.jdbc
-def test_run_remove_solution(test_mp, request):
+def test_run_remove_solution(
+    test_mp: "Platform", request: pytest.FixtureRequest
+) -> None:
     # create a new instance of the transport problem and solve it
     mp = test_mp
     scen = make_dantzig(mp, solve=True, quiet=True, request=request)
@@ -97,28 +111,30 @@ def test_run_remove_solution(test_mp, request):
     assert np.isnan(scen3.var("z")["lvl"])
     assert_frame_equal(
         scen3.timeseries(iamc=True),
-        TS_DF_CLEARED.assign(scenario=[scen.scenario, scen.scenario]),
+        TS_DF_CLEARED.assign(scenario=pd.Series([scen.scenario, scen.scenario])),
     )
 
 
-def scenario_list(mp):
+def scenario_list(mp: "Platform") -> pd.DataFrame:
     return mp.scenario_list(default=False)[["model", "scenario"]]
 
 
-def assert_multi_db(mp1, mp2):
+def assert_multi_db(mp1: "Platform", mp2: "Platform") -> None:
     assert_frame_equal(scenario_list(mp1), scenario_list(mp2))
 
 
-def get_distance(scen):
-    return scen.par("d").set_index(["i", "j"]).loc["san-diego", "topeka"]["value"]
+def get_distance(scen: "Scenario") -> "pd.Series[Union[float, int]]":
+    d = scen.par("d")
+    assert isinstance(d, pd.DataFrame)
+    return d.set_index(["i", "j"]).loc[("san-diego", "topeka"), :]["value"]
 
 
-def test_multi_db_run(tmpdir, request):
+def test_multi_db_run(tmp_path: Path, request: pytest.FixtureRequest) -> None:
     # create a new instance of the transport problem and solve it
-    mp1 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmpdir / "mp1")
+    mp1 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmp_path / "mp1")
     scen1 = make_dantzig(mp1, solve=True, quiet=True, request=request)
 
-    mp2 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmpdir / "mp2")
+    mp2 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmp_path / "mp2")
     # add other unit to make sure that the mapping is correct during clone
     mp2.add_unit("wrong_unit")
     mp2.add_region("wrong_region", "country")
@@ -134,36 +150,48 @@ def test_multi_db_run(tmpdir, request):
     del mp2
 
     # reopen the connection to the second platform and reload scenario
-    _mp2 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmpdir / "mp2")
+    _mp2 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmp_path / "mp2")
     assert_multi_db(mp1, _mp2)
     args = models["dantzig"].copy()
-    args.update(scenario=request.node.name)
+    args["scenario"] = request.node.name
     scen2 = ixmp.Scenario(_mp2, **args)
 
     # check that sets, variables and parameter were copied correctly
     assert_array_equal(scen1.set("i"), scen2.set("i"))
-    assert_frame_equal(scen1.par("d"), scen2.par("d"))
+    d1 = scen1.par("d")
+    d2 = scen2.par("d")
+    assert isinstance(d1, pd.DataFrame)
+    assert isinstance(d2, pd.DataFrame)
+    assert_frame_equal(d1, d2)
     assert np.isclose(scen2.var("z")["lvl"], 153.675)
-    assert_frame_equal(scen1.var("x"), scen2.var("x"))
+    x1 = scen1.var("x")
+    x2 = scen2.var("x")
+    assert isinstance(x1, pd.DataFrame)
+    assert isinstance(x2, pd.DataFrame)
+    assert_frame_equal(x1, x2)
 
     # check that custom unit, region and timeseries are migrated correctly
     assert scen2.par("f")["value"] == 90.0
     assert scen2.par("f")["unit"] == "USD/km"
     assert_frame_equal(
         scen2.timeseries(iamc=True),
-        TS_DF.assign(scenario=[scen2.scenario, scen2.scenario]),
+        TS_DF.assign(scenario=pd.Series([scen2.scenario, scen2.scenario])),
     )
 
 
-def test_multi_db_edit_source(tmpdir, request):
+def test_multi_db_edit_source(tmp_path: Path, request: pytest.FixtureRequest) -> None:
     # create a new instance of the transport problem
-    mp1 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmpdir / "mp1")
+    mp1 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmp_path / "mp1")
     scen1 = make_dantzig(mp1, request=request)
 
-    mp2 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmpdir / "mp2")
+    mp2 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmp_path / "mp2")
     scen2 = scen1.clone(platform=mp2)
 
-    assert_frame_equal(scen1.par("d"), scen2.par("d"))
+    d1 = scen1.par("d")
+    d2 = scen2.par("d")
+    assert isinstance(d1, pd.DataFrame)
+    assert isinstance(d2, pd.DataFrame)
+    assert_frame_equal(d1, d2)
 
     scen1.check_out()
     scen1.add_par("d", ["san-diego", "topeka"], 1.5, "km")
@@ -180,15 +208,19 @@ def test_multi_db_edit_source(tmpdir, request):
     assert_multi_db(mp1, mp2)
 
 
-def test_multi_db_edit_target(tmpdir, request):
+def test_multi_db_edit_target(tmp_path: Path, request: pytest.FixtureRequest) -> None:
     # create a new instance of the transport problem
-    mp1 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmpdir / "mp1")
+    mp1 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmp_path / "mp1")
     scen1 = make_dantzig(mp1, request=request)
 
-    mp2 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmpdir / "mp2")
+    mp2 = ixmp.Platform(backend="jdbc", driver="hsqldb", path=tmp_path / "mp2")
     scen2 = scen1.clone(platform=mp2)
 
-    assert_frame_equal(scen1.par("d"), scen2.par("d"))
+    d1 = scen1.par("d")
+    d2 = scen2.par("d")
+    assert isinstance(d1, pd.DataFrame)
+    assert isinstance(d2, pd.DataFrame)
+    assert_frame_equal(d1, d2)
 
     scen2.check_out()
     scen2.add_par("d", ["san-diego", "topeka"], 1.5, "km")

--- a/ixmp/tests/test_model.py
+++ b/ixmp/tests/test_model.py
@@ -1,6 +1,10 @@
 import logging
 import re
+from collections.abc import Generator
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
 
+import pandas as pd
 import pytest
 
 from ixmp import Scenario
@@ -8,9 +12,13 @@ from ixmp.model.base import Model, ModelError
 from ixmp.model.dantzig import DantzigModel
 from ixmp.model.gams import GAMSInfo, gams_version
 from ixmp.testing import assert_logs, make_dantzig
+from ixmp.types import GamsModelInitKwargs
+
+if TYPE_CHECKING:
+    from ixmp.core.platform import Platform
 
 
-def test_base_model():
+def test_base_model() -> None:
     # An incomplete Backend subclass can't be instantiated
     class M1(Model):
         pass
@@ -20,13 +28,17 @@ def test_base_model():
         match="Can't instantiate abstract class M1 with(out an implementation for)? "
         "abstract methods",
     ):
-        M1()
+        M1(name_="test")  # type: ignore[abstract]
 
 
 # FIXME IXMP4Backend doesn't handle scenario.change_scalar() correctly:
 # We can't just create() it, it might already exist, so then we need update()
 @pytest.mark.jdbc
-def test_model_initialize(test_mp, caplog, request):
+def test_model_initialize(
+    test_mp: "Platform",
+    caplog: pytest.LogCaptureFixture,
+    request: pytest.FixtureRequest,
+) -> None:
     # Model.initialize runs on an empty Scenario
     s = make_dantzig(test_mp, request=request)
     b1 = s.par("b")
@@ -45,6 +57,7 @@ def test_model_initialize(test_mp, caplog, request):
     b2 = s.par("b")
     assert len(b2) == 3
     # ...but modified value(s) are not overwritten
+    assert isinstance(b2, pd.DataFrame)
     assert (b2.query("j == 'chicago'")["value"] == new_value).all()
 
     # Unrecognized Scenario(scheme=...) is initialized using the base method, a
@@ -76,7 +89,7 @@ def test_model_initialize(test_mp, caplog, request):
             scenario="scenario-name",
             version="new",
             scheme="unknown",
-            bad_arg1=111,
+            bad_arg1=111,  # type: ignore[call-arg]
         )
 
     with pytest.raises(TypeError, match="unexpected keyword argument 'bad_arg2'"):
@@ -87,7 +100,7 @@ def test_model_initialize(test_mp, caplog, request):
             version="new",
             scheme="dantzig",
             with_data=True,
-            bad_arg2=222,
+            bad_arg2=222,  # type: ignore[call-arg]
         )
 
     # Replace b[j] with a parameter of the same name, but different indices
@@ -100,7 +113,7 @@ def test_model_initialize(test_mp, caplog, request):
         DantzigModel.initialize(s)
 
 
-def test_gams_version():
+def test_gams_version() -> None:
     parts = gams_version().split(".")
 
     # Returns a version string like X.Y.Z, in which each part is a number (no leading or
@@ -110,7 +123,7 @@ def test_gams_version():
 
 
 class TestGAMSInfo:
-    def test_version(self, monkeypatch, tmp_path) -> None:
+    def test_version(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
         """:attr:`GAMSInfo.version` contains useful info if no installation found."""
         # Set the expected name of the GAMS executable to a non-existent program
         monkeypatch.setattr(GAMSInfo, "_name", "__F_O_O")
@@ -130,14 +143,16 @@ class TestGAMSInfo:
 
 class TestGAMSModel:
     @pytest.fixture(scope="class")
-    def dantzig(self, test_mp, request):
+    def dantzig(
+        self, test_mp: "Platform", request: pytest.FixtureRequest
+    ) -> Generator[Scenario, Any, None]:
         yield make_dantzig(test_mp, request=request)
 
     # FIXME The name_ seems to be handled correctly, but IXMP4Backend struggles with
     # make_dantzig().clone().solve() somehow.
     @pytest.mark.jdbc
     @pytest.mark.parametrize("char", r'<>"/\|?*')
-    def test_filename_invalid_char(self, dantzig, char):
+    def test_filename_invalid_char(self, dantzig: Scenario, char: str) -> None:
         """Model can be solved with invalid character names."""
         name = f"foo{char}bar"
         s = dantzig.clone(model=name, scenario=name)
@@ -158,11 +173,17 @@ class TestGAMSModel:
         ],
         ids=["null-comment", "null-list", "empty-list"],
     )
-    def test_GAMSModel_solve(test_data_path, dantzig, kwargs):
+    def test_GAMSModel_solve(
+        self,
+        test_data_path: Path,
+        dantzig: Scenario,
+        kwargs: GamsModelInitKwargs,
+    ) -> None:
         """Options to GAMSModel are handled without error."""
-        dantzig.clone().solve(**kwargs, quiet=True)
+        kwargs["quiet"] = True
+        dantzig.clone().solve(**kwargs)
 
-    def test_error_message(self, test_data_path, test_mp):
+    def test_error_message(self, test_data_path: Path, test_mp: "Platform") -> None:
         """GAMSModel.solve() displays a user-friendly message on error."""
         # Empty Scenario
         s = Scenario(test_mp, model="foo", scenario="bar", version="new")

--- a/ixmp/tests/test_perf.py
+++ b/ixmp/tests/test_perf.py
@@ -1,6 +1,7 @@
 """Performance tests."""
 
 from functools import partial
+from typing import TYPE_CHECKING, Any
 
 import pytest
 
@@ -8,18 +9,25 @@ from ixmp import Scenario
 from ixmp.testing import models
 from ixmp.testing.data import add_random_model_data
 
+if TYPE_CHECKING:
+    from ixmp.core.platform import Platform
 
-def add_par_setup(mp, length):  # pragma: no cover
+
+def add_par_setup(
+    mp: "Platform", length: int
+) -> tuple[tuple[Scenario, int], dict[str, Any]]:  # pragma: no cover
     return (Scenario(mp, **models["dantzig"], version="new"), length), dict()
 
 
-def add_par(scen, length):  # pragma: no cover
+def add_par(scen: Scenario, length: int) -> None:  # pragma: no cover
     with scen.transact():
         add_random_model_data(scen, length)
 
 
 @pytest.mark.parametrize("length", [1e2, 1e3, 1e4, 1e6])
-def test_add_par(benchmark, test_mp, length):  # pragma: no cover
+def test_add_par(
+    benchmark: Any, test_mp: "Platform", length: int
+) -> None:  # pragma: no cover
     """Test performance of :meth:`.add_par`."""
     benchmark.pedantic(
         add_par,

--- a/ixmp/tests/test_testing.py
+++ b/ixmp/tests/test_testing.py
@@ -1,15 +1,20 @@
+from typing import TYPE_CHECKING
+
 import ixmp
 from ixmp.testing import models
 from ixmp.testing.data import random_ts_data
 from ixmp.testing.resource import memory_usage
 
+if TYPE_CHECKING:
+    from ixmp.core.platform import Platform
 
-def test_random_ts_data(N=100):
+
+def test_random_ts_data(N: int = 100) -> None:
     df = random_ts_data(N)
     assert N == len(df)
 
 
-def test_resource_limit(resource_limit, test_mp):
+def test_resource_limit(resource_limit: None, test_mp: "Platform") -> None:
     """Exercise :func:`memory_usage` and :func:`resource_limit`."""
     # TODO expand to cover other missed lines in those functions
 

--- a/ixmp/tests/test_tutorials.py
+++ b/ixmp/tests/test_tutorials.py
@@ -1,6 +1,8 @@
 import os
 import platform
 import sys
+from pathlib import Path
+from typing import TypedDict
 
 import numpy as np
 import pytest
@@ -21,8 +23,12 @@ FLAKY = pytest.mark.flaky(
 )
 
 
+class DefaultKwargs(TypedDict, total=False):
+    timeout: int
+
+
 @pytest.fixture(scope="session")
-def default_args():
+def default_args() -> DefaultKwargs:
     """Default arguments for :func:`.run_notebook."""
     # Use a longer timeout for GHA
     return dict(timeout=30) if GHA else dict()
@@ -31,7 +37,13 @@ def default_args():
 @FLAKY
 @pytest.mark.xdist_group(name=f"{group_base_name}-0")
 @pytest.mark.parametrize("ixmp_backend", available())
-def test_py_transport(tmp_path, tmp_env, tutorial_path, default_args, ixmp_backend):
+def test_py_transport(
+    tmp_path: Path,
+    tmp_env: os._Environ[str],
+    tutorial_path: Path,
+    default_args: DefaultKwargs,
+    ixmp_backend: str,
+) -> None:
     fname = tutorial_path.joinpath("transport", "py_transport.ipynb")
 
     # Set the "default" platform to be either the platform named "local" or
@@ -49,7 +61,12 @@ def test_py_transport(tmp_path, tmp_env, tutorial_path, default_args, ixmp_backe
 
 
 @pytest.mark.xdist_group(name=f"{group_base_name}-0")
-def test_py_transport_scenario(tutorial_path, tmp_path, tmp_env, default_args):
+def test_py_transport_scenario(
+    tutorial_path: Path,
+    tmp_path: Path,
+    tmp_env: os._Environ[str],
+    default_args: DefaultKwargs,
+) -> None:
     fname = tutorial_path / "transport" / "py_transport_scenario.ipynb"
     nb, errors = run_notebook(fname, tmp_path, tmp_env, **default_args)
     assert errors == []
@@ -63,7 +80,12 @@ def test_py_transport_scenario(tutorial_path, tmp_path, tmp_env, default_args):
 @pytest.mark.rixmp
 # TODO investigate and resolve the cause of the time outs; remove this mark
 @pytest.mark.skipif(GHA and sys.platform == "linux", reason="Times out")
-def test_R_transport(tutorial_path, tmp_path, tmp_env, default_args):
+def test_R_transport(
+    tutorial_path: Path,
+    tmp_path: Path,
+    tmp_env: os._Environ[str],
+    default_args: DefaultKwargs,
+) -> None:
     fname = tutorial_path / "transport" / "R_transport.ipynb"
     nb, errors = run_notebook(
         fname, tmp_path, tmp_env, kernel_name="IR", **default_args
@@ -75,7 +97,12 @@ def test_R_transport(tutorial_path, tmp_path, tmp_env, default_args):
 @pytest.mark.rixmp
 # TODO investigate and resolve the cause of the time outs; remove this mark
 @pytest.mark.skipif(GHA and sys.platform == "linux", reason="Times out")
-def test_R_transport_scenario(tutorial_path, tmp_path, tmp_env, default_args):
+def test_R_transport_scenario(
+    tutorial_path: Path,
+    tmp_path: Path,
+    tmp_env: os._Environ[str],
+    default_args: DefaultKwargs,
+) -> None:
     fname = tutorial_path / "transport" / "R_transport_scenario.ipynb"
     nb, errors = run_notebook(
         fname, tmp_path, tmp_env, kernel_name="IR", **default_args

--- a/ixmp/types.py
+++ b/ixmp/types.py
@@ -1,13 +1,151 @@
 """Types for type hinting and checking of :mod:`ixmp` and downstream code."""
 
-from typing import NotRequired, TypedDict, Union
+import os
+from collections.abc import Sequence
+from pathlib import Path
+from typing import (
+    TYPE_CHECKING,
+    Literal,
+    NotRequired,
+    Optional,
+    TypeAlias,
+    TypedDict,
+    Union,
+)
+
+from ixmp.backend.common import ItemType
+
+if TYPE_CHECKING:
+    from ixmp.core.scenario import Scenario
+    from ixmp.core.timeseries import TimeSeries
+    from ixmp.util.ixmp4 import ContainerData
 
 
-class PlatformArgs(TypedDict, total=False):
-    """Arguments to :class:`.Platform`."""
+ItemTypeNames: TypeAlias = Literal["set", "par", "equ", "var"]
+ItemTypeFlags: TypeAlias = Literal[
+    ItemType.PAR, ItemType.SET, ItemType.EQU, ItemType.VAR
+]
+VersionType: TypeAlias = Optional[Union[int, Literal["new"]]]
 
-    name: NotRequired[Union[str, None]]
-    # NB The class itself has Literal["ixmp4", "jdbc"] first as an aid to completion in
-    #    IDE/interactive use, but for downstream code any str is valid, though may raise
-    #    in get_class().
-    backend: NotRequired[Union[str, None]]
+
+# NOTE Use this form to enable the key 'class'
+BackendInitKwargs = TypedDict(
+    "BackendInitKwargs", {"class": NotRequired[Union[Literal["jdbc", "ixmp4"], str]]}
+)
+
+
+class JDBCBackendInitKwargs(TypedDict):
+    driver: NotRequired[Optional[str]]
+    path: NotRequired[Optional[Union[str, Path]]]
+    url: NotRequired[Optional[str]]
+    user: NotRequired[Optional[str]]
+    password: NotRequired[Optional[str]]
+
+
+class IXMP4BackendInitKwargs(TypedDict):
+    ixmp4_name: str
+    dsn: NotRequired[str]
+    jdbc_compat: NotRequired[Union[bool, str]]
+
+
+# NOTE This would ideally inherit from IXMP4BackendInitKwargs, but ixmp4_name cannot be
+# required here since it's not required for JDBC.__init__()
+class PlatformInitKwargs(BackendInitKwargs, JDBCBackendInitKwargs):
+    jvmargs: NotRequired[Optional[Union[str, list[str]]]]
+    dbprops: NotRequired[Optional[os.PathLike[str]]]
+    cache: NotRequired[bool]
+    log_level: NotRequired[Optional[Union[int, str]]]
+    ixmp4_name: NotRequired[str]
+    dsn: NotRequired[str]
+    jdbc_compat: NotRequired[Union[bool, str]]
+
+
+class InitializeItemsKwargs(TypedDict):
+    ix_type: Literal["set", "par", "equ", "var"]
+    idx_sets: NotRequired[Optional[list[str]]]
+    idx_names: NotRequired[Optional[list[str]]]
+
+
+class GamsModelInitKwargs(TypedDict, total=False):
+    model_file: os.PathLike[str]
+    case: str
+    in_file: os.PathLike[str]
+    out_file: os.PathLike[str]
+    solve_args: list[str]
+    gams_args: list[str]
+    check_solution: bool
+    comment: Optional[str]
+    equ_list: Optional[list[str]]
+    var_list: Optional[list[str]]
+    quiet: bool
+    use_temp_dir: bool
+    name_: Optional[str]
+    record_version_packages: Sequence[str]
+    container_data: list["ContainerData"]
+
+
+class ScenarioInitKwargs(TypedDict, total=False):
+    cache: bool
+    with_data: bool
+
+
+class ScenarioIdentifiers(TypedDict):
+    """Identifiers of a Scenario."""
+
+    model: str
+    scenario: str
+
+
+class ScenarioInfo(ScenarioIdentifiers):
+    version: NotRequired[Optional[Union[int, Literal["new"]]]]
+
+
+class PlatformInfo(TypedDict):
+    name: NotRequired[str]
+
+
+class WriteFiltersKwargs(TypedDict, total=False):
+    scenario: "Scenario | TimeSeries | list[str]"
+    model: list[str]
+    variable: list[str]
+    unit: list[str]
+    region: list[str]
+    default: bool
+    export_all_runs: bool
+
+
+class RunKwargs(TypedDict):
+    filters: WriteFiltersKwargs
+    record_version_packages: NotRequired[Sequence[str]]
+    container_data: NotRequired[list["ContainerData"]]
+
+
+class WriteKwargs(TypedDict, total=False):
+    filters: WriteFiltersKwargs
+    record_version_packages: Sequence[str]
+    container_data: list["ContainerData"]
+    max_row: Optional[int]
+
+
+class ReadKwargs(TypedDict, total=False):
+    filters: WriteFiltersKwargs
+    firstyear: Optional[int]
+    lastyear: Optional[int]
+    add_units: bool
+    init_items: bool
+    commit_steps: bool
+    check_solution: bool
+    comment: str
+    equ_list: list[str]
+    var_list: list[str]
+
+
+class TSReadFileKwargs(TypedDict, total=False):
+    firstyear: Optional[int]
+    lastyear: Optional[int]
+
+
+class SReadFileKwargs(TypedDict, total=False):
+    add_units: bool
+    init_items: bool
+    commit_steps: bool

--- a/ixmp/util/ixmp4.py
+++ b/ixmp/util/ixmp4.py
@@ -1,24 +1,11 @@
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any, Literal, Optional, Union
+from typing import Literal, Optional, Union
 
 import pandas as pd
 
 # TODO Import this from typing when dropping Python 3.11
-from typing_extensions import TypedDict
-
-if TYPE_CHECKING:
-    from ixmp.core.scenario import Scenario
-
 
 # These are based on existing calls within ixmp
-class WriteFiltersKwargs(TypedDict, total=False):
-    scenario: "Scenario | list[str]"
-    model: list[str]
-    variable: list[str]
-    unit: list[str]
-    region: list[str]
-    default: bool
-    export_all_runs: bool
 
 
 @dataclass
@@ -37,25 +24,6 @@ class ContainerData:
     ]
     domain: Optional[list[str]] = None
     docs: Optional[str] = None
-
-
-class WriteKwargs(TypedDict, total=False):
-    filters: WriteFiltersKwargs
-    record_version_packages: list[str]
-    container_data: list[ContainerData]
-
-
-class ReadKwargs(TypedDict, total=False):
-    filters: WriteFiltersKwargs
-    firstyear: Optional[Any]
-    lastyear: Optional[Any]
-    add_units: bool
-    init_items: bool
-    commit_steps: bool
-    check_solution: bool
-    comment: str
-    equ_list: list[str]
-    var_list: list[str]
 
 
 def configure_logging_and_warnings() -> None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,10 +97,31 @@ files = [
   "doc",
   "ixmp",
 ]
+show_error_codes = true
+warn_unused_configs = true
+warn_redundant_casts = true
+warn_unused_ignores = true
+strict_equality = true
+extra_checks = true
+check_untyped_defs = true
+disallow_subclassing_any = true
+disallow_untyped_decorators = true
+disallow_any_generics = true
+disallow_untyped_calls = true
+disallow_incomplete_defs = true
+disallow_untyped_defs = true
+warn_return_any = true
+disallow_any_unimported = true
+no_implicit_optional = true
+warn_unreachable = true
+no_implicit_reexport = true
 
 [[tool.mypy.overrides]]
 # Packages/modules for which no type hints are available.
 module = [
+  "gams.*",
+  "ixmp.reporting.*",
+  "ixmp.utils",
   "jpype",
   "memory_profiler",
   "pyam",


### PR DESCRIPTION
This PR enables settings that are equivalent to `mypy --strict` and even slightly more :)

There is still room for improvement and some cleanups, I think, but all tests should be passing already.
There are some dependencies that are not fully annotated (e.g. pint, dask, and genno) so that we have to implore some `type: ignore`s. These feel a bit unnecessary, especially when the underlying functions are documented clearly. For example, `genno.Computer.get()` is documented, but not typed, so we could think of proxying it here (essentially just calling the `super()` method) to include type hints (I also looked at genno if I could quickly provide the required type hints there, but got lost by more and more type hints and aborted the project to save some time).

Other than that, I had to change several occurrences of `scen.par()` in the test suite. Per `par()`'s docstring (and function logic), it returns a `pd.DataFrame` for indexed Parameters and a `dict[str, float | str]` for scalar Parameters. Unfortunately, it was previously annotated to return `pd.DataFrame` only, which I changed now to the actual return type union. Several places in the test suite expect only a `pd.DataFrame` to be returned, though.
I'm not sure what the best thing to do is, here. We could maybe come up with another function for scalar Parameters (to allow `scen.par()` to return only `pd.DataFrame), but that also requires code adjustments. Alternatively, we could adjust `backend.item_get_elements()` to always return `pd.DataFrame` for `ItemType.PAR`, even for Scalars. Based on existing usage, `scen.par()` doesn't seem to be called often to return Scalar data.

## How to review

- Read the diff and note that the CI checks all pass.


## PR checklist


- [ ] Continuous integration checks all ✅
- [ ] Add or expand tests; coverage checks both ✅
- [ ] Add, expand, or update documentation.
- [ ] Update release notes.
