### PR TITLE
Restore GAMSModel.__init__(…, name_=…) argument

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.16.0
+  rev: v1.17.0
   hooks:
   - id: mypy
     pass_filenames: false
@@ -16,8 +16,8 @@ repos:
     - werkzeug
     - xarray
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.11.13
+  rev: v0.12.4
   hooks:
-  - id: ruff
+  - id: ruff-check
   - id: ruff-format
     args: [ --check ]

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -39,7 +39,7 @@ All changes
 
 - New method :meth:`.Scenario.iter_par_data` (:pull:`581`).
   :meth:`.Scenario.items` no longer supports iterating over item *contents*.
-- Improve type hinting in :mod:`ixmp` (:pull:`581`).
+- Improve type hinting in :mod:`ixmp` (:pull:`581`, :pull:`587`).
   This supports more precise and complete type checking of downstream code that uses :mod:`ixmp`.
 
   - New module :mod:`ixmp.types` containing types for annotating code that uses :mod:`ixmp`.

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -26,7 +26,6 @@ from ixmp.util import as_str_list, check_year
 if TYPE_CHECKING:
     from ixmp.types import (
         Filters,
-        GamsModelInitKwargs,
         ModelItemType,
         ParData,
         ScalarParData,
@@ -899,7 +898,7 @@ class Scenario(TimeSeries):
         model: Optional[str] = None,
         callback: Optional[Callable[["Scenario"], bool]] = None,
         cb_kwargs: dict[str, Any] = {},
-        **model_options: Unpack["GamsModelInitKwargs"],
+        **model_options: Any,
     ) -> None:
         """Solve the model and store output.
 

--- a/ixmp/model/__init__.py
+++ b/ixmp/model/__init__.py
@@ -1,29 +1,21 @@
-from typing import TYPE_CHECKING, Optional, Union
-
-# TODO Import from typing when dropping support for Python 3.11
-from typing_extensions import Unpack
+from typing import TYPE_CHECKING, Any, Optional
 
 from .dantzig import DantzigModel
 from .gams import GAMSModel
 
 if TYPE_CHECKING:
-    from ixmp.types import GamsModelInitKwargs
-
+    from .base import Model
 
 #: Mapping from names to available models. To register additional models, add elements
 #: to this variable.
-MODELS: dict[
-    str, Union[type[GAMSModel], type[DantzigModel]]
-] = {  # type["ixmp.model.base.Model"]
+MODELS: dict[str, type["Model"]] = {
     "default": GAMSModel,
     "gams": GAMSModel,
     "dantzig": DantzigModel,
 }
 
 
-def get_model(
-    name: Optional[str], **model_options: Unpack["GamsModelInitKwargs"]
-) -> Union[GAMSModel, DantzigModel]:
+def get_model(name: Optional[str], **model_options: Any) -> "Model":
     """Return a model instance for `name` (or the default) with `model_options`.
 
     Note that unlike :func:`.backend.get_class`, this function creates a new instance.

--- a/ixmp/model/base.py
+++ b/ixmp/model/base.py
@@ -5,16 +5,12 @@ from abc import ABC, abstractmethod
 from collections.abc import Mapping, Sequence
 from typing import TYPE_CHECKING, Any, Optional, cast
 
-# Compatibility with Python 3.11 and earlier
-# TODO Use "from typing import Unpack" when dropping support for Python 3.11
-from typing_extensions import Unpack
-
 from ixmp.backend.common import ItemType
 from ixmp.util import maybe_check_out, maybe_commit
 
 if TYPE_CHECKING:
     from ixmp.core.scenario import Scenario
-    from ixmp.types import GamsModelInitKwargs, InitializeItemsKwargs
+    from ixmp.types import InitializeItemsKwargs
 
 log = logging.getLogger(__name__)
 
@@ -28,7 +24,7 @@ class Model(ABC):
     name: str = "base"
 
     @abstractmethod
-    def __init__(self, **kwargs: Unpack["GamsModelInitKwargs"]) -> None:
+    def __init__(self, *args: Any, **kwargs: Any) -> None:
         """Constructor.
 
         **Required.**

--- a/ixmp/model/base.py
+++ b/ixmp/model/base.py
@@ -152,11 +152,11 @@ class Model(ABC):
 
                 # If the item exists; check its index sets/names
                 if exists:
-                    existing = tuple(method(name))
-                    if existing != init_kw.get(key, ()):
+                    existing, arg = tuple(method(name)), init_kw.get(key, ())
+                    if existing != arg and not (key == "idx_names" and arg == ()):
                         log.warning(
                             f"Existing index {key.split('_')[-1]} of {name!r} "
-                            f"{existing!r} do not match {init_kw.get(key, ())!r}"
+                            f"{existing!r} do not match {arg!r}"
                         )
 
             # Can't do anything to existing items

--- a/ixmp/model/gams.py
+++ b/ixmp/model/gams.py
@@ -252,8 +252,11 @@ class GAMSModel(Model):
         "container_data": [],
     }
 
-    def __init__(self, **model_options: Unpack["GamsModelInitKwargs"]) -> None:
-        name_ = model_options.get("name_", None)
+    def __init__(
+        self,
+        name_: Optional[str] = None,
+        **model_options: Unpack["GamsModelInitKwargs"],
+    ) -> None:
         self.model_name = self.clean_path(name_ or self.name)
 
         # Store options from `model_options`, otherwise from `defaults`

--- a/ixmp/tests/test_model.py
+++ b/ixmp/tests/test_model.py
@@ -151,9 +151,6 @@ class TestGAMSModel:
     ) -> Generator[Scenario, Any, None]:
         yield make_dantzig(test_mp, request=request)
 
-    # FIXME The name_ seems to be handled correctly, but IXMP4Backend struggles with
-    # make_dantzig().clone().solve() somehow.
-    @pytest.mark.jdbc
     @pytest.mark.parametrize("char", r'<>"/\|?*')
     def test_filename_invalid_char(self, dantzig: Scenario, char: str) -> None:
         """Model can be solved with invalid character names."""

--- a/ixmp/tests/test_model.py
+++ b/ixmp/tests/test_model.py
@@ -2,15 +2,18 @@ import logging
 import re
 from collections.abc import Generator
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Optional
 
 import pandas as pd
 import pytest
 
+# TODO Use "from typing import Unpack" when dropping support for Python 3.11
+from typing_extensions import Unpack
+
 from ixmp import Scenario
 from ixmp.model.base import Model, ModelError
 from ixmp.model.dantzig import DantzigModel
-from ixmp.model.gams import GAMSInfo, gams_version
+from ixmp.model.gams import GAMSInfo, GAMSModel, gams_version
 from ixmp.testing import assert_logs, make_dantzig
 
 if TYPE_CHECKING:
@@ -206,3 +209,16 @@ Log file  : {}
 Input data: {}""".format(*paths),
         ):
             s.solve(model_file=test_data_path / "_abort.gms", use_temp_dir=False)
+
+    def test_subclass_init(self) -> None:
+        """Subclasses can call :py:`super().__init__()`, as in :mod:`message_ix`."""
+
+        class Foo(GAMSModel):
+            def __init__(
+                self,
+                name: Optional[str] = None,
+                **model_options: Unpack["GamsModelInitKwargs"],
+            ) -> None:
+                super().__init__(name, **model_options)
+
+        Foo()

--- a/ixmp/types.py
+++ b/ixmp/types.py
@@ -130,7 +130,6 @@ class GamsModelInitKwargs(TypedDict, total=False):
     var_list: Optional[list[str]]
     quiet: bool
     use_temp_dir: bool
-    name_: Optional[str]
     record_version_packages: Sequence[str]
     container_data: list["ContainerData"]
 


### PR DESCRIPTION
Removal of this argument in #581 broke message_ix and message-ix-models `main` branches, as evidenced by scheduled CI, for instance [here](https://github.com/iiasa/message_ix/actions/runs/16385241030/job/46303799944):
```
FAILED message_ix/tests/util/test_gams_io.py::test_add_default_data_to_container_data_list[ixmp4] - TypeError: GAMSModel.__init__() takes 1 positional argument but 2 were given
= 220 failed, 41 passed, 5 xfailed, 1 xpassed, 4 warnings, 114 errors in 60.77s (0:01:00) =
```

Related:
- Remove types.GamsModelInitKwargs.name_.
- Use GamsModelInitKwargs for GAMSModel only. Other functions, like `ixmp.model.get_model()` and `Scenario.solve()`, must be usable with _any_ subclass of ixmp.model.base.Model. If such subclasses are created in the future (see for instance https://github.com/iiasa/message_ix/issues/879#issuecomment-3067296560) they may have different arguments than GAMSModel.

Also:
- Reduce log verbosity in `.base.Model.initialize_items()`. Changes to this method in #581 resulted in spurious messages like:
  ```
  Existing index names of 'renewable_potential' ('node', 'commodity', 'grade', 'level', 'year') do not match ()
  ```
  These are spurious because an argument value of idx_names=() used when creating a parameter is automatically replaced with the same value as idx_sets, resulting in the values shown; so there is no difference.

## How to review

- Read the diff and note that the CI checks all pass.
- Run the `message_ix` test suite with the code on this branch.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ Bugfix.
- [x] Update release notes.