### PR TITLE
Remove pytest-rerunfailures pin after issue was resolved

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -74,8 +74,7 @@ tests = [
   "pytest-benchmark",
   "pytest-cov",
   "pytest-httpserver",
-  # TODO Remove pin after https://github.com/pytest-dev/pytest-rerunfailures/issues/302
-  "pytest-rerunfailures<16.0",
+  "pytest-rerunfailures",
   "pytest-xdist",
 ]
 


### PR DESCRIPTION
#593 pinned pytest-rerunfailures since v16.0.0 was breaking our CI. I reported this issue upstream in https://github.com/pytest-dev/pytest-rerunfailures/issues/303, which was closed after v16.0.1 reverted the braking changes. So we should remove our pin to test against their latest version again.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just dependency management.
- ~[ ] Update release notes.~ Just dependency management.
