### PR TITLE
Bump minimum required version of ixmp4

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,7 @@ repos:
     additional_dependencies:
     - genno
     - GitPython
-    - "ixmp4 >= 0.10, < 0.13"
+    - "ixmp4 >= 0.12, < 0.13"
     - nbclient
     - pandas-stubs
     - pytest

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,7 +61,7 @@ docs = [
   "sphinxcontrib-bibtex",
 ]
 ixmp4 = [
-  "ixmp4 >= 0.10, < 0.13; python_version > '3.9'",
+  "ixmp4 >= 0.12, < 0.13; python_version > '3.9'",
   "gamsapi[core,transfer] >= 45.7.0",
 ]
 report = ["genno[compat,graphviz]"]


### PR DESCRIPTION
The recent bump of allowed ixmp4 versions adds support for later versions, but in some aspects, these versions are incompatible with earlier versions. As @khaeru rightly notes, we don't need to support all versions of the (currently still unstable) ixmp4 API. So this PR bumps the minimum required version to save ourselves this unnecessary maintenance work.

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

<!-- This item is always required. -->
- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just handling dependencies.
- ~[ ] Update release notes.~ Just handling dependencies.
