### PR TITLE
Fix CI timeout of test_tutorials on macos-latest-py3.13

### DIFF
--- a/ixmp/tests/test_tutorials.py
+++ b/ixmp/tests/test_tutorials.py
@@ -33,7 +33,7 @@ class DefaultKwargs(TypedDict, total=False):
 def default_args() -> DefaultKwargs:
     """Default arguments for :func:`.run_notebook."""
     # Use a longer timeout for GHA
-    return dict(timeout=30) if GHA else dict()
+    return dict(timeout=60) if GHA else dict()
 
 
 @FLAKY


### PR DESCRIPTION
Beginning on September 12, the `macos-latest-py3.13` test started failing consistently. This PR adjusts our CI so that all tests are passing again.

The failure start date coincides with a dependency bump from dask 2025.7.0 to 2025.9.0, but this is likely not the culprit as the `py3.10` version of the job is completing fine and using dask 2025.9.0 and now 2025.9.1.
It also coincides with a runner update from [this image](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20250830.2281) to [this one](https://github.com/actions/runner-images/releases/tag/macos-15-arm64%2F20250911.2324). I couldn't find other differences comparing the last successful and first failed run.

Even though I think we tried the same in https://github.com/iiasa/ixmp/pull/593, we'll start here by trying to increase the timeout limit (by a factor 2). If this doesn't work, @khaeru and I agreed on Slack that our best course of action is to disable the offending tests for non-linux OSes. Running them on Linux should be enough to bring any "real" issues to our attention while not wasting our time on handling specific setups that don't add coverage to our other test cases. 

## How to review

- Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just CI.
- ~[ ] Update release notes.~ Just CI.
