### PR TITLE
Address CI failures on Windows

### DIFF
--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -34,6 +34,7 @@ These include:
 
 import logging
 import os
+import platform
 import shutil
 import sys
 from collections.abc import Callable, Generator, Iterable
@@ -91,7 +92,20 @@ __all__ = [
     "tmp_env",
 ]
 
+#: :any:`True` if testing is occurring on GitHub Actions runners/machines.
 GHA = "GITHUB_ACTIONS" in os.environ
+
+_uname = platform.uname()
+
+#: Pytest marks for use throughout the test suite.
+MARK = {
+    "pytest#10843": pytest.mark.xfail(
+        condition=GHA
+        and _uname.system == "Windows"
+        and ("2025" in _uname.release or _uname.version >= "10.0.26100"),
+        reason="https://github.com/pytest-dev/pytest/issues/10843",
+    )
+}
 
 # Provide a skip marker since ixmp4 is not published for Python 3.9
 min_ixmp4_version = pytest.mark.skipif(

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -16,7 +16,7 @@ from pytest import raises
 import ixmp
 import ixmp.backend.jdbc
 from ixmp.backend.jdbc import DRIVER_CLASS, java
-from ixmp.testing import DATA, add_random_model_data, bool_param_id, make_dantzig
+from ixmp.testing import DATA, MARK, add_random_model_data, bool_param_id, make_dantzig
 from ixmp.testing.resource import memory_usage
 from ixmp.util.ixmp4 import is_ixmp4backend
 
@@ -87,6 +87,7 @@ def test_close_default_logging(
 
 # NOTE IXMP4Backend's close_db() is a noop
 @pytest.mark.jdbc
+@MARK["pytest#10843"]
 def test_close_increased_logging(
     test_mp_f: "Platform", capfd: pytest.CaptureFixture[str]
 ) -> None:
@@ -286,6 +287,7 @@ def test_invalid_properties_file(test_data_path: "Path") -> None:
         ixmp.Platform(dbprops=test_data_path / "hsqldb.properties")
 
 
+@MARK["pytest#10843"]
 def test_connect_message(
     capfd: pytest.CaptureFixture[str],
     caplog: pytest.LogCaptureFixture,


### PR DESCRIPTION
For some time, CI jobs on Windows (all Python versions) have been failing, e.g. [here](https://github.com/iiasa/ixmp/actions/runs/18611127478/job/53069407089#step:13:4065), with:

```
FAILED ixmp/tests/backend/test_jdbc.py::test_close_increased_logging[jdbc] - AssertionError: assert 'Database connection could not be closed or was already closed' in ''
 +  where '' = CaptureResult(out='', err='').out
FAILED ixmp/tests/backend/test_jdbc.py::test_connect_message - assert "connected to database 'jdbc:hsqldb:mem://test_connect_message_1' (user: ixmp)..." in ''
 +  where '' = CaptureResult(out='', err='').out
```

This PR is to debug and fix.

- The jobs succeeded at least as recently as 23 September, e.g. [here](https://github.com/iiasa/ixmp/actions/runs/17936278030).

In the end, we determined the cause is either pytest-dev/pytest#10843 or further upstream; see https://github.com/pytest-dev/pytest/issues/10843#issuecomment-3425483081. The two failing tests are marked XFAIL under the specific conditions where the issue arises.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, test/CI changes only.
- ~Update release notes.~