### PR TITLE
Add modelinstance support 

### DIFF
--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -1000,7 +1000,10 @@ class Scenario(TimeSeries):
                 break
 
     def create_model_instance(
-        self, model: Optional[str] = None, **model_options: Any
+        self,
+        model: Optional[str] = None,
+        modifiable_pars: Optional[list[str]] = None,
+        **model_options: Any,
     ):
         """Create a persistent GAMS model instance for efficient resolving.
 
@@ -1013,6 +1016,9 @@ class Scenario(TimeSeries):
         model : str, optional
             Model name (e.g., MESSAGE) or GAMS file name (excluding '.gms').
             If not provided, uses the scenario's scheme.
+        modifiable_pars : list of str, optional
+            List of parameter names that can be modified between solves.
+            Parameters used in conditional expressions ($) cannot be modifiable.
         model_options :
             Keyword arguments specific to the model. See :class:`.GAMSModel`.
 
@@ -1023,9 +1029,12 @@ class Scenario(TimeSeries):
 
         Examples
         --------
-        >>> mi, ws = scen.create_model_instance()
+        >>> mi, ws = scen.create_model_instance(
+        ...     modifiable_pars=["inv_cost", "var_cost"]
+        ... )
         >>> mi.solve()
-        >>> obj_value = mi.sync_db["OBJ"].first_record().level
+        >>> # Modify parameters in mi.sync_db and resolve
+        >>> mi.solve()
 
         See Also
         --------
@@ -1037,7 +1046,7 @@ class Scenario(TimeSeries):
         model_obj = get_model(model or self.scheme, **model_options)
 
         # Create and return the model instance
-        return model_obj.create_model_instance(self)
+        return model_obj.create_model_instance(self, modifiable_pars=modifiable_pars)
 
     # Input and output
     def to_excel(

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -999,6 +999,46 @@ class Scenario(TimeSeries):
                 # Callback indicates convergence is reached
                 break
 
+    def create_model_instance(
+        self, model: Optional[str] = None, **model_options: Any
+    ):
+        """Create a persistent GAMS model instance for efficient resolving.
+
+        This method creates a GAMS model instance that can be resolved multiple times
+        without rebuilding the model. The initial compilation is done without solving
+        to save time.
+
+        Parameters
+        ----------
+        model : str, optional
+            Model name (e.g., MESSAGE) or GAMS file name (excluding '.gms').
+            If not provided, uses the scenario's scheme.
+        model_options :
+            Keyword arguments specific to the model. See :class:`.GAMSModel`.
+
+        Returns
+        -------
+        tuple of (GamsModelInstance, GamsWorkspace)
+            The model instance and workspace that can be used for efficient resolving.
+
+        Examples
+        --------
+        >>> mi, ws = scen.create_model_instance()
+        >>> mi.solve()
+        >>> obj_value = mi.sync_db["OBJ"].first_record().level
+
+        See Also
+        --------
+        .GAMSModel.create_model_instance
+        """
+        from ixmp.model import get_model
+
+        # Instantiate a model
+        model_obj = get_model(model or self.scheme, **model_options)
+
+        # Create and return the model instance
+        return model_obj.create_model_instance(self)
+
     # Input and output
     def to_excel(
         self,

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -1003,6 +1003,7 @@ class Scenario(TimeSeries):
         self,
         model: Optional[str] = None,
         modifiable_pars: Optional[list[str]] = None,
+        fixable_vars: Optional[list[str]] = None,
         **model_options: Any,
     ):
         """Create a persistent GAMS model instance for efficient resolving.
@@ -1019,6 +1020,9 @@ class Scenario(TimeSeries):
         modifiable_pars : list of str, optional
             List of parameter names that can be modified between solves.
             Parameters used in conditional expressions ($) cannot be modifiable.
+        fixable_vars : list of str, optional
+            List of variable names that can be fixed between solves using
+            UpdateAction.Fixed.
         model_options :
             Keyword arguments specific to the model. See :class:`.GAMSModel`.
 
@@ -1046,7 +1050,9 @@ class Scenario(TimeSeries):
         model_obj = get_model(model or self.scheme, **model_options)
 
         # Create and return the model instance
-        return model_obj.create_model_instance(self, modifiable_pars=modifiable_pars)
+        return model_obj.create_model_instance(
+            self, modifiable_pars=modifiable_pars, fixable_vars=fixable_vars
+        )
 
     # Input and output
     def to_excel(


### PR DESCRIPTION
This is an experimental branch which adds support for the [Gamsmodelinstance API ](https://www.gams.com/50/docs/apis/python/classgams_1_1control_1_1execution_1_1GamsModelInstance.html) which provides a persistent model object for use. 

Right now this is quite experimental, hence the code is not up to quality. The API for allowing user access is also not final. Putting it here for reference and feedback. For most models, model generation times dominate solving times. This means when a sequence of scenarios are to be evaluated in an ensemble a large fraction of the time is spent in the generation of the model matrix. Modelinstance provides a persistent object with an in-memory database for modifiable parameters via sync_db. 

In theory this allows for gains = 1 + time_build/time_solving. For the baseline model time_build is ~500s and solve is 200s which yields a gain of 3.5X for large number of runs. Additionally the model instance passes the previous solution's basis to the next solution. In theory then a barrier followed by Simplex methods with advanced basis can approach even higher performance gains. But this requires dynamic solver parametrization maybe ML methods could help here.  

## How to review

At this point feedback and usage would be appreciated 

<!--
For example, one or more of:

- Read the diff and note that the CI checks all pass.
- Run a specific code snippet or command and check the output.
- View the preview build of the documentation and look at a certain page.
- Ensure that changes/additions are self-documenting, i.e. that another
  developer (someone like the reviewer) will be able to understand what the code
  does in the future.
-->

## PR checklist
Experimental so this will not apply till at least an early Alpha stage is reached. 
<!-- This item is always required. -->
~~- [ ] Continuous integration checks all ✅~~
<!--
The following items are *required* if the PR results in changes to user-facing
behaviour—such as new features, or fixes to existing behaviour.

They are *optional* if the changes are solely to documentation, test/CI
configuration, etc. In such cases, strike them out and add a short explanation,
for example:

- ~Add or expand tests.~ No change in behaviour, simply refactoring.
-->
~~- [ ] Add or expand tests; coverage checks both ✅~~
~~- [ ] Add, expand, or update documentation.~~
~~- [ ] Update release notes.~~
  <!--
  To do this, add a single line at the TOP of the “Next release” section of
  RELEASE_NOTES.rst, where '999' is the GitHub pull request number:

  - Title or single-sentence description from above (:pull:`999`:).

  Commit with a message like “Add #999 to release notes”
  -->
