### PR TITLE
Adjust to Pint 0.25.1

### DIFF
--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -41,7 +41,7 @@ from contextlib import contextmanager, nullcontext
 from copy import deepcopy
 from itertools import chain
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal, Sequence
+from typing import TYPE_CHECKING, Any, Literal, Sequence, TypeAlias
 
 import pint
 import pytest
@@ -71,6 +71,13 @@ from .resource import resource_limit
 
 if TYPE_CHECKING:
     from ixmp4.core import Run
+
+    try:
+        # Pint 0.25.1 or later
+        UReg: TypeAlias = pint.UnitRegistry[float]
+    except TypeError:
+        # Python 3.10 / earlier pint version without parametrized generic
+        UReg: TypeAlias = pint.UnitRegistry  # type: ignore[no-redef,misc]
 
 log = logging.getLogger(__name__)
 
@@ -347,7 +354,7 @@ def tutorial_path() -> Path:
 
 
 @pytest.fixture(scope="session")
-def ureg() -> Generator[pint.UnitRegistry, Any, None]:
+def ureg() -> Generator["UReg", Any, None]:
     """Application-wide units registry."""
     # Pylance registers an ApplicationRegistry, so maybe try `follow-untyped-imports`?
     registry = pint.get_application_registry()  # type: ignore[no-untyped-call]

--- a/ixmp/tests/report/test_reporter.py
+++ b/ixmp/tests/report/test_reporter.py
@@ -15,7 +15,7 @@ from ixmp.testing import add_test_data, assert_logs, make_dantzig
 if TYPE_CHECKING:
     from ixmp.core.platform import Platform
     from ixmp.core.scenario import Scenario
-    from ixmp.testing import Runner
+    from ixmp.testing import Runner, UReg
 
 pytestmark = [
     pytest.mark.ixmp4_209,
@@ -65,7 +65,7 @@ def test_reporter_from_scenario(scenario: "Scenario") -> None:
 
 
 def test_platform_units(
-    test_mp: "Platform", caplog: pytest.LogCaptureFixture, ureg: pint.UnitRegistry
+    test_mp: "Platform", caplog: pytest.LogCaptureFixture, ureg: "UReg"
 ) -> None:
     """Test handling of units from ixmp.Platform.
 


### PR DESCRIPTION
Today, our CI Code Quality check broke because of Pint's recent 0.25.1 release. This changed the type hints for `pint.UnitRegistry`, which is now generic over the generic `pint.Quantity` generic parameter. 
Unfortunately, it's not clear to me from the [changelog](https://pint.readthedocs.io/en/stable/changes.html) or [code usage](https://github.com/search?q=repo%3Ahgrecco%2Fpint%20UnitRegistry&type=code) how this generic parameter should be chosen (it doesn't seem to be specified in pint's code at all), but at least mypy knows that 

> Type argument "Quantity[float]" of "UnitRegistry" must be a subtype of "complex | float | int | Decimal | Fraction | number[Any, int | float | complex] | ndarray[Any, Any]"

Of these, I've just picked `float` because it seems very broad -- and our Code Quality check doesn't complain about it. There's no other reason to restrict this choice, though, so we could also try using `Any` explicitly.  

## How to review

- Read the diff and note that the CI checks all pass.
- Let me know whether to try using `Any` instead of `float`.

## PR checklist

<!-- This item is always required. -->
- [ ] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~[ ] Add, expand, or update documentation.~ Just internal adjustment.
- ~[ ] Update release notes.~ Just internal adjustment.
