### PR TITLE
Use `uv publish` for 'publish' CI workflow

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -1,21 +1,37 @@
 name: Build package / publish
 
 on:
+  pull_request:
+    branches: [ main ]
   push:
+    branches: [ main ]
     tags: [ "v*" ]
   release:
     types: [ published ]
-  # Check that package can be built even on PRs
-  pull_request:
-    branches: [ main ]
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  python-version: "3.14"
+  # Uncomment for testing
+  # UV_PUBLISH_URL: https://test.pypi.org/legacy/
+
 jobs:
   publish:
-    uses: iiasa/actions/.github/workflows/publish.yaml@main
-    secrets:
-      PYPI_TOKEN: ${{ secrets.PYPI_TOKEN }}
-      TESTPYPI_TOKEN: ${{ secrets.TESTPYPI_TOKEN }}
+    environment: { name: publish }
+    permissions: { id-token: write }
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v6
+    - uses: astral-sh/setup-uv@v7
+      with: { python-version: "${{ env.python-version }}" }
+    - run: uv build
+    - run: uv publish --trusted-publishing=always
+      if: >-
+        github.event_name == 'release' || (
+          github.event_name == 'push'
+          && startsWith(github.ref, 'refs/tags')
+        )


### PR DESCRIPTION
With pypa/setuptools#4759 resolved, it should now be possible to use `uv publish` and PyPI Trusted Publishing ([1](https://docs.pypi.org/trusted-publishers/), [2](https://docs.astral.sh/uv/guides/package/)) in CI workflows. Prevously (cf. https://github.com/iiasa/ixmp/pull/555#issuecomment-2595176043 and astral-sh/uv#9513) it was necessary to switch away from setuptools as a build backend in order to do that.

This PR makes this change.

Other configuration changes that were needed to enable this, and will be needed for parallel PRs in message_ix and other repos

1. At https://github.com/iiasa/ixmp/settings/environments, create a new environment named 'publish'.
2. At **both**:
   - https://test.pypi.org/manage/project/ixmp/settings/publishing/
   - https://pypi.org/manage/project/ixmp/settings/publishing/

   …under "Add a new publisher" / "GitHub", enter:

   Owner: iiasa
   Repository name: ixmp
   Workflow name: publish.yaml
   Environment name: publish

## How to review

- Check that the alpha release tagged on this branch is published to test.pypi.org.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, CI only
- ~Update release notes.~ ditto
- [x] (after approval) Drop the TEMPORARY commit.
- [x] (after merge) Remove the GitHub Actions secrets for PyPI and TestPyPI; delete the tokens on (Test)PyPI proper.
