### PR TITLE
Adjust for pandas-stubs v2.3.3.251219

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 - repo: https://github.com/pre-commit/mirrors-mypy
-  rev: v1.17.1
+  rev: v1.19.1
   hooks:
   - id: mypy
     pass_filenames: false
@@ -17,7 +17,7 @@ repos:
     - werkzeug
     - xarray
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.12.10
+  rev: v0.14.11
   hooks:
   - id: ruff-check
   - id: ruff-format

--- a/ixmp/core/scenario.py
+++ b/ixmp/core/scenario.py
@@ -719,9 +719,7 @@ class Scenario(TimeSeries):
         if "key" not in data.columns:
             # Form the 'key' column from other columns
             if N_dim > 1 and len(data):
-                data["key"] = (
-                    data[idx_names].astype(str).agg(lambda s: s.tolist(), axis=1)
-                )
+                data["key"] = data[idx_names].astype(str).agg(pd.Series.tolist, axis=1)
             else:
                 data["key"] = data[idx_names[0]]
 

--- a/ixmp/report/__init__.py
+++ b/ixmp/report/__init__.py
@@ -29,7 +29,7 @@ __all__ = [
 
 
 # TODO Remove once genno adds annotation
-@genno.config.handles("filters", iterate=False)  # type: ignore[misc]
+@genno.config.handles("filters", iterate=False)  # type: ignore [untyped-decorator]
 def filters(c: Computer, filters: dict[str, Any]) -> None:
     """Handle the entire ``filters:`` config section."""
     # Ensure a filters dict exists
@@ -48,14 +48,14 @@ def filters(c: Computer, filters: dict[str, Any]) -> None:
             c.graph["config"]["filters"].pop(key, None)
 
 
-@genno.config.handles("rename_dims", iterate=False)  # type: ignore[misc]
+@genno.config.handles("rename_dims", iterate=False)  # type: ignore [untyped-decorator]
 def rename_dims(c: Computer, info: dict[str, str]) -> None:
     """Handle the entire ``rename_dims:`` config section."""
     common.RENAME_DIMS.update(info)
 
 
 # keep=True is different vs. genno.config
-@genno.config.handles("units", iterate=False, discard=False)  # type: ignore[misc]
+@genno.config.handles("units", iterate=False, discard=False)  # type: ignore [untyped-decorator]
 def units(c: Computer, info: dict[str, str]) -> None:
     """Handle the entire ``units:`` config section."""
     genno.config.units(c, info)

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -418,10 +418,8 @@ class TestTimeSeries:
     )
     def test_long_variable_name_jdbc(self, ts: TimeSeries, format: str, N: int) -> None:
         """Variable names up to 256 characters can be added or removed."""
-        data = (DATA[0] if format == "long" else wide(DATA[0])).copy()
-
         # Use long variable name, max 256 characters
-        data.variable = "x" * N
+        data = (DATA[0] if format == "long" else wide(DATA[0])).assign(variable="x" * N)
 
         ts.add_timeseries(data)
         ts.commit("")
@@ -448,10 +446,8 @@ class TestTimeSeries:
         self, ts: TimeSeries, format: str, N: int
     ) -> None:
         """Variable names up to 255 characters can be added or removed."""
-        data = (DATA[0] if format == "long" else wide(DATA[0])).copy()
-
         # Use long variable name, max 255 characters
-        data.variable = "x" * N
+        data = (DATA[0] if format == "long" else wide(DATA[0])).assign(variable="x" * N)
 
         ts.add_timeseries(data)
         ts.commit("")

--- a/ixmp/util/__init__.py
+++ b/ixmp/util/__init__.py
@@ -512,12 +512,12 @@ def format_scenario_list(
         _match = match if isinstance(match, str) else match.pattern
         match = re.compile(".*" + _match + ".*")
 
-    def describe(df: pd.DataFrame) -> "pd.Series[Any]":
+    def describe(df: pd.DataFrame) -> "pd.Series":
         N = len(df)
         min = df.version.min()
         max = df.version.max()
 
-        result: dict[str, int | str] = dict(N=N, range="")
+        result: dict[str, Any] = dict(N=N, range="")
         if N > 1:
             result["range"] = "{}–{}".format(min, max)
             if N != max:

--- a/ixmp/util/__init__.py
+++ b/ixmp/util/__init__.py
@@ -10,7 +10,7 @@ from importlib.util import find_spec
 from itertools import chain, repeat
 from pathlib import Path
 from types import ModuleType
-from typing import IO, TYPE_CHECKING, Any, Literal
+from typing import IO, TYPE_CHECKING, Any, Literal, TypeGuard
 from urllib.parse import urlparse
 from warnings import warn
 
@@ -106,6 +106,11 @@ def as_str_list(
         return [str(arg[idx]) for idx in idx_names]
     else:
         return list(map(str, arg))
+
+
+def is_dict_int_float(value: dict[Any, Any]) -> TypeGuard[dict[int, float]]:
+    """Type guard to narrow type of `value` to :py:`dict[int, float]`."""
+    return all(isinstance(k, int) for k in value.keys())
 
 
 def isscalar(x: object) -> bool:


### PR DESCRIPTION
[pandas-stubs v2.3.3.251219 was released on 2025-12-19](https://pypi.org/project/pandas-stubs/2.3.3.251219/). This caused mypy to fail in the "code quality" job of the "pytest" workflow, for example [here](https://github.com/iiasa/ixmp/actions/runs/20422409423/job/58676518298#step:5:31):

```
ixmp/util/__init__.py:523: error: Incompatible types in assignment (expression has type "str | bytes | date | datetime | timedelta | <7 more items> | complex | integer[Any] | floating[Any] | complexfloating[Any, Any]", target has type "int | str")  [assignment]
ixmp/core/timeseries.py:403: error: Argument 4 to "set_data" of "JDBCBackend" has incompatible type "dict[Hashable, float]"; expected "dict[int, float]"  [arg-type]
ixmp/core/timeseries.py:403: error: Argument 4 to "set_data" of "IXMP4Backend" has incompatible type "dict[Hashable, float]"; expected "dict[int, float]"  [arg-type]
ixmp/core/timeseries.py:504: error: Argument 2 to "delete" of "JDBCBackend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:504: error: Argument 2 to "delete" of "IXMP4Backend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:504: error: Argument 3 to "delete" of "JDBCBackend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:504: error: Argument 3 to "delete" of "IXMP4Backend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:504: error: Argument 4 to "delete" of "JDBCBackend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:504: error: Argument 4 to "delete" of "IXMP4Backend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:504: error: Argument 6 to "delete" of "JDBCBackend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:504: error: Argument 6 to "delete" of "IXMP4Backend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:554: error: Argument 2 to "delete_geo" of "JDBCBackend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:554: error: Argument 3 to "delete_geo" of "JDBCBackend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:554: error: Argument 4 to "delete_geo" of "JDBCBackend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/timeseries.py:554: error: Argument 6 to "delete_geo" of "JDBCBackend" has incompatible type "Hashable"; expected "str"  [arg-type]
ixmp/core/scenario.py:723: error: No overload variant matches argument types "Callable[[Any], Any]", "int"  [call-overload]
ixmp/core/scenario.py:723: note: Possible overload variants:
ixmp/core/scenario.py:723: note:     def aggregate(self, func: Callable[[VarArg(Any), KwArg(Any)], Any] | str | ufunc | Mapping[Any, Callable[[VarArg(Any), KwArg(Any)], Any] | str | ufunc], axis: Literal['index', 0] | Literal['columns', 1] = ..., **kwargs: Any) -> Series[Any]
ixmp/core/scenario.py:723: note:     def aggregate(self, func: list[Callable[[VarArg(Any), KwArg(Any)], Any] | str | ufunc] | Mapping[Any, Callable[[VarArg(Any), KwArg(Any)], Any] | str | ufunc | Sequence[Callable[[VarArg(Any), KwArg(Any)], Any] | str | ufunc]] | None = ..., axis: Literal['index', 0] | Literal['columns', 1] = ..., **kwargs: Any) -> DataFrame
ixmp/tests/core/test_timeseries.py:424: error: "DataFrame" has no attribute "variable"  [attr-defined]
ixmp/tests/core/test_timeseries.py:454: error: "DataFrame" has no attribute "variable"  [attr-defined]
Found 18 errors in 4 files (checked 59 source files)
```

The PR adjusts to the new version, and also updates the mypy and ruff versions.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A, CI changes only.
- ~Update release notes.~
