### PR TITLE
Test against/adjust for pandas 3.0.0, pytest 9

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -34,11 +34,24 @@ jobs:
         - "3.14"  # Latest supported by ixmp
         gams-version:
         - "45.7.0" # Oldest version of gamsapi allowed by pyproject.toml
+        extra-id:
+        - ""
+        install-extra:
+        - ""
+
+        # Extra job that forces installation of pandas >=3,
+        # notwithstanding other dependencies that bound pandas <2.4.
+        include:
+        - os: ubuntu-latest
+          python-version: "3.14"
+          gams-version: "45.7.0"
+          extra-id: "-pandas-3"
+          install-extra: uv pip install "pandas >=3"
 
       fail-fast: false
 
     runs-on: ${{ matrix.os }}
-    name: ${{ matrix.os }}-py${{ matrix.python-version }}
+    name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.extra-id }}
 
     steps:
     - uses: actions/checkout@v6
@@ -98,6 +111,7 @@ jobs:
         uv pip install \
             "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/fixes-for-ixmp-support-september-2025; python_version > '3.9'" \
             .[docs]
+        ${{ matrix.install-extra }}
       shell: bash
 
     - name: "Install libpng-dev"  # for R 'png', required by reticulate

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ See [`doc/README.rst`](doc/README.rst) for further details.
 
 ## License
 
-Copyright © 2017–2025 IIASA Energy, Climate, and Environment (ECE) program
+Copyright © 2017–2026 IIASA Energy, Climate, and Environment (ECE) program
 
 `ixmp` is licensed under the Apache License, Version 2.0 (the "License"); you
 may not use the files in this repository except in compliance with the License.

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -38,6 +38,8 @@ All changes
   - Use :mod:`ixmp4` version 0.14.x (:pull:`613`).
 
 - Support for Python 3.9 is dropped (:pull:`602`), as it has reached end-of-life.
+- :mod:`ixmp` is tested and compatible with `Pandas 3.0.0 <https://pandas.pydata.org/pandas-docs/stable/whatsnew/v3.0.0.html>`_,
+  released 2026-01-21 (:pull:`627`, :issue:`626`).
 - Improve :class:`.IXMP4Backend` (:pull:`581`):
 
   - Support creation and modification of 0-dimensional parameters (:class:`ixmp4.Scalar`).

--- a/doc/api-backend.rst
+++ b/doc/api-backend.rst
@@ -94,12 +94,8 @@ IXMP4Backend
    The same holds for IXMP4Backend.
    Consequently you **may** but probably **should not** use it for 'production' scientific scenario work.
 
-   As of version 0.14, :mod:`ixmp4` supports only Python 3.10 and above.
-
-   - If you want to use IXMP4Backend,
-     please ensure you are using a sufficiently recent Python version.
-   - If you are restricted to Python 3.9 and below,
-     please use JDBCBackend instead.
+   As of version 0.14.0, :mod:`ixmp4` is not compatible with Pandas 3.0.0.
+   If you want to use IXMP4Backend, please install a version of `pandas < 3`.
 
 .. automodule:: ixmp.backend.ixmp4
    :members:

--- a/ixmp/backend/ixmp4.py
+++ b/ixmp/backend/ixmp4.py
@@ -123,7 +123,7 @@ def _align_dtypes_for_filters(
 ) -> None:
     """Convert `filters` values to types enabling `data.isin()`."""
     # TODO Is this really the proper way to handle these types?
-    TYPE_MAP = {"object": str, "int64": int}
+    TYPE_MAP = {"object": str, "int64": int, "str": str}
 
     for column_name in filters.keys():
         # Guard against empty filters like {'time': []}
@@ -617,11 +617,11 @@ class IXMP4Backend(CachingBackend):
             model_name=_model, scenario_name=_scenario, version=_version
         )
 
-        meta_df = pd.DataFrame.from_dict(
-            data=meta, orient="index", columns=["value"]
-        ).reset_index(names="key")
-        meta_df["run__id"] = run.id
-
+        meta_df = (
+            pd.DataFrame.from_dict(data=meta, orient="index", columns=["value"])
+            .reset_index(names="key")
+            .assign(run__id=run.id)
+        )
         try:
             self._backend.meta.bulk_upsert(df=meta_df)
         except KeyError as e:

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -1255,7 +1255,7 @@ class JDBCBackend(CachingBackend):
                 _get("Levels", "lvl")
                 _get("Marginals", "mrg")
 
-            result = pd.concat(columns, axis=1, copy=False)
+            result = pd.concat(columns, axis=1)
         elif ix_type == "set":
             # Index sets
             # dtype=object is to silence a warning in pandas 1.0

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -39,6 +39,7 @@ from ixmp.core.platform import Platform
 from ixmp.core.scenario import Scenario
 from ixmp.core.timeseries import TimeSeries
 from ixmp.util import as_str_list
+from ixmp.util.pandas import STRING_DTYPE
 
 from .base import CachingBackend
 from .common import FIELDS, CrossPlatformClone, ItemType
@@ -1258,7 +1259,7 @@ class JDBCBackend(CachingBackend):
         elif ix_type == "set":
             # Index sets
             # dtype=object is to silence a warning in pandas 1.0
-            result = pd.Series(item.getCol(0, jList)[:], dtype=object)
+            result = pd.Series(item.getCol(0, jList)[:], dtype=STRING_DTYPE)
         elif ix_type == "par":
             # Scalar parameter
             result = dict(

--- a/ixmp/core/timeseries.py
+++ b/ixmp/core/timeseries.py
@@ -22,11 +22,23 @@ from ixmp.util import (
     year_list,
 )
 from ixmp.util.ixmp4 import is_ixmp4backend
+from ixmp.util.pandas import STRING_DTYPE
 
 if TYPE_CHECKING:
     from ixmp.types import VersionType
 
 log = logging.getLogger(__name__)
+
+#: Pandas dtypes returned by :meth:`TimeSeries.get_geodata`.
+GEO_DTYPES = {
+    "meta": int,
+    "region": STRING_DTYPE,
+    "subannual": STRING_DTYPE,
+    "unit": STRING_DTYPE,
+    "value": STRING_DTYPE,
+    "variable": STRING_DTYPE,
+    "year": int,
+}
 
 
 class TimeSeries:
@@ -564,13 +576,12 @@ class TimeSeries:
         :class:`pandas.DataFrame`
             Specified data.
         """
-        # TODO remove astype here; this is the responsibility of Backend
         return (
             pd.DataFrame(
                 self.platform._backend.get_geo(self), columns=FIELDS["ts_get_geo"]
             )
             .reset_index(drop=True)
-            .astype({"meta": "int64", "year": "int64"})
+            .astype(GEO_DTYPES)
         )
 
     # Metadata

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -52,7 +52,6 @@ from typing_extensions import override
 
 from ixmp import Platform, Scenario, cli
 from ixmp import config as ixmp_config
-from ixmp.backend import available
 from ixmp.backend.ixmp4 import IXMP4Backend
 from ixmp.util.ixmp4 import format_url, is_ixmp4backend, is_sqlalchemybackend
 
@@ -173,12 +172,11 @@ def pytest_report_collectionfinish(
     config: pytest.Config, start_path: Path, items: Sequence[Any]
 ) -> list[str]:
     """Show messages if a database error means IXMP4Backend tests cannot be run."""
-    from ixmp.backend import available
-
+    backends = config.stash[KEY_BACKENDS]
     db_name = config.stash[KEY_IXMP4_PG_NAME]
 
     messages = []
-    if "ixmp4" in available() and db_name.startswith(PG_NAME_NONE):  # pragma: no cover
+    if "ixmp4" in backends and db_name.startswith(PG_NAME_NONE):  # pragma: no cover
         messages += [
             "",
             "No PostgreSQL database available → tests of IXMP4Backend will be skipped:",
@@ -204,7 +202,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     - :data:`.jdbc._GC_AGGRESSIVE` is set to :any:`False` to disable aggressive garbage
       collection, which can be slow.
     """
-    from ixmp.backend import jdbc
+    from ixmp.backend import available, jdbc
 
     if not session.config.option.ixmp_user_config:
         ixmp_config.clear()
@@ -216,6 +214,8 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     backends = session.config.stash[KEY_BACKENDS] = sorted(available())
 
     jdbc._GC_AGGRESSIVE = False
+
+    db_name = PG_NAME_NONE
 
     if "ixmp4" in backends:
         # Connect to a PostgreSQL server and create a test database for this worker
@@ -240,7 +240,7 @@ def pytest_sessionstart(session: pytest.Session) -> None:
             # Store for pytest_sessionfinish()
             session.config.stash[KEY_ENGINE] = engine
 
-        session.config.stash[KEY_IXMP4_PG_NAME] = db_name
+    session.config.stash[KEY_IXMP4_PG_NAME] = db_name
 
 
 def pytest_sessionfinish(

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -132,6 +132,11 @@ MARK = {
         and ("2025" in _uname.release or _uname.version >= "10.0.26100"),
         reason="https://github.com/pytest-dev/pytest/issues/10843",
     ),
+    "ixmp4-pandas-3": pytest.mark.xfail(
+        raises=AttributeError,
+        # 'str' object has no attribute 'value' in ixmp4.data.db.meta.repository
+        reason="XFAIL for IXMP4Backend only",
+    ),
 }
 
 # Pytest hooks

--- a/ixmp/tests/core/test_meta.py
+++ b/ixmp/tests/core/test_meta.py
@@ -48,7 +48,6 @@ def mp(test_mp_f: ixmp.Platform) -> Generator[ixmp.Platform, Any, None]:
 # DB Model. ixmp4 can only store meta entries for a Run, which is always linked to Model
 # AND Scenario. So the tests here that call *_meta() without full arguments won't pass
 # on ixmp4.
-@pytest.mark.ixmp4_not_yet
 class TestMeta:
     @pytest.mark.parametrize("meta", META_ENTRIES)
     def test_set_meta_missing_argument(
@@ -63,6 +62,7 @@ class TestMeta:
         with pytest.raises(ValueError):
             mp.set_meta(meta, scenario=DANTZIG["scenario"], version=0)
 
+    @pytest.mark.ixmp4_not_yet
     @pytest.mark.parametrize("meta", META_ENTRIES)
     def test_set_get_meta(
         self,
@@ -74,6 +74,7 @@ class TestMeta:
         obs = mp.get_meta(model=DANTZIG["model"])
         assert obs == meta
 
+    @pytest.mark.ixmp4_not_yet
     @pytest.mark.parametrize("meta", META_ENTRIES)
     def test_unique_meta(
         self,
@@ -107,6 +108,7 @@ class TestMeta:
         with pytest.raises(Exception, match=expected):
             mp.set_meta(meta, **DANTZIG, version=scenario.version)
 
+    @pytest.mark.ixmp4_not_yet
     @pytest.mark.parametrize("meta", META_ENTRIES)
     def test_set_get_meta_equals(
         self,
@@ -118,6 +120,7 @@ class TestMeta:
         obs_meta = mp.get_meta(scenario=DANTZIG["scenario"])
         assert obs_meta == initial_meta
 
+    @pytest.mark.ixmp4_not_yet
     @pytest.mark.parametrize("meta", META_ENTRIES)
     def test_unique_meta_model_scenario(
         self,
@@ -143,6 +146,7 @@ class TestMeta:
         with pytest.raises(Exception, match=expected):
             mp.set_meta(meta, **dantzig2)
 
+    @pytest.mark.ixmp4_not_yet
     @pytest.mark.parametrize("meta", META_ENTRIES)
     def test_get_meta_strict(
         self,
@@ -247,6 +251,7 @@ class TestMeta:
         )
         assert obs6_strict == meta_scen
 
+    @pytest.mark.ixmp4_not_yet
     @pytest.mark.parametrize("meta", META_ENTRIES)
     def test_unique_meta_scenario(
         self,
@@ -274,6 +279,7 @@ class TestMeta:
         with pytest.raises(Exception, match=expected):
             mp.set_meta(meta, model=DANTZIG["model"])
 
+    @pytest.mark.ixmp4_not_yet
     def test_meta_partial_overwrite(self, mp: ixmp.Platform) -> None:
         meta1 = {
             "sample_string": 3.0,
@@ -293,6 +299,7 @@ class TestMeta:
         obs = scen.get_meta()
         assert obs == expected
 
+    @pytest.mark.ixmp4_not_yet
     def test_remove_meta(self, mp: ixmp.Platform) -> None:
         meta = {"sample_int": 3.0, "another_string": "string_value"}
         remove_key = "another_string"
@@ -303,6 +310,7 @@ class TestMeta:
         obs = mp.get_meta(**DANTZIG)
         assert expected == obs
 
+    @pytest.mark.ixmp4_not_yet
     def test_remove_invalid_meta(self, mp: ixmp.Platform) -> None:
         """
         Removing nonexisting meta entries or None shouldn't result in any meta
@@ -316,6 +324,7 @@ class TestMeta:
         obs = mp.get_meta(**DANTZIG)
         assert obs == SAMPLE_META
 
+    @pytest.mark.ixmp4_not_yet
     def test_set_and_remove_meta_scenario(self, mp: ixmp.Platform) -> None:
         """
         Test partial overwriting and meta deletion on scenario level.
@@ -337,6 +346,7 @@ class TestMeta:
         obs = scen.get_meta()
         assert obs == expected
 
+    @pytest.mark.ixmp4_not_yet
     def test_scenario_delete_meta_warning(self, mp: ixmp.Platform) -> None:
         """
         Scenario.delete_meta works but raises a deprecation warning.
@@ -355,6 +365,7 @@ class TestMeta:
         obs = scen.get_meta()
         assert obs == expected
 
+    @pytest.mark.ixmp4_not_yet
     def test_meta_arguments(self, mp: ixmp.Platform) -> None:
         """Set scenario meta with key-value arguments"""
         meta = {"sample_int": 3}
@@ -366,6 +377,7 @@ class TestMeta:
         scen2.set_meta(*meta.popitem())
         assert scen.get_meta() == scen2.get_meta()
 
+    @pytest.mark.ixmp4_not_yet
     def test_update_meta_lists(self, mp: ixmp.Platform) -> None:
         """Set metadata categories having list/array values."""
         SAMPLE_META = {"list_category": ["a", "b", "c"]}
@@ -378,6 +390,7 @@ class TestMeta:
         obs = mp.get_meta(model=DANTZIG["model"])
         assert obs == SAMPLE_META
 
+    @pytest.mark.ixmp4_not_yet
     def test_meta_mixed_list(self, mp: ixmp.Platform) -> None:
         """Set metadata categories having list/array values."""
         meta = {"mixed_category": ["string", 0.01, True]}

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -21,6 +21,7 @@ from ixmp.testing import (
 )
 from ixmp.testing.data import populate_test_platform
 from ixmp.util.ixmp4 import is_ixmp4backend
+from ixmp.util.pandas import STRING_DTYPE
 
 if TYPE_CHECKING:
     from ixmp.core.platform import Platform
@@ -927,7 +928,7 @@ def test_filter_str(scen_empty: "Scenario") -> None:
     # Elements are stored and returned as str
     s = scen.set("s")
     assert isinstance(s, pd.Series)
-    assert s.dtype == "object"
+    assert s.dtype == STRING_DTYPE
     assert all(isinstance(element, str) for element in s)
     assert expected == cast("pd.Series[str]", s.tolist())
 

--- a/ixmp/tests/core/test_scenario.py
+++ b/ixmp/tests/core/test_scenario.py
@@ -14,6 +14,7 @@ from pandas.testing import assert_frame_equal
 import ixmp
 from ixmp.testing import (
     KEY_BACKENDS,
+    MARK,
     _platform_fixture,
     assert_logs,
     make_dantzig,
@@ -721,6 +722,7 @@ class TestScenario:
             assert "'notapackage'.'(not installed)'" in result.stdout.decode()
 
     # Combined tests
+    @MARK["ixmp4-pandas-3"]
     def test_meta(
         self, mp: "Platform", test_dict: dict[str, bool | float | int | str]
     ) -> None:
@@ -757,6 +759,7 @@ class TestScenario:
             # NOTE Triggering the error on purpose
             scen.set_meta("test_string", complex(1, 1))  # type: ignore[arg-type]
 
+    @MARK["ixmp4-pandas-3"]
     def test_meta_bulk(
         self, mp: "Platform", test_dict: dict[str, bool | float | int | str]
     ) -> None:

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -9,7 +9,6 @@ import pytest
 from numpy import testing as npt
 from pandas.testing import assert_frame_equal
 
-import ixmp.backend
 from ixmp import IAMC_IDX, Scenario, TimeSeries
 from ixmp.testing import DATA, MARK, models
 from ixmp.util.ixmp4 import is_ixmp4backend
@@ -18,8 +17,12 @@ if TYPE_CHECKING:
     from ixmp.core.platform import Platform
     from ixmp.types import TimeSeriesIdentifiers
 
-if "ixmp4" in ixmp.backend.available():
+try:
     import sqlalchemy.exc
+except ImportError:  # pragma: no cover
+    MARKS: list[pytest.MarkDecorator] = []
+else:
+    MARKS = [pytest.mark.xfail(raises=sqlalchemy.exc.DataError)]
 
 # string columns for timeseries checks
 IDX_COLS = ["region", "variable", "unit", "year"]
@@ -437,10 +440,7 @@ class TestTimeSeries:
         (
             255,
             # This fails at add_timeseries()
-            pytest.param(
-                256,
-                marks=pytest.mark.xfail(raises=sqlalchemy.exc.DataError),
-            ),
+            pytest.param(256, marks=MARKS),
         ),
     )
     def test_long_variable_name_ixmp4(

--- a/ixmp/tests/core/test_timeseries.py
+++ b/ixmp/tests/core/test_timeseries.py
@@ -11,7 +11,7 @@ from pandas.testing import assert_frame_equal
 
 import ixmp.backend
 from ixmp import IAMC_IDX, Scenario, TimeSeries
-from ixmp.testing import DATA, models
+from ixmp.testing import DATA, MARK, models
 from ixmp.util.ixmp4 import is_ixmp4backend
 
 if TYPE_CHECKING:
@@ -209,6 +209,7 @@ class TestTimeSeries:
         with pytest.raises(ValueError):
             ts.add_timeseries(DATA[0].drop("unit", axis=1))
 
+    @MARK["ixmp4-pandas-3"]
     def test_discard_changes(self, ts: TimeSeries) -> None:
         ts.commit("")
         assert 0 == len(ts.timeseries())

--- a/ixmp/tests/test_util.py
+++ b/ixmp/tests/test_util.py
@@ -1,6 +1,7 @@
 """Tests for ixmp.util."""
 
 import logging
+import re
 from contextlib import nullcontext
 from typing import TYPE_CHECKING
 
@@ -198,11 +199,9 @@ def test_discard_on_error(
             s.add_par("d", pd.DataFrame([["foo", "bar", 1.0, "kg"]]))
 
     # Exception was caught and logged
-    assert caplog.messages[-3].startswith("Avoid locking ")
-    assert [
-        "Discard scenario changes",
-        "Close database connection",
-    ] == caplog.messages[-2:]
+    assert any(re.match("Avoid locking ", msg) for msg in caplog.messages)
+    assert any(re.search("[Dd]iscard scenario changes", msg) for msg in caplog.messages)
+    assert "Close database connection" == caplog.messages[-1]
 
     # Re-load the mp and the scenario
     with (

--- a/ixmp/util/__init__.py
+++ b/ixmp/util/__init__.py
@@ -17,6 +17,8 @@ from warnings import warn
 import numpy as np
 import pandas as pd
 
+from ixmp.util.pandas import STRING_DTYPE
+
 if TYPE_CHECKING:
     from ixmp import Platform, Scenario, TimeSeries
     from ixmp.types import Filters, ParData, PlatformInfo, TimeSeriesIdentifiers
@@ -171,7 +173,7 @@ def diff(
             kw = merge_kw | dict(left_index=True, right_index=True)
 
         # Merge the data from each side
-        return pd.merge(x, y, **kw).astype({"value_a": float})
+        return pd.merge(x, y, **kw).astype({"unit_a": STRING_DTYPE, "value_a": float})
 
     # Iterator over parameter data from `b`, followed by name="~ end"/empty data frame
     items_b = chain(b.iter_par_data(filters=filters), repeat(("~ end", pd.DataFrame())))

--- a/ixmp/util/__init__.py
+++ b/ixmp/util/__init__.py
@@ -234,12 +234,13 @@ def discard_on_error(ts: "TimeSeries") -> Generator[None, Any, None]:
             + str(e).splitlines()[0].strip('"')
         )
 
+        msg = f"Discard {type(ts).__name__.lower()} changes"
         try:
             ts.discard_changes()
-        except Exception:  # pragma: no cover
-            pass  # Some exception trying to discard changes()
+        except Exception as e:  # pragma: no cover
+            log.error(f"When trying to {msg.lower()}: {type(e).__name__}: {e}")
         else:
-            log.info(f"Discard {ts.__class__.__name__.lower()} changes")
+            log.info(msg)
 
         mp.close_db()
         log.info("Close database connection")

--- a/ixmp/util/ixmp4.py
+++ b/ixmp/util/ixmp4.py
@@ -3,6 +3,8 @@ from typing import TYPE_CHECKING, Any, Literal, TypeGuard
 
 import pandas as pd
 
+from .pandas import SettingWithCopyWarning
+
 if TYPE_CHECKING:
     from ixmp4.data.backend.db import SqlAlchemyBackend
 
@@ -43,8 +45,6 @@ def configure_logging_and_warnings() -> None:
     """
     import logging
     import warnings
-
-    from pandas.errors import SettingWithCopyWarning
 
     logging.getLogger("ixmp4.data.db.base").setLevel(logging.WARNING + 1)
 

--- a/ixmp/util/pandas.py
+++ b/ixmp/util/pandas.py
@@ -1,0 +1,28 @@
+"""Compatibility utilities for :mod:`pandas`.
+
+These are used to allow code to work with pandas version 2.x and 3.x.
+"""
+
+from importlib.metadata import version
+from typing import Any
+
+import numpy as np
+import pandas as pd
+
+__all__ = [
+    "SettingWithCopyWarning",
+    "STRING_DTYPE",
+]
+
+if version("pandas") >= "3.":
+    SettingWithCopyWarning: type[Warning] = Warning
+
+    #: Default dtype for string columns. :class:`pandas.StringDtype` is available in
+    #: pandas 2.3.3, but is not the default, so cannot be used directly.
+    STRING_DTYPE: Any = pd.StringDtype(na_value=np.nan)
+else:
+    import pandas.errors
+
+    SettingWithCopyWarning = pandas.errors.SettingWithCopyWarning
+
+    STRING_DTYPE = object

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,7 +68,7 @@ tests = [
   "ixmp[ixmp4,report,tutorial]",
   "memory_profiler",
   "nbclient >= 0.5",
-  "pytest >= 5",
+  "pytest >= 9",
   "pytest-benchmark",
   "pytest-cov",
   "pytest-httpserver",
@@ -130,16 +130,18 @@ module = [
 ]
 ignore_missing_imports = true
 
-[tool.pytest.ini_options]
-# Disable faulthandler plugin on Windows to prevent spurious console noise; see
-# - https://github.com/jpype-project/jpype/issues/561
-# - https://github.com/iiasa/ixmp/issues/229
-# - https://github.com/iiasa/ixmp/issues/247
-addopts = """
-  -m "not rixmp and not performance"
-  -p no:faulthandler
-  --benchmark-skip
-  --cov=ixmp --cov-report="""
+[tool.pytest]
+addopts = [
+  '-m "not rixmp and not performance"',
+  # Disable faulthandler plugin on Windows to prevent spurious console noise; see
+  # - https://github.com/jpype-project/jpype/issues/561
+  # - https://github.com/iiasa/ixmp/issues/229
+  # - https://github.com/iiasa/ixmp/issues/247
+  "-p no:faulthandler",
+  "--benchmark-skip",
+  "--cov=ixmp",
+  "--cov-report=",
+]
 # Parallel to .util.ixmp4.configure_logging_and_warnings(), prevent warnings
 # from appearing in the test output
 filterwarnings = [
@@ -157,8 +159,11 @@ markers = [
   "ixmp4_never: tests that ixmp4 will never implement",
   "ixmp4_not_yet: tests that ixmp4 does not yet support"
 ]
+minversion = "9.0"
+strict_config = true
+strict_markers = true
 tmp_path_retention_policy = "none"
-usefixtures = "tmp_env"
+usefixtures = ["tmp_env"]
 
 [tool.ruff.lint]
 select = ["C9", "E", "F", "I", "W"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -145,7 +145,8 @@ addopts = """
 filterwarnings = [
   "ignore:Accessing the 'model_fields' :DeprecationWarning:ixmp4.db.filters",
   # NB The following don't work if a message regex is added
-  "ignore::pandas.errors.SettingWithCopyWarning:ixmp4.data.db.base",
+  # NB This is SettingWithCopyWarning(Warning), removed in pandas 3.0.0.
+  "ignore:::ixmp4.data.db.base",
   "ignore::DeprecationWarning:sqlalchemy.sql.schema",
 ]
 markers = [


### PR DESCRIPTION
Closes #626:
- Add a CI job "ubuntu-latest-py3.14-pandas-3" that forcibly installs pandas 3 for testing. In the future, if/when gamsapi removes its bound of `pandas <2.4`, this job can be removed, and perhaps replaced with another that forces pandas < 3 to ensure backwards compatibility.

Also:

- [Pytest 9 was released 2025-12-06](https://docs.pytest.org/en/stable/changelog.html). The PR adjusts to some failures apparently triggered by this change.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand~ Adjust tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.