### PR TITLE
Adjust type hints for genno 1.30.0

### DIFF
--- a/doc/requirements.in
+++ b/doc/requirements.in
@@ -1,6 +1,7 @@
 # Only specify the packages necessary for [docs]
 
-gitpython==3.1.47
+# Last updated per https://github.com/iiasa/ixmp/pull/636
+gitpython>=3.1.50
 numpydoc==1.8.0
 pandas==2.2.3
 
@@ -15,4 +16,6 @@ requests>=2.33.0
 sphinx==8.2.3
 sphinx-rtd-theme==3.0.2
 sphinxcontrib-bibtex==2.6.5
-urllib3==2.6.3
+
+# Last updated per https://github.com/iiasa/ixmp/pull/637
+urllib3>=2.7.0

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -16,7 +16,7 @@ docutils==0.21.2
     #   sphinxcontrib-bibtex
 gitdb==4.0.10
     # via gitpython
-gitpython==3.1.47
+gitpython==3.1.50
     # via -r requirements.in
 idna==3.7
     # via requests
@@ -95,7 +95,7 @@ tabulate==0.9.0
     # via numpydoc
 tzdata==2025.2
     # via pandas
-urllib3==2.6.3
+urllib3==2.7.0
     # via
     #   -r requirements.in
     #   requests

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 ScenarioClass: type[ixmp.Scenario] = ixmp.Scenario
 
 
-class VersionType(click.ParamType):
+class VersionType(click.ParamType[int | Literal["new"]]):
     """A Click parameter type that accepts :class:`int` or 'all'."""
 
     name = "version"  # https://github.com/pallets/click/issues/411

--- a/ixmp/cli.py
+++ b/ixmp/cli.py
@@ -139,7 +139,7 @@ def report(context: dict[str, Any], config: str | Path | None, key: str | None) 
 
     # Print the target
     # TODO Remove once genno adds annotation
-    print(r.get(key).to_series().sort_index())  # type: ignore[no-untyped-call]
+    print(r.get(key).to_series().sort_index())
 
 
 @main.command("show-versions")

--- a/ixmp/report/__init__.py
+++ b/ixmp/report/__init__.py
@@ -29,7 +29,7 @@ __all__ = [
 
 
 # TODO Remove once genno adds annotation
-@genno.config.handles("filters", iterate=False)  # type: ignore [untyped-decorator]
+@genno.config.handles("filters", iterate=False)
 def filters(c: Computer, filters: dict[str, Any]) -> None:
     """Handle the entire ``filters:`` config section."""
     # Ensure a filters dict exists
@@ -48,14 +48,14 @@ def filters(c: Computer, filters: dict[str, Any]) -> None:
             c.graph["config"]["filters"].pop(key, None)
 
 
-@genno.config.handles("rename_dims", iterate=False)  # type: ignore [untyped-decorator]
+@genno.config.handles("rename_dims", iterate=False)
 def rename_dims(c: Computer, info: dict[str, str]) -> None:
     """Handle the entire ``rename_dims:`` config section."""
     common.RENAME_DIMS.update(info)
 
 
 # keep=True is different vs. genno.config
-@genno.config.handles("units", iterate=False, discard=False)  # type: ignore [untyped-decorator]
+@genno.config.handles("units", iterate=False, discard=False)
 def units(c: Computer, info: dict[str, str]) -> None:
     """Handle the entire ``units:`` config section."""
     genno.config.units(c, info)

--- a/ixmp/report/reporter.py
+++ b/ixmp/report/reporter.py
@@ -18,7 +18,7 @@ class Reporter(Computer):
 
     def __init__(self, *args: Any, **kwargs: Any) -> None:
         # TODO Remove once genno adds annotation
-        super().__init__(*args, **kwargs)  # type: ignore[no-untyped-call]
+        super().__init__(*args, **kwargs)
 
         # Append ixmp.report.operator to the modules in which the Computer will look up
         # names

--- a/ixmp/tests/report/test_operator.py
+++ b/ixmp/tests/report/test_operator.py
@@ -67,12 +67,12 @@ def test_get_remove_ts(
 
     # Can be used through a Computer
 
-    c = Computer()  # type: ignore[no-untyped-call]
+    c = Computer()
     c.require_compat("ixmp.report.operator")
     c.add("scenario", ts)
 
     key = c.add("test1", "get_ts", "scenario", filters=dict(variable="GDP"))
-    result1 = c.get(key)  # type: ignore[no-untyped-call]
+    result1 = c.get(key)
     assert 3 == len(result1)
 
     # remove_ts() can be used through Computer
@@ -80,7 +80,7 @@ def test_get_remove_ts(
 
     # Task runs, logs
     with assert_logs(caplog, "Remove 5 of 5 (1964 <= year) rows of time series data"):
-        c.get(key)  # type: ignore[no-untyped-call]
+        c.get(key)
 
     # See comment above; only one row is removed
     assert 6 - 3 == len(ts.timeseries())
@@ -133,7 +133,7 @@ def test_update_scenario(
     assert 6 == N_before
 
     # A Computer used as calculation engine
-    c = Computer()  # type: ignore[no-untyped-call]
+    c = Computer()
 
     # Target Scenario for updating data
     c.add("target", scen)
@@ -152,7 +152,7 @@ def test_update_scenario(
     # Trigger the computation that results in data being added
     with assert_logs(caplog, f"'d' ← {len(data)} rows", at_level=logging.INFO):
         # Returns nothing
-        assert c.get("test 1") is None  # type: ignore[no-untyped-call]
+        assert c.get("test 1") is None
 
     # Rows were added to the parameter
     assert len(scen.par("d")) == N_before + len(data)
@@ -170,7 +170,7 @@ def test_update_scenario(
 
     # Trigger the computation
     with assert_logs(caplog, f"'d' ← {len(data)} rows", at_level=logging.INFO):
-        c.get("test 2")  # type: ignore[no-untyped-call]
+        c.get("test 2")
 
     # All the rows have been updated
     # TODO We should probably rework scen.par() to only return pd.DataFrame and handle
@@ -184,7 +184,7 @@ def test_update_scenario(
 
 def test_store_ts(caplog: pytest.LogCaptureFixture, test_mp: "Platform") -> None:
     # Computer and target scenario
-    c = Computer()  # type: ignore[no-untyped-call]
+    c = Computer()
 
     # Target scenario
     model_name = __name__
@@ -213,7 +213,7 @@ def test_store_ts(caplog: pytest.LogCaptureFixture, test_mp: "Platform") -> None
     assert 0 == len(scen.timeseries())
 
     # The computation runs successfully
-    c.get("test 1")  # type: ignore[no-untyped-call]
+    c.get("test 1")
 
     # All rows from both inputs are present
     assert len(input_1) + len(input_2) == len(scen.timeseries())
@@ -228,7 +228,7 @@ def test_store_ts(caplog: pytest.LogCaptureFixture, test_mp: "Platform") -> None
 
     # Succeeds with default strict=False
     caplog.clear()
-    c.get("test 2")  # type: ignore[no-untyped-call]
+    c.get("test 2")
 
     # A message is logged
     r = caplog.record_tuples[-1]
@@ -246,4 +246,4 @@ def test_store_ts(caplog: pytest.LogCaptureFixture, test_mp: "Platform") -> None
         ComputationError,
         match=re.compile("computing 'test 2' using:.*region = Moon", flags=re.DOTALL),
     ):
-        c.get("test 2")  # type: ignore[no-untyped-call]
+        c.get("test 2")

--- a/ixmp/tests/report/test_reporter.py
+++ b/ixmp/tests/report/test_reporter.py
@@ -46,7 +46,7 @@ def test_configure(
     scen = make_dantzig(test_mp, request=request)
     rep = Reporter.from_scenario(scen)
     assert "d:i_renamed-j" in rep, rep.graph.keys()
-    assert ["seattle", "san-diego"] == rep.get("i_renamed")  # type: ignore[no-untyped-call]
+    assert ["seattle", "san-diego"] == rep.get("i_renamed")
 
     # Original name 'i' are not found in the reporter
     assert "d:i-j" not in rep, rep.graph.keys()
@@ -102,7 +102,7 @@ def test_platform_units(
 
         # Parsing units with invalid chars raises an intelligible exception
         with pytest.raises(ComputationError, match=msg.format(expr, chars)):
-            rep.get(x_key)  # type: ignore[no-untyped-call]
+            rep.get(x_key)
 
     # Now using parseable but unrecognized units
     x["unit"] = "USD/kWa"
@@ -113,7 +113,7 @@ def test_platform_units(
 
     # Protect from --verbose command-line option, which sets the level to DEBUG
     with caplog.at_level(logging.INFO):
-        rep.get(x_key)  # type: ignore[no-untyped-call]
+        rep.get(x_key)
 
     # NB cannot use assert_logs here. report.util.parse_units uses the pint
     #    application registry, so depending which tests are run and in which order, this
@@ -128,7 +128,7 @@ def test_platform_units(
     scen.add_par("x", x)
 
     caplog.clear()
-    rep.get(x_key)  # type: ignore[no-untyped-call]
+    rep.get(x_key)
     assert not any("Add unit definition: USD = [USD]" in m for m in caplog.messages)
 
     # Mixed units are discarded
@@ -138,7 +138,7 @@ def test_platform_units(
     with assert_logs(
         caplog, ["x: mixed units", "kg", "USD/pkm", "discarded"], at_level=logging.INFO
     ):
-        rep.get(x_key)  # type: ignore[no-untyped-call]
+        rep.get(x_key)
 
     # Configured unit substitutions are applied
     rep.graph["config"]["units"] = dict(apply=dict(x="USD/pkm"))
@@ -146,7 +146,7 @@ def test_platform_units(
     with assert_logs(
         caplog, "x: replace units dimensionless with USD/pkm", at_level=logging.INFO
     ):
-        x = rep.get(x_key)  # type: ignore[no-untyped-call]
+        x = rep.get(x_key)
 
     # Applied units are pint objects with the correct dimensionality
     unit = x.attrs["_unit"]
@@ -215,7 +215,7 @@ def test_filters(
     x_key = rep.full_key("x")
 
     def assert_t_indices(labels: list[str]) -> None:
-        assert set(rep.get(x_key).coords["t"].values) == set(labels)  # type: ignore[no-untyped-call]
+        assert set(rep.get(x_key).coords["t"].values) == set(labels)
 
     # 1. Set filters directly
     rep.graph["config"]["filters"] = {"t": t_foo}
@@ -275,4 +275,4 @@ def test_filters(
         ),
         at_level=logging.DEBUG,
     ):
-        rep.get(x_key)  # type: ignore[no-untyped-call]
+        rep.get(x_key)


### PR DESCRIPTION
khaeru/genno#188, released with v1.30.0, improved type hints. This obviated some `type: ignore` comments present in `ixmp.report` and test code. Because we have:
https://github.com/iiasa/ixmp/blob/2128fc272f940b2cc9c349fa8ccdd1286c687596/pyproject.toml#L118

…these unused ignores caused the "code quality" job in the nightly CI run to begin to fail.

The PR adjusts, and also:

- Adjust for typing changes in [Click v8.4.0, released 2026-05-17](https://click.palletsprojects.com/en/stable/changes/#version-8-4-0).
- Cherry-pick the changes from #636 and #637.

## How to review

Read the diff and note that the CI checks all pass.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] ~Add or expand tests;~ coverage checks both ✅
- ~Add, expand, or update documentation.~ N/A: type hint changes only.
- ~Update release notes.~ ditto