### PR TITLE
Use cached HyperSQL tables by default

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -25,7 +25,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: astral-sh/setup-uv@v7
       with: { python-version: "${{ env.python-version }}" }
     - run: uv build

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -33,7 +33,7 @@ jobs:
         - "3.13"
         - "3.14"  # Latest supported by ixmp
         gams-version:
-        - "45.7.0" # Oldest version of gamsapi allowed by pyproject.toml
+        - "48.7.0" # Oldest version of gamsapi allowed by pyproject.toml
         extra-id:
         - ""
         install-extra:
@@ -44,7 +44,7 @@ jobs:
         include:
         - os: ubuntu-latest
           python-version: "3.14"
-          gams-version: "45.7.0"
+          gams-version: "48.7.0"
           extra-id: "-pandas-3"
           install-extra: uv pip install "pandas >=3"
 

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -54,7 +54,7 @@ jobs:
     name: ${{ matrix.os }}-py${{ matrix.python-version }}${{ matrix.extra-id }}
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
       with:
         fetch-depth: ${{ env.depth }}
         fetch-tags: true
@@ -142,7 +142,7 @@ jobs:
           --ixmp-postgres=${{ steps.setup-postgres.outputs.connection-uri }}
 
     - name: Upload test coverage to Codecov.io
-      uses: codecov/codecov-action@v6
+      uses: codecov/codecov-action@v7
       with:
         token: ${{ secrets.CODECOV_TOKEN}}
 
@@ -152,7 +152,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@v7
     - uses: astral-sh/setup-uv@v7
       with: { enable-cache: true, python-version: "3.14" }
     - name: Clear and re-create the pre-commit environments

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -10,7 +10,8 @@ repos:
     # TEMPORARY Use branch for https://github.com/iiasa/ixmp4/pull/208
     - "ixmp4 @ git+https://github.com/iiasa/ixmp4@enh/fixes-for-ixmp-support-september-2025; python_version > '3.9'"
     - nbclient
-    - pandas-stubs
+    # Work around https://github.com/pandas-dev/pandas-stubs/issues/1787
+    - "pandas-stubs < 3.0.3.260530"
     - pytest
     - pytest_httpserver
     - Sphinx

--- a/RELEASE_NOTES.rst
+++ b/RELEASE_NOTES.rst
@@ -48,9 +48,14 @@ All changes
     All remaining differences between :class:`.JDBCBackend` and :class:`.IXMP4Backend` are documented.
   - :class:`.Scenario.clone` can clone a Scenario *from* JDBCBackend *to* IXMP4Backend (:pull:`610`).
 
+- Improve :class:`.JDBCBackend` (:pull:`645`):
+
+  - Use cached tables for HyperSQL local file databases by default to improve performance
+    (:issue:`433`, :issue:`643`).
+
 - New method :meth:`.Scenario.iter_par_data` (:pull:`581`).
   :meth:`.Scenario.items` no longer supports iterating over item *contents*.
-- Improve type hinting in :mod:`ixmp` (:pull:`581`, :pull:`587`).
+- Improve type hinting (:pull:`581`, :pull:`587`).
   This supports more precise and complete type checking of downstream code that uses :mod:`ixmp`.
 
   - New module :mod:`ixmp.types` containing types for annotating code that uses :mod:`ixmp`.

--- a/doc/api-backend.rst
+++ b/doc/api-backend.rst
@@ -33,23 +33,36 @@ JDBCBackend
 -----------
 
 .. autoclass:: ixmp.backend.jdbc.JDBCBackend
-   :members: handle_config, read_file, write_file
+   :members: handle_config, read_file, write_file 
 
-   JDBCBackend supports:
+   JDBCBackend supports two :class:`DRIVER` options:
 
-   - Databases in local files (HyperSQL) using ``driver='hsqldb'`` and the *path* argument.
-   - Remote, Oracle databases using ``driver='oracle'`` and the *url*, *username* and *password* arguments.
-   - Temporary, in-memory databases using ``driver='hsqldb'`` and the *url* argument.
-     Use the `url` parameter with the format ``jdbc:hsqldb:mem:[NAME]``, where [NAME] is any string::
+   :any:`DRIVER.oracle`
+      Shared databases on remote (networked) servers using :attr:`~.jdbc.Options.url`,
+      :attr:`~.jdbc.Options.user`, and :attr:`~.jdbc.Options.password`.
 
-       mp = ixmp.Platform(
-           backend="jdbc",
-           driver="hsqldb",
-           url="jdbc:hsqldb:mem:temporary platform",
-       )
+   :any:`DRIVER.hsqldb`
+      - Databases in local files (HyperSQL) using :attr:`~.jdbc.Options.path`.
 
+        For such databases,
+        JDBCBackend automatically ensures a binary cache of the table data is stored on disk.
+        See :attr:`.Options.full_url` and :data:`.HSQLDB_DEFAULT_PROPS` for details.
+     - Temporary, in-memory databases using :attr:`~.jdbc.Options.url`.
+       Give a URL in the form "jdbc:hsqldb:mem:[NAME]",
+       where "[NAME]" is any string:
 
-   JDBCBackend caches values in memory to improve performance when repeatedly reading data from the same items with :meth:`.par`, :meth:`.equ`, or :meth:`.var`.
+       .. code-block:: python
+
+          mp = ixmp.Platform(
+              backend="jdbc",
+              driver="hsqldb",
+              url="jdbc:hsqldb:mem:temporary platform",
+          )
+
+   JDBCBackend is a subclass of :class:`.CachingBackend`.
+   As such, it caches values in memory to improve performance
+   when repeatedly reading data from the same items
+   with :meth:`.par`, :meth:`.equ`, or :meth:`.var`.
 
    .. tip:: If repeatedly accessing the same item with different *filters*:
 
@@ -63,7 +76,9 @@ JDBCBackend
    JDBCBackend has the following **limitations**:
 
    - The `comment` argument to :meth:`.Platform.add_unit` is limited to 64 characters.
-   - Infinite floating-point values (:data:`numpy.inf`, :data:`math.inf`) cannot be stored using :meth:`.TimeSeries.add_timeseries` when using an Oracle database via ``driver='oracle'``.
+   - Infinite floating-point values (:data:`numpy.inf`, :data:`math.inf`) cannot be stored
+     using :meth:`.TimeSeries.add_timeseries` when using an Oracle database via ``driver='oracle'``.
+   - :meth:`.JDBCBackend.s_clone` is only supported when `target_backend` is JDBCBackend.
 
    JDBCBackend's implementation allows the following kinds of file input and output:
 
@@ -72,7 +87,22 @@ JDBCBackend
       read_file
       write_file
 
-.. autofunction:: ixmp.backend.jdbc.start_jvm
+   .. note:: Much of the code of this backend is in Java,
+      in the iiasa/ixmp_source GitHub repository.
+ 
+      Among other abstractions, this backend:
+
+      - Handles any conversion between Java and Python types
+        that is not done automatically by JPype.
+      - Catches Java exceptions
+        such as :py:`at.ac.iiasa.ixmp.exceptions.IxException`
+        and re-raises them as appropriate Python exceptions.
+    
+.. automodule:: ixmp.backend.jdbc
+   :members: DRIVER, Options, start_jvm
+
+.. automodule:: ixmp.backend.jdbc.options
+   :members: HSQLDB_DEFAULT_PROPS
 
 .. currentmodule:: ixmp.backend.ixmp4
 

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -14,6 +14,8 @@ from collections.abc import (
 )
 from contextlib import contextmanager
 from copy import copy
+from dataclasses import asdict, dataclass, field
+from enum import Enum, auto
 from functools import lru_cache
 from itertools import islice
 from pathlib import Path, PurePosixPath
@@ -22,6 +24,7 @@ from typing import (
     TYPE_CHECKING,
     Any,
     Literal,
+    NoReturn,
     cast,
     overload,
 )
@@ -48,7 +51,6 @@ from .common import FIELDS, CrossPlatformClone, ItemType
 if TYPE_CHECKING:
     from ixmp.types import (
         Filters,
-        JDBCBackendInitKwargs,
         ParData,
         ReadKwargs,
         SetData,
@@ -76,6 +78,9 @@ LOG_LEVELS = {
     "DEBUG": "DEBUG",
     "NOTSET": "ALL",
 }
+
+#: Default URL-end property/value pairs for HyperSQL databases.
+HSQLDB_DEFAULT_PROPS = ["hsqldb.default_table_type=cached"]
 
 # Java classes, loaded by start_jvm(). These become available as e.g. java.IxException
 # or java.HashMap.
@@ -105,67 +110,186 @@ JAVA_CLASSES = [
 ]
 
 
-DRIVER_CLASS = {
-    "oracle": "oracle.jdbc.driver.OracleDriver",
-    "hsqldb": "org.hsqldb.jdbcDriver",
-}
+class DRIVER(Enum):
+    """Supported JDBC drivers."""
+
+    #: HyperSQL.
+    hsqldb = auto()
+    #: Oracle.
+    oracle = auto()
+
+    @classmethod
+    def from_str(cls, value: "str | DRIVER") -> "DRIVER":
+        """Maybe convert :class:`str` to an enumeration member."""
+        try:
+            return cls[value] if isinstance(value, str) else value
+        except KeyError:
+            raise ValueError(f"unrecognized/unsupported JDBC driver {value!r}")
 
 
-def _create_properties(
-    driver: str | None = None,
-    path: str | Path | None = None,
-    url: str | None = None,
-    user: str | None = None,
-    password: str | None = None,
-) -> Any:
-    """Create a database Properties from arguments."""
-    properties = java.Properties()
+@dataclass
+class Options:
+    """Options and configuration for :class:`JDBCBackend`."""
 
-    # Handle arguments
-    try:
-        # FIXME Improve handling of None driver value
-        properties.setProperty("jdbc.driver", DRIVER_CLASS[driver])  # type:ignore[index]
-    except KeyError:
-        raise ValueError(f"unrecognized/unsupported JDBC driver {repr(driver)}")
+    driver: DRIVER
+    path: os.PathLike[str] | None = None
+    url: str = ""
+    user: str = ""
+    password: str = ""
+    extra_properties: dict[str, str] = field(default_factory=dict)
+    jvmargs: str | list[str] = ""
 
-    if driver == "oracle":
-        if url is None or path is not None:
+    def __post_init__(self) -> None:
+        # Maybe convert a str to a DRIVER member
+        self.driver = DRIVER.from_str(self.driver)
+
+        # Check consistency of fields
+        if self.driver is DRIVER.oracle and (self.path or not self.url):
             raise ValueError("use JDBCBackend(driver='oracle', url=…)")
+        elif self.driver is DRIVER.hsqldb and not self.path and not self.url:
+            raise ValueError(
+                "use JDBCBackend(driver='hsqldb', path=…) or "
+                "JDBCBackend(driver='hsqldb', url=…)"
+            )
 
-        full_url = f"jdbc:oracle:thin:@{url}"
-    elif driver == "hsqldb":
-        if path is None and url is None:
-            raise ValueError("use JDBCBackend(driver='hsqldb', path=…)")
+        # Remaining arguments are for the JVM
+        if isinstance(self.jvmargs, list):
+            self.jvmargs, *extra = self.jvmargs or [""]
+            if extra:
+                raise ValueError(f"Extra arguments for JDBCBackend: {extra!r}")
 
-        if url is not None:
-            if url.startswith("jdbc:hsqldb:"):
-                full_url = url
-            else:
-                raise ValueError(url)
+    @property
+    def full_url(self) -> str:
+        """The full JDBC URL for the connection."""
+        result = ["jdbc", self.driver.name]
+        match self.driver:
+            case DRIVER.oracle:
+                result.extend(["thin", f"@{self.url}"])
+            case DRIVER.hsqldb:
+                if self.path:
+                    proto = "file"
+                    # Convert Windows paths to use forward slashes
+                    db = str(PurePosixPath(Path(self.path).resolve())).replace("\\", "")
+                    props = HSQLDB_DEFAULT_PROPS.copy()
+                elif match := re.fullmatch(
+                    "(jdbc:hsqldb:)?(?P<proto>file|mem):(?P<db>[^;]+)(;(?P<props>.*))?",
+                    self.url,
+                ):
+                    proto, db, all_props = match.group("proto", "db", "props")
+                    props = all_props.split(";") if all_props else []
+                else:
+                    raise ValueError(f"Cannot construct a JDBC URL for {self}")
+
+                # Use cached tables by default for non-memory databases
+                if proto == "file" and not any(
+                    HSQLDB_DEFAULT_PROPS[0].partition("=")[0] in p for p in props
+                ):
+                    props.append(HSQLDB_DEFAULT_PROPS[0])
+
+                result.append(proto)
+                result.append(db + ((";".join([""] + props)) if props else ""))
+
+        return ":".join(result)
+
+    @property
+    def properties(self) -> Any:
+        """Return a Java Properties instance for use with ``ixmp.Platform(…)``."""
+        result = java.Properties()
+
+        for key, value in (
+            {
+                "jdbc.driver": {
+                    DRIVER.hsqldb: "org.hsqldb.jdbcDriver",
+                    DRIVER.oracle: "oracle.jdbc.driver.OracleDriver",
+                }[self.driver],
+                "jdbc.url": self.full_url,
+                "jdbc.user": self.user or "ixmp",
+                "jdbc.pwd": self.password or "ixmp",
+                # commented: This has no effect, apparently because ixmp_source Platform
+                # class fails to pass the property on to HyperSQL
+                # "hsqldb.default_table_type": "cached",
+            }
+            | self.extra_properties
+        ).items():
+            result.setProperty(key, value)
+
+        return result
+
+    @classmethod
+    def handle_config(cls, args: Sequence[Any], **kw: Any) -> dict[str, str]:
+        """Handle CLI arguments to :program:`ixmp platform add [name] ...`.
+
+        Returns
+        -------
+        dict
+            Representation of the `args` and `kw` suitable for :file:`config.json`.
+        """
+        args = list(args)
+
+        # Shorthand for exception formatting
+        exp, got = " expected for JDBCBackend", f"; got {args}, {kw!r}"
+
+        def _raise(text: str) -> NoReturn:
+            raise ValueError(f"{text}{exp}{got}")
+
+        # First argument: driver
+        try:
+            driver = DRIVER.from_str(args.pop(0))
+        except IndexError:
+            _raise("≥1 positional argument (driver)")
         else:
-            # path can not also be None due to the check above, convince type checker
-            assert path is not None
-            # Convert Windows paths to use forward slashes per HyperSQL JDBC URL spec
-            url_path = str(PurePosixPath(Path(path).resolve())).replace("\\", "")
-            full_url = f"jdbc:hsqldb:file:{url_path}"
-        user = user or "ixmp"
-        password = password or "ixmp"
+            exp += f"(driver={driver.name!r})"
 
-    properties.setProperty("jdbc.url", full_url)
-    properties.setProperty("jdbc.user", user)
-    properties.setProperty("jdbc.pwd", password)
+        # Remaining arguments
+        match driver:
+            case DRIVER.oracle:
+                if len(args) < 3:
+                    _raise("3–4 arguments (URL, user, password, [jvmargs])")
 
-    return properties
+                kw["url"], kw["user"], kw["password"], *kw["jvmargs"] = args
+            case DRIVER.hsqldb:
+                try:
+                    kw["path"] = Path(args.pop(0)).resolve()
+                except IndexError:
+                    if "url" not in kw:
+                        _raise("either positional path or url= keyword argument")
+                kw["jvmargs"] = args
 
+        # Convert from a Config instance back to a dict
+        result = dict()
+        for key, value in asdict(cls(driver, **kw)).items():
+            if key == "driver":
+                result["driver"] = value.name  # String name of enumeration value
+            elif value:
+                result[key] = value  # Non-empty item
 
-def _read_properties(file: Path) -> dict[str, str]:
-    """Read database properties from *file*, returning :class:`dict`."""
-    properties = dict()
-    for line in file.read_text().split("\n"):
-        match = re.search(r"([^\s]+)\s*=\s*(.+)\s*", line)
-        if match is not None:
-            properties[match.group(1)] = match.group(2)
-    return properties
+        return result
+
+    @classmethod
+    def from_file(cls, path: os.PathLike[str], jvmargs: str | list[str]) -> "Options":
+        """Read database properties from a file at `path`."""
+        path = Path(path)
+        if not path.exists() and path.is_file():
+            raise FileNotFoundError(path)
+
+        args: dict[str, Any] = dict(path=None, extra_properties={})
+        expr = re.compile(r"^(?:jdbc\.)?([\w\.]+)\s*=\s*(.+)\s*")
+        for match in filter(None, map(expr.fullmatch, path.read_text().splitlines())):
+            name, value = match.group(1), match.group(2)
+            match name:
+                case "driver":
+                    args[name] = DRIVER.hsqldb if "hsqldb" in value else DRIVER.oracle
+                case "pwd":
+                    args["password"] = value  # Change name
+                case "url" | "user":
+                    args[name] = value  # Store
+                case _:
+                    args["extra_properties"][name] = value  # Store
+
+        if "url" not in args:
+            raise ValueError(f"File {path} contains no database URL")
+
+        return cls(**args, jvmargs=jvmargs)
 
 
 def _raise_jexception(exc: Any, msg: str = "unhandled Java exception: ") -> None:
@@ -285,6 +409,8 @@ class JDBCBackend(CachingBackend):
         `driver`, `url`, `user`, and `password` information.
     """
 
+    _options: Options
+
     # NB Much of the code of this backend is in Java, in the iiasa/ixmp_source GitHub
     #    repository.
     #
@@ -300,7 +426,7 @@ class JDBCBackend(CachingBackend):
     #    - s_clone() is only supported when target_backend is JDBCBackend.
 
     #: Reference to the at.ac.iiasa.ixmp.Platform Java object.
-    jobj: jpype.JObject = None  # type: ignore[no-any-unimported]
+    jobj: jpype.JObject = None  # type: ignore [no-any-unimported]
 
     #: Mapping from ixmp.TimeSeries object to the underlying at.ac.iiasa.ixmp.Scenario
     #: object (or subclasses of either).
@@ -314,60 +440,34 @@ class JDBCBackend(CachingBackend):
         dbprops: os.PathLike[str] | None = None,
         cache: bool = True,
         log_level: int | str | None = None,
-        **kwargs: Unpack["JDBCBackendInitKwargs"],
+        **kwargs: Any,
     ) -> None:
-        properties: Any | None = None
-
-        # Handle arguments
-        if dbprops:
-            # Use an existing file
-            _dbprops = Path(dbprops)
-            if _dbprops.exists() and _dbprops.is_file():
-                # Existing properties file
-                properties = _read_properties(_dbprops)
-                if "jdbc.url" not in properties:
-                    raise ValueError("Config file contains no database URL")
-            else:
-                raise FileNotFoundError(_dbprops)
-
-        start_jvm(jvmargs)
-
-        # Invoke the parent constructor to initialize the cache
-        super().__init__(cache_enabled=cache)
-
         # Extract a log_level keyword argument before _create_properties(). By default,
         # use the same level as the 'ixmp' logger, whatever that has been set to.
         ixmp_logger = logging.getLogger("ixmp")
         log_level = log_level or ixmp_logger.getEffectiveLevel()
 
-        # Create a database properties object
-        if properties:
-            # ...using file contents
-            new_props = java.Properties()
-            [new_props.setProperty(k, v) for k, v in properties.items()]
-            properties = new_props
-        else:
-            # ...from arguments
-            try:
-                properties = _create_properties(**kwargs)
-            except TypeError as e:
-                msg = e.args[0].replace("_create_properties", "JDBCBackend")
-                raise TypeError(msg)
-
-        # We seem to assume this
-        assert properties is not None
-
-        log.info(
-            "launching ixmp.Platform connected to {}".format(
-                properties.getProperty("jdbc.url")
+        # Handle arguments, create a Config object, and store for later reference
+        try:
+            self._options = (
+                Options.from_file(dbprops, jvmargs or "")
+                if dbprops
+                else Options(**kwargs, jvmargs=jvmargs or "")
             )
-        )
+        except TypeError as e:
+            raise TypeError(e.args[0].replace("Options.__init__", "JDBCBackend"))
 
-        # Store a copy of the properties for later introspection
-        self._properties = properties
+        # Start the JVM
+        start_jvm(self._options.jvmargs)
+
+        # Invoke the parent constructor to initialize the cache
+        super().__init__(cache_enabled=cache)
+
+        log.info(f"launching ixmp.Platform connected to {self._options.full_url}")
 
         try:
-            self.jobj = java.Platform("Python", properties)
+            # Instantiate the Java Platform object
+            self.jobj = java.Platform("Python", self._options.properties)
         except java.NoClassDefFoundError as e:  # pragma: no cover
             raise NameError(
                 f"{e}\nCheck that dependencies of ixmp.jar are "
@@ -377,11 +477,10 @@ class JDBCBackend(CachingBackend):
             # Handle Java exceptions
             jclass = e.__class__.__name__
             if jclass.endswith("HikariPool.PoolInitializationException"):
-                redacted = copy(kwargs)
                 # See https://github.com/python/mypy/issues/6019 for why we need a dict
                 # here
-                redacted.update({"user": "(HIDDEN)", "password": "(HIDDEN)"})
-                msg = f"unable to connect to database:\n{repr(redacted)}"
+                redacted = kwargs | dict(user="(HIDDEN)", password="(HIDDEN)")
+                msg = f"unable to connect to database:\n{redacted!r}"
             elif jclass.endswith("FlywayException"):
                 msg = "when initializing database:"
                 if "applied migration" in e.args[0]:
@@ -427,51 +526,7 @@ class JDBCBackend(CachingBackend):
         - ("hsqldb",) with "url" supplied via `kwargs`, e.g. "jdbc:hsqldb:mem://foo" for
           an in-memory database.
         """
-        args = list(args)
-        info = copy(kwargs)
-
-        # First argument: driver
-        try:
-            info["driver"] = args.pop(0)
-        except IndexError:
-            raise ValueError(
-                f"≥1 positional argument required for class=jdbc: driver; got: {args}, "
-                + str(kwargs)
-            )
-
-        if info["driver"] == "oracle":
-            if len(args) < 3:
-                raise ValueError(
-                    "3 or 4 arguments expected for driver=oracle: url, user, password, "
-                    f"[jvmargs]; got: {str(args)}"
-                )
-            info["url"], info["user"], info["password"], *jvmargs = args
-
-        elif info["driver"] == "hsqldb":
-            try:
-                info["path"] = Path(args.pop(0)).resolve()
-            except IndexError:
-                if "url" not in info:
-                    raise ValueError(
-                        "must supply either positional path or url= keyword argument "
-                        "for driver=hsqldb"
-                    )
-            jvmargs = args
-
-        else:
-            raise ValueError(
-                f"driver={info['driver']}; expected one of {set(DRIVER_CLASS)}"
-            )
-
-        if len(jvmargs) > 1:
-            raise ValueError(
-                f"Unrecognized extra argument(s) for driver={info['driver']}: "
-                f"{jvmargs[1:]}"
-            )
-        elif len(jvmargs):
-            info["jvmargs"] = jvmargs[0]
-
-        return info
+        return Options.handle_config(args, **kwargs)
 
     def set_log_level(self, level: int | str) -> None:
         # Set the level of the 'ixmp.backend.jdbc' logger. Messages are handled by the
@@ -583,8 +638,8 @@ class JDBCBackend(CachingBackend):
 
         for s in scenarios:
             data = []
-            for field in FIELDS["get_scenarios"]:
-                data.append(int(s[field]) if field == "version" else s[field])
+            for _field in FIELDS["get_scenarios"]:
+                data.append(int(s[_field]) if _field == "version" else s[_field])
             yield data
 
     def set_unit(self, name: str, comment: str) -> None:
@@ -967,9 +1022,7 @@ class JDBCBackend(CachingBackend):
         meta: bool,
     ) -> None:
         # Oracle is unable to handle ±∞ (issue #442)
-        if self._properties["jdbc.driver"] == DRIVER_CLASS["oracle"] and any(
-            map(np.isinf, data.values())
-        ):
+        if self._options.driver is DRIVER.oracle and any(map(np.isinf, data.values())):
             raise ValueError(
                 f"± infinity (at region={region}, variable={variable}) cannot be stored"
                 " in an Oracle database using JDBCBackend"

--- a/ixmp/backend/jdbc.py
+++ b/ixmp/backend/jdbc.py
@@ -575,12 +575,14 @@ class JDBCBackend(CachingBackend):
         """
         try:
             self.jobj.closeDB()
-        except java.IxException as e:  # pragma: no cover
-            log.warning(str(e))
-        except (AttributeError, jpype.JVMNotRunning):
-            # - self.jobj is None, e.g. cleanup after __init__ fails
-            # - JVM has already shut down, e.g. on program exit
+        except (AttributeError, ImportError):
+            # self.jobj is None, e.g. cleanup after __init__ fails
             pass
+        except Exception as e:  # pragma: no cover
+            # JVM has already shut down, e.g. on program exit. At this point, the
+            # `jpype` global is None, so we cannot check its type in the above block
+            if str(e) != "Java Virtual Machine is not running":
+                print(str(e))
 
     def get_auth(self, user: str, models: Iterable[str], kind: str) -> dict[str, bool]:
         model_access = self.jobj.checkModelAccess(user, kind, to_jlist(models))

--- a/ixmp/backend/jdbc/__init__.py
+++ b/ixmp/backend/jdbc/__init__.py
@@ -1,7 +1,6 @@
 import gc
 import logging
 import os
-import platform
 import re
 from collections import ChainMap
 from collections.abc import (
@@ -12,22 +11,11 @@ from collections.abc import (
     MutableMapping,
     Sequence,
 )
-from contextlib import contextmanager
 from copy import copy
-from dataclasses import asdict, dataclass, field
-from enum import Enum, auto
 from functools import lru_cache
 from itertools import islice
-from pathlib import Path, PurePosixPath
-from types import SimpleNamespace
-from typing import (
-    TYPE_CHECKING,
-    Any,
-    Literal,
-    NoReturn,
-    cast,
-    overload,
-)
+from pathlib import Path
+from typing import TYPE_CHECKING, Any, Literal, cast, overload
 from weakref import WeakKeyDictionary
 
 import jpype
@@ -37,6 +25,8 @@ import pandas as pd
 # TODO Import from typing when dropping support for Python 3.11
 from typing_extensions import Unpack, override
 
+from ixmp.backend.base import CachingBackend
+from ixmp.backend.common import FIELDS, CrossPlatformClone, ItemType
 from ixmp.core.item import CLASS as ITEM_CLASS
 from ixmp.core.item import Equation, Item, Parameter, Set, Variable
 from ixmp.core.platform import Platform
@@ -45,8 +35,17 @@ from ixmp.core.timeseries import TimeSeries
 from ixmp.util import as_str_list
 from ixmp.util.pandas import STRING_DTYPE
 
-from .base import CachingBackend
-from .common import FIELDS, CrossPlatformClone, ItemType
+from .jvm import (
+    handle_jexception,
+    java,
+    raise_jexception,
+    start_jvm,
+    to_jlist,
+    to_pylist,
+    unwrap,
+    wrap,
+)
+from .options import DRIVER, Options
 
 if TYPE_CHECKING:
     from ixmp.types import (
@@ -59,6 +58,11 @@ if TYPE_CHECKING:
         WriteKwargs,
     )
 
+__all__ = [
+    "DRIVER",
+    "JDBCBackend",
+    "Options",
+]
 
 log = logging.getLogger(__name__)
 
@@ -68,8 +72,8 @@ _EXCEPTION_VERBOSE = os.environ.get("IXMP_JDBC_EXCEPTION_VERBOSE", "0") == "1"
 #: See :meth:`JDBCBackend.gc`.
 _GC_AGGRESSIVE = True
 
-# Map of Python to Java log levels
-# https://logging.apache.org/log4j/2.x/log4j-api/apidocs/org/apache/logging/log4j/Level.html
+#: Map of Python to Java log levels
+#: https://logging.apache.org/log4j/2.x/log4j-api/apidocs/org/apache/logging/log4j/Level.html
 LOG_LEVELS = {
     "CRITICAL": "FATAL",
     "ERROR": "ERROR",
@@ -78,245 +82,6 @@ LOG_LEVELS = {
     "DEBUG": "DEBUG",
     "NOTSET": "ALL",
 }
-
-#: Default URL-end property/value pairs for HyperSQL databases.
-HSQLDB_DEFAULT_PROPS = ["hsqldb.default_table_type=cached"]
-
-# Java classes, loaded by start_jvm(). These become available as e.g. java.IxException
-# or java.HashMap.
-java = SimpleNamespace()
-
-JAVA_CLASSES = [
-    "at.ac.iiasa.ixmp.dto.TimesliceDTO",
-    "at.ac.iiasa.ixmp.exceptions.IxException",
-    "at.ac.iiasa.ixmp.modelspecs.MESSAGEspecs",
-    "at.ac.iiasa.ixmp.objects.Scenario",
-    "at.ac.iiasa.ixmp.Platform",
-    "java.lang.Double",
-    "java.lang.Exception",
-    "java.lang.Integer",
-    "java.lang.NoClassDefFoundError",
-    "java.lang.IllegalArgumentException",
-    "java.lang.Long",
-    "java.lang.Runtime",
-    "java.lang.System",
-    "java.math.BigDecimal",
-    "java.util.HashMap",
-    "java.util.LinkedHashMap",
-    "java.util.LinkedList",
-    "java.util.ArrayList",
-    "java.util.Properties",
-    "at.ac.iiasa.ixmp.dto.DocumentationKey",
-]
-
-
-class DRIVER(Enum):
-    """Supported JDBC drivers."""
-
-    #: HyperSQL.
-    hsqldb = auto()
-    #: Oracle.
-    oracle = auto()
-
-    @classmethod
-    def from_str(cls, value: "str | DRIVER") -> "DRIVER":
-        """Maybe convert :class:`str` to an enumeration member."""
-        try:
-            return cls[value] if isinstance(value, str) else value
-        except KeyError:
-            raise ValueError(f"unrecognized/unsupported JDBC driver {value!r}")
-
-
-@dataclass
-class Options:
-    """Options and configuration for :class:`JDBCBackend`."""
-
-    driver: DRIVER
-    path: os.PathLike[str] | None = None
-    url: str = ""
-    user: str = ""
-    password: str = ""
-    extra_properties: dict[str, str] = field(default_factory=dict)
-    jvmargs: str | list[str] = ""
-
-    def __post_init__(self) -> None:
-        # Maybe convert a str to a DRIVER member
-        self.driver = DRIVER.from_str(self.driver)
-
-        # Check consistency of fields
-        if self.driver is DRIVER.oracle and (self.path or not self.url):
-            raise ValueError("use JDBCBackend(driver='oracle', url=…)")
-        elif self.driver is DRIVER.hsqldb and not self.path and not self.url:
-            raise ValueError(
-                "use JDBCBackend(driver='hsqldb', path=…) or "
-                "JDBCBackend(driver='hsqldb', url=…)"
-            )
-
-        # Remaining arguments are for the JVM
-        if isinstance(self.jvmargs, list):
-            self.jvmargs, *extra = self.jvmargs or [""]
-            if extra:
-                raise ValueError(f"Extra arguments for JDBCBackend: {extra!r}")
-
-    @property
-    def full_url(self) -> str:
-        """The full JDBC URL for the connection."""
-        result = ["jdbc", self.driver.name]
-        match self.driver:
-            case DRIVER.oracle:
-                result.extend(["thin", f"@{self.url}"])
-            case DRIVER.hsqldb:
-                if self.path:
-                    proto = "file"
-                    # Convert Windows paths to use forward slashes
-                    db = str(PurePosixPath(Path(self.path).resolve())).replace("\\", "")
-                    props = HSQLDB_DEFAULT_PROPS.copy()
-                elif match := re.fullmatch(
-                    "(jdbc:hsqldb:)?(?P<proto>file|mem):(?P<db>[^;]+)(;(?P<props>.*))?",
-                    self.url,
-                ):
-                    proto, db, all_props = match.group("proto", "db", "props")
-                    props = all_props.split(";") if all_props else []
-                else:
-                    raise ValueError(f"Cannot construct a JDBC URL for {self}")
-
-                # Use cached tables by default for non-memory databases
-                if proto == "file" and not any(
-                    HSQLDB_DEFAULT_PROPS[0].partition("=")[0] in p for p in props
-                ):
-                    props.append(HSQLDB_DEFAULT_PROPS[0])
-
-                result.append(proto)
-                result.append(db + ((";".join([""] + props)) if props else ""))
-
-        return ":".join(result)
-
-    @property
-    def properties(self) -> Any:
-        """Return a Java Properties instance for use with ``ixmp.Platform(…)``."""
-        result = java.Properties()
-
-        for key, value in (
-            {
-                "jdbc.driver": {
-                    DRIVER.hsqldb: "org.hsqldb.jdbcDriver",
-                    DRIVER.oracle: "oracle.jdbc.driver.OracleDriver",
-                }[self.driver],
-                "jdbc.url": self.full_url,
-                "jdbc.user": self.user or "ixmp",
-                "jdbc.pwd": self.password or "ixmp",
-                # commented: This has no effect, apparently because ixmp_source Platform
-                # class fails to pass the property on to HyperSQL
-                # "hsqldb.default_table_type": "cached",
-            }
-            | self.extra_properties
-        ).items():
-            result.setProperty(key, value)
-
-        return result
-
-    @classmethod
-    def handle_config(cls, args: Sequence[Any], **kw: Any) -> dict[str, str]:
-        """Handle CLI arguments to :program:`ixmp platform add [name] ...`.
-
-        Returns
-        -------
-        dict
-            Representation of the `args` and `kw` suitable for :file:`config.json`.
-        """
-        args = list(args)
-
-        # Shorthand for exception formatting
-        exp, got = " expected for JDBCBackend", f"; got {args}, {kw!r}"
-
-        def _raise(text: str) -> NoReturn:
-            raise ValueError(f"{text}{exp}{got}")
-
-        # First argument: driver
-        try:
-            driver = DRIVER.from_str(args.pop(0))
-        except IndexError:
-            _raise("≥1 positional argument (driver)")
-        else:
-            exp += f"(driver={driver.name!r})"
-
-        # Remaining arguments
-        match driver:
-            case DRIVER.oracle:
-                if len(args) < 3:
-                    _raise("3–4 arguments (URL, user, password, [jvmargs])")
-
-                kw["url"], kw["user"], kw["password"], *kw["jvmargs"] = args
-            case DRIVER.hsqldb:
-                try:
-                    kw["path"] = Path(args.pop(0)).resolve()
-                except IndexError:
-                    if "url" not in kw:
-                        _raise("either positional path or url= keyword argument")
-                kw["jvmargs"] = args
-
-        # Convert from a Config instance back to a dict
-        result = dict()
-        for key, value in asdict(cls(driver, **kw)).items():
-            if key == "driver":
-                result["driver"] = value.name  # String name of enumeration value
-            elif value:
-                result[key] = value  # Non-empty item
-
-        return result
-
-    @classmethod
-    def from_file(cls, path: os.PathLike[str], jvmargs: str | list[str]) -> "Options":
-        """Read database properties from a file at `path`."""
-        path = Path(path)
-        if not path.exists() and path.is_file():
-            raise FileNotFoundError(path)
-
-        args: dict[str, Any] = dict(path=None, extra_properties={})
-        expr = re.compile(r"^(?:jdbc\.)?([\w\.]+)\s*=\s*(.+)\s*")
-        for match in filter(None, map(expr.fullmatch, path.read_text().splitlines())):
-            name, value = match.group(1), match.group(2)
-            match name:
-                case "driver":
-                    args[name] = DRIVER.hsqldb if "hsqldb" in value else DRIVER.oracle
-                case "pwd":
-                    args["password"] = value  # Change name
-                case "url" | "user":
-                    args[name] = value  # Store
-                case _:
-                    args["extra_properties"][name] = value  # Store
-
-        if "url" not in args:
-            raise ValueError(f"File {path} contains no database URL")
-
-        return cls(**args, jvmargs=jvmargs)
-
-
-def _raise_jexception(exc: Any, msg: str = "unhandled Java exception: ") -> None:
-    """Convert Java/JPype exceptions to ordinary Python RuntimeError."""
-    # Try to re-raise as a ValueError for bad model or scenario name
-    arg = exc.args[0] if isinstance(exc.args[0], str) else ""
-    if match := re.search(r"getting '([^']*)' in table '([^']*)'", arg):
-        param = match.group(2).lower()
-        if param in {"model", "scenario"}:
-            raise ValueError(f"{param}={repr(match.group(1))}") from None
-
-    # Other exceptions
-    if _EXCEPTION_VERBOSE:
-        msg += "\n\n" + exc.stacktrace()
-    else:
-        msg += exc.message()
-
-    raise RuntimeError(msg) from None
-
-
-@contextmanager
-def _handle_jexception() -> Generator[None, Any, None]:
-    """Context manager form of :func:`_raise_jexception`."""
-    try:
-        yield
-    except java.Exception as e:
-        _raise_jexception(e)
 
 
 @lru_cache
@@ -327,57 +92,23 @@ def _fixed_index_sets(scheme: str) -> Mapping[str, list[str]]:
     called once.
     """
     if scheme == "MESSAGE":
-        return {k: to_pylist(v) for k, v in java.MESSAGEspecs.getIndexDimMap().items()}
+        return {
+            k: to_pylist(v)
+            for k, v in java.ixmp.modelspecs.MESSAGEspecs.getIndexDimMap().items()
+        }
     else:
         return {}
 
 
 def _domain_enum(domain: str) -> str:
-    domain_enum = java.DocumentationKey.DocumentationDomain
+    domain_enum = java.ixmp.dto.DocumentationKey.DocumentationDomain
     try:
         # NOTE in truth, _domain seems to only be a compatible Java type
         _domain: str = domain_enum.valueOf(domain.upper())
         return _domain
-    except java.IllegalArgumentException:
+    except java.lang.IllegalArgumentException:
         domains = ", ".join([d.name().lower() for d in domain_enum.values()])
         raise ValueError(f"No such domain: {domain}, existing domains: {domains}")
-
-
-@overload
-def _unwrap(v: list[bool | float | str]) -> list[bool | float | str]: ...
-
-
-@overload
-def _unwrap(v: bool | float | str) -> bool | float | str: ...
-
-
-def _unwrap(v: Any) -> bool | float | str | list[bool | float | str]:
-    """Unwrap meta numeric value or list of values (BigDecimal -> Double)."""
-    if isinstance(v, java.BigDecimal):
-        _v: float = v.doubleValue()
-        return _v
-    elif isinstance(v, java.ArrayList):
-        return [_unwrap(elt) for elt in v]
-    else:
-        # NOTE In truth, this value might only be a compatible Java type
-        else_v: bool | str = v
-        return else_v
-
-
-def _wrap(value: Any) -> bool | float | int | str | list[bool | float | str]:
-    if isinstance(value, (str, bool)):
-        return value
-    elif isinstance(value, (int, float)):
-        # NOTE In truth, BigDecimal seems to return a Java type compatible with both
-        # float and int
-        _value: float | int = java.BigDecimal(value)
-        return _value
-    elif isinstance(value, (Sequence, Iterable)):
-        jlist = java.ArrayList()
-        jlist.addAll([_wrap(elt) for elt in value])
-        return cast(list[bool | float | str], jlist)
-    else:
-        raise ValueError(f"Cannot use value {value} as metadata")
 
 
 class JDBCBackend(CachingBackend):
@@ -386,50 +117,36 @@ class JDBCBackend(CachingBackend):
     This backend is based on the third-party `JPype <https://jpype.readthedocs.io>`_
     Python package that allows interaction with Java code.
 
+
     Parameters
     ----------
-    driver : 'oracle' or 'hsqldb'
-        JDBC driver to use.
-    path : os.PathLike, optional
-        Path to the HyperSQL database.
-    url : str, optional
-        Partial or complete JDBC URL for the Oracle or HyperSQL database, e.g.
-        ``database-server.example.com:PORT:SCHEMA``. See :ref:`configuration`.
-    user : str, optional
-        Database user name.
-    password : str, optional
-        Database user password.
-    cache : bool, optional
-        If :obj:`True` (the default), cache Python objects after conversion from Java
-        objects.
     jvmargs : str, optional
-        Java Virtual Machine arguments. See :func:`.start_jvm`.
-    dbprops : os.PathLike, optional
-        With ``driver='oracle'``, the path to a database properties file containing
-        `driver`, `url`, `user`, and `password` information.
+        Java Virtual Machine arguments. See :func:`.start_jvm` and
+        :attr:`.Options.jvmargs`.
+    dbprops : os.PathLike
+        Path to a database properties file containing connection information.
+        See :meth:`.Options.from_file`.
+    cache : bool
+        Passed to :class:`CachingBackend` py:`cache_enabled=...` to cache Python objects
+        after conversion from Java objects.
+    log_level :
+        Initial log level. See :meth:`set_log_level`.
+
+    Other parameters
+    ----------------
+    kwargs :
+         including `driver`, `path`, `url`, `user`, `password`, `extra_properties`.
+         Passed to :class:`~.backend.jdbc.options.Options`; see its documentation.
     """
 
     _options: Options
 
-    # NB Much of the code of this backend is in Java, in the iiasa/ixmp_source GitHub
-    #    repository.
-    #
-    #    Among other abstractions, this backend:
-    #
-    #    - Handles any conversion between Java and Python types that is not done
-    #      automatically by JPype.
-    #    - Catches Java exceptions such as ixmp.exceptions.IxException, and re-raises
-    #      them as appropriate Python exceptions.
-    #
-    #    Limitations:
-    #
-    #    - s_clone() is only supported when target_backend is JDBCBackend.
-
-    #: Reference to the at.ac.iiasa.ixmp.Platform Java object.
+    #: Reference to the :py:`at.ac.iiasa.ixmp.Platform` Java object.
     jobj: jpype.JObject = None  # type: ignore [no-any-unimported]
 
-    #: Mapping from ixmp.TimeSeries object to the underlying at.ac.iiasa.ixmp.Scenario
-    #: object (or subclasses of either).
+    #: Mapping from :class:`.TimeSeries` (Python) instances to the underlying/
+    #: corresponding Java :py:`at.ac.iiasa.ixmp.TimeSeries` object (or subclasses of
+    #: either).
     jindex: MutableMapping[TimeSeries | Scenario, jpype.JObject] = (  # type: ignore[no-any-unimported]
         WeakKeyDictionary()
     )
@@ -467,13 +184,13 @@ class JDBCBackend(CachingBackend):
 
         try:
             # Instantiate the Java Platform object
-            self.jobj = java.Platform("Python", self._options.properties)
-        except java.NoClassDefFoundError as e:  # pragma: no cover
+            self.jobj = java.ixmp.Platform("Python", self._options.properties)
+        except java.lang.NoClassDefFoundError as e:  # pragma: no cover
             raise NameError(
                 f"{e}\nCheck that dependencies of ixmp.jar are "
                 f"included in {Path(__file__).parents[2] / 'lib'}"
             )
-        except java.Exception as e:  # pragma: no cover
+        except java.lang.Exception as e:  # pragma: no cover
             # Handle Java exceptions
             jclass = e.__class__.__name__
             if jclass.endswith("HikariPool.PoolInitializationException"):
@@ -490,7 +207,7 @@ class JDBCBackend(CachingBackend):
                         "of ixmp used to create the database, or delete it and retry."
                     )
             else:
-                _raise_jexception(e)
+                raise_jexception(e)
             raise RuntimeError(f"{msg}\n(Java: {jclass})")
 
         # Set the log level
@@ -505,7 +222,7 @@ class JDBCBackend(CachingBackend):
         if _GC_AGGRESSIVE:
             # log.debug('Collect garbage')
             try:
-                java.System.gc()
+                java.lang.System.gc()
             except jpype.JVMNotRunning:
                 pass
             gc.collect()
@@ -517,14 +234,9 @@ class JDBCBackend(CachingBackend):
     def handle_config(
         cls, args: Sequence[Any], kwargs: dict[str, Any]
     ) -> dict[str, Any]:
-        """Handle platform/backend config arguments.
+        """Handle configuration arguments from file or the command line.
 
-        `args` will overwrite any `kwargs`, and may be one of:
-
-        - ("oracle", url, user, password, [jvmargs]) for an Oracle database.
-        - ("hsqldb", path, [jvmargs]) for a file-backed HyperSQL database.
-        - ("hsqldb",) with "url" supplied via `kwargs`, e.g. "jdbc:hsqldb:mem://foo" for
-          an in-memory database.
+        See :meth:`.backend.jdbc.Options.handle_config`
         """
         return Options.handle_config(args, **kwargs)
 
@@ -546,7 +258,7 @@ class JDBCBackend(CachingBackend):
         self, domain: str, docs: dict[str, str] | Iterable[tuple[str, str]]
     ) -> None:
         dd = _domain_enum(domain)
-        jdata = java.LinkedHashMap()
+        jdata = java.util.LinkedHashMap()
         if isinstance(docs, dict):
             docs = list(docs.items())
         for k, v in docs:
@@ -615,7 +327,7 @@ class JDBCBackend(CachingBackend):
             yield name, category, duration
 
     def set_timeslice(self, name: str, category: str, duration: float) -> None:
-        self.jobj.addTimeslice(name, category, java.Double(duration))
+        self.jobj.addTimeslice(name, category, java.lang.Double(duration))
 
     def add_model_name(self, name: str) -> None:
         self.jobj.addModel(str(name))
@@ -635,7 +347,7 @@ class JDBCBackend(CachingBackend):
         self, default: bool, model: str | None, scenario: str | None
     ) -> Generator[list[bool | int | str], Any, None]:
         # List<Map<String, Object>>
-        with _handle_jexception():
+        with handle_jexception():
             scenarios = self.jobj.getScenarioList(default, model, scenario)
 
         for s in scenarios:
@@ -652,7 +364,7 @@ class JDBCBackend(CachingBackend):
                 # ixmp_source does not support adding "" with Oracle
                 log.warning(f"…skip {repr(name)} (ixmp.JDBCBackend with driver=oracle)")
             else:
-                _raise_jexception(e)
+                raise_jexception(e)
 
     def get_units(self) -> list[str]:
         return to_pylist(self.jobj.getUnitList())
@@ -721,7 +433,7 @@ class JDBCBackend(CachingBackend):
             if len(kwargs):
                 raise ValueError(f"extra keyword arguments {kwargs}")
 
-            with _handle_jexception():
+            with handle_jexception():
                 self.jindex[ts].readSolutionFromGDX(*args)
 
             self.cache_invalidate(ts)
@@ -866,7 +578,7 @@ class JDBCBackend(CachingBackend):
 
         # Call either newTimeSeries or newScenario
         method = getattr(self.jobj, "new" + klass)
-        with _handle_jexception():
+        with handle_jexception():
             jobj = method(ts.model, ts.scenario, *args)
 
         self._index_and_set_attrs(jobj, ts)
@@ -891,7 +603,7 @@ class JDBCBackend(CachingBackend):
             # At least transmute to a ValueError
             raise ValueError("model, scenario, or version not found")
         except BaseException as e:
-            _raise_jexception(e)
+            raise_jexception(e)
 
         self._index_and_set_attrs(jobj, ts)
 
@@ -903,18 +615,18 @@ class JDBCBackend(CachingBackend):
         self.jindex.pop(ts, None)
 
     def check_out(self, ts: TimeSeries, timeseries_only: bool) -> None:
-        with _handle_jexception():
+        with handle_jexception():
             self.jindex[ts].checkOut(timeseries_only)
 
     def commit(self, ts: TimeSeries, comment: str) -> None:
         try:
             self.jindex[ts].commit(comment)
-        except java.Exception as e:
+        except java.lang.Exception as e:
             arg = e.args[0]
             if isinstance(arg, str) and "this Scenario is not checked out" in arg:
                 raise RuntimeError(arg)
             else:  # pragma: no cover
-                _raise_jexception(e)
+                raise_jexception(e)
         if ts.version == 0:
             ts.version = self.jindex[ts].getVersion()
 
@@ -1032,13 +744,15 @@ class JDBCBackend(CachingBackend):
 
         # Convert *data* to a Java data structure. Explicitly cast the key (period) to
         # Integer so JPype does not produce invalid java.lang.Long.
-        jdata = java.LinkedHashMap({java.Integer(k): v for k, v in data.items()})
+        jdata = java.util.LinkedHashMap(
+            {java.lang.Integer(k): v for k, v in data.items()}
+        )
 
         try:
             self.jindex[ts].addTimeseries(
                 region, variable, subannual, jdata, unit, meta
             )
-        except java.IxException as e:
+        except java.ixmp.exceptions.IxException as e:
             match = re.search("node '([^']*)' does not exist in the database", str(e))
             if match:
                 raise ValueError(f"region = {match.group(1)}") from None
@@ -1057,7 +771,7 @@ class JDBCBackend(CachingBackend):
         meta: bool,
     ) -> None:
         self.jindex[ts].addGeoData(
-            region, variable, subannual, java.Integer(year), value, unit, meta
+            region, variable, subannual, java.lang.Integer(year), value, unit, meta
         )
 
     def delete(
@@ -1069,7 +783,7 @@ class JDBCBackend(CachingBackend):
         years: Iterable[int],
         unit: str,
     ) -> None:
-        years = to_jlist(years, java.Integer)
+        years = to_jlist(years, java.lang.Integer)
         self.jindex[ts].removeTimeseries(region, variable, subannual, years, unit)
 
     def delete_geo(
@@ -1081,7 +795,7 @@ class JDBCBackend(CachingBackend):
         years: Iterable[int],
         unit: str,
     ) -> None:
-        years = to_jlist(years, java.Integer)
+        years = to_jlist(years, java.lang.Integer)
         self.jindex[ts].removeGeoData(region, variable, subannual, years, unit)
 
     # Scenario methods
@@ -1168,11 +882,11 @@ class JDBCBackend(CachingBackend):
         # by Backend, so don't return here
         try:
             func(name, java_idx_sets, java_idx_names)
-        except java.Exception as e:
+        except java.lang.Exception as e:
             if "already exists" in e.args[0]:
                 raise ValueError(f"{repr(name)} already exists")
             else:
-                _raise_jexception(e)
+                raise_jexception(e)
 
     def delete_item(
         self, s: Scenario, type: Literal["set", "par", "equ"], name: str
@@ -1183,7 +897,7 @@ class JDBCBackend(CachingBackend):
             if "There exists no" in e.args[0]:
                 raise KeyError(name)
             else:  # pragma: no cover
-                _raise_jexception(e)
+                raise_jexception(e)
         self.cache_invalidate(s, type, name)
 
     def item_index(
@@ -1241,7 +955,7 @@ class JDBCBackend(CachingBackend):
 
         # Get list of elements, using filters if provided
         if filters is not None:
-            jFilter = java.HashMap()
+            jFilter = java.util.HashMap()
 
             for idx_name, values in filters.items():
                 # Retrieve the elements of the index set as a list
@@ -1352,7 +1066,7 @@ class JDBCBackend(CachingBackend):
                 # Prepare arguments
                 args = [to_jlist(key)] if key else []
                 if type is Parameter:
-                    args.extend([java.Double(value), unit])
+                    args.extend([java.lang.Double(value), unit])
                 if comment:
                     args.append(comment)
 
@@ -1363,14 +1077,14 @@ class JDBCBackend(CachingBackend):
                 # - par: (key, value, unit)
                 # - par: (value, unit, comment)
                 jobj.addElement(*args)
-        except java.IxException as e:
+        except java.ixmp.exceptions.IxException as e:
             if any(s in e.args[0] for s in ("does not have an element", "The unit")):
                 # Re-raise as Python ValueError
                 raise ValueError(e.args[0]) from None
             elif "cannot be edited" in e.args[0]:
                 raise RuntimeError(e.args[0])
             else:  # pragma: no cover
-                _raise_jexception(e)
+                raise_jexception(e)
 
         self.cache_invalidate(s, type.ix_type, name)
 
@@ -1425,12 +1139,12 @@ class JDBCBackend(CachingBackend):
     ) -> dict[str, Any]:
         self._validate_meta_args(model, scenario, version)
         if version is not None:
-            version = java.Long(version)
+            version = java.lang.Long(version)
 
-        with _handle_jexception():
+        with handle_jexception():
             meta = self.jobj.getMeta(model, scenario, version, strict)
 
-        return {entry.getKey(): _unwrap(entry.getValue()) for entry in meta.entrySet()}
+        return {entry.getKey(): unwrap(entry.getValue()) for entry in meta.entrySet()}
 
     def set_meta(
         self,
@@ -1441,13 +1155,13 @@ class JDBCBackend(CachingBackend):
     ) -> None:
         self._validate_meta_args(model, scenario, version)
         if version is not None:
-            version = java.Long(version)
+            version = java.lang.Long(version)
 
-        jmeta = java.HashMap()
+        jmeta = java.util.HashMap()
         for k, v in meta.items():
-            jmeta.put(str(k), _wrap(v))
+            jmeta.put(str(k), wrap(v))
 
-        with _handle_jexception():
+        with handle_jexception():
             self.jobj.setMeta(model, scenario, version, jmeta)
 
     def remove_meta(
@@ -1459,7 +1173,7 @@ class JDBCBackend(CachingBackend):
     ) -> None:
         self._validate_meta_args(model, scenario, version)
         if version is not None:
-            version = java.Long(version)
+            version = java.lang.Long(version)
         self.jobj.removeMeta(model, scenario, version, to_jlist(names))
 
     def clear_solution(self, s: Scenario, from_year: int | None = None) -> None:
@@ -1510,124 +1224,11 @@ class JDBCBackend(CachingBackend):
         try:
             type_name = item.ix_type.title()
             return getattr(self.jindex[s], f"get{type_name}")(*args)
-        except java.IxException as e:
+        except java.ixmp.exceptions.IxException as e:
             # Regex for similar but not consistent messages from Java code
             msg = f"No (item|{type_name}) '?{item.name}'? exists in this Scenario!"
             if re.match(msg, e.args[0]):
                 # Re-raise as a Python KeyError
                 raise KeyError(item.name) from None
             else:  # pragma: no cover
-                _raise_jexception(e)
-
-
-def start_jvm(jvmargs: str | list[str] | None = None) -> None:
-    """Start the Java Virtual Machine via JPype_.
-
-    Parameters
-    ----------
-    jvmargs : str or list of str, optional
-        Additional arguments for launching the JVM, passed to :func:`jpype.startJVM`.
-
-        For instance, to set the maximum heap space to 4 GiB, give
-        ``jvmargs=['-Xmx4G']``. See the `JVM documentation`_ for a list of options.
-
-        .. _`JVM documentation`: https://docs.oracle.com/javase/7/docs
-           /technotes/tools/windows/java.html)
-    """
-    from ixmp.model.gams import gams_info
-
-    if jvmargs is None:
-        jvmargs = []
-    if jpype.isJVMStarted():
-        return
-
-    # Base directory for the classpath and library path
-    base = Path(__file__).with_name("jdbc")
-
-    # Arguments
-    args = jvmargs if isinstance(jvmargs, list) else [jvmargs]
-
-    # Append path to directories containing arch-specific libraries
-    uname = platform.uname()
-    paths = [
-        gams_info().java_api_dir,  # GAMS system directory
-        base.joinpath(uname.machine),  # Subdirectory of ixmp/backend/jdbc
-    ]
-    sep = ";" if uname.system == "Windows" else ":"
-    args.append(f"-Djava.library.path={sep.join(map(str, paths))}")
-
-    # Keyword arguments
-    kwargs = dict(
-        # Use ixmp.jar and related Java JAR files
-        classpath=str(base.joinpath("*")),
-        # For JPype 0.7 (raises a warning) and 0.8 (default is False). 'True' causes
-        # Java string objects to be converted automatically to Python str(), as expected
-        # by ixmp Python code.
-        convertStrings=True,
-    )
-
-    log.debug(f"JAVA_HOME: {os.environ.get('JAVA_HOME', '(not set)')}")
-    log.debug(f"jpype.getDefaultJVMPath: {jpype.getDefaultJVMPath()}")
-    log.debug(f"args to startJVM: {args} {kwargs}")
-
-    try:
-        jpype.startJVM(*args, **kwargs)
-    except FileNotFoundError as e:  # pragma: no cover
-        # Not covered by tests. jpype.getDefaultJVMPath() tries an extensive set of
-        # methods to find the JVM; it would require excessive effort to defeat these.
-        raise FileNotFoundError(
-            "This error may occur because you have not installed or configured a Java"
-            "Runtime Environment. See the install documentation."
-        ) from e
-
-    # Define auxiliary references to Java classes
-    global java
-    for class_name in JAVA_CLASSES:
-        setattr(java, class_name.split(".")[-1], jpype.JClass(class_name))
-
-
-# Conversion methods
-
-
-def to_pylist(jlist: Any) -> list[Any]:
-    """Convert Java list types to :class:`list`."""
-    try:
-        return list(jlist[:])
-    except Exception:
-        # java.LinkedList
-        return list(jlist.toArray()[:])
-
-
-def to_jlist(
-    arg: str | Iterable[float | int | str],
-    convert: Callable[..., Any] | None = None,
-) -> Any:
-    """Convert :class:`list` *arg* to java.LinkedList.
-
-    Parameters
-    ----------
-    arg : Collection or Iterable or str
-    convert : callable, optional
-        If supplied, every element of `arg` is passed through `convert` before being
-        added.
-
-    Returns
-    -------
-    java.LinkedList
-    """
-    # Previously JPype1 (prior to 1.0) could take single argument in addAll method of
-    # Java collection. As string implements Sequence contract in Python we need to
-    # convert it explicitly to list here.
-    if isinstance(arg, str):
-        arg = [arg]
-
-    if convert is not None:
-        return java.LinkedList(list(map(convert, arg)))
-    elif isinstance(arg, Sequence):
-        # Sized collection can be used directly
-        return java.LinkedList(arg)
-    elif isinstance(arg, Iterable):
-        # Transfer items from an iterable, generator, etc. to the LinkedList
-        return java.LinkedList(list(arg))
-    else:
-        raise ValueError(arg)
+                raise_jexception(e)

--- a/ixmp/backend/jdbc/jvm.py
+++ b/ixmp/backend/jdbc/jvm.py
@@ -1,0 +1,216 @@
+"""Utilities for interaction with Java and ``ixmp_source`` via :mod:`jpype`."""
+
+import logging
+import os
+import platform
+import re
+from collections.abc import Callable, Generator, Iterable, Sequence
+from contextlib import contextmanager
+from pathlib import Path
+from typing import Any, cast, overload
+
+log = logging.getLogger(__name__)
+
+
+class JClassProxy:
+    """Proxy to Java packages and classes.
+
+    This class works around the JPype limitation that classes cannot be imported and
+    referenced until the JVM has been started. After a call to :meth:`setup`, Java
+    classes like "at.iiasa.ac.iiasa.ixmp.Platform" can be accessed as
+    :py:`java.ixmp.Platform`, or others from the Java standard library as for instance
+    :py:`java.lang.Double` or :py:`java.util.HashMap`.
+    """
+
+    ixmp: Any  # NB jpype.JPackage, but this is not typed upstream
+    lang: Any
+    math: Any
+    util: Any
+
+    def setup(self) -> None:
+        import jpype
+
+        setattr(self, "lang", jpype.JPackage("java.lang"))
+        setattr(self, "math", jpype.JPackage("java.math"))
+        setattr(self, "util", jpype.JPackage("java.util"))
+        setattr(self, "ixmp", jpype.JPackage("at.ac.iiasa.ixmp"))
+
+
+#: Proxy to Java classes.
+java = JClassProxy()
+
+
+@contextmanager
+def handle_jexception() -> Generator[None, Any, None]:
+    """Context manager form of :func:`_raise_jexception`."""
+    try:
+        yield
+    except java.lang.Exception as e:
+        raise_jexception(e)
+
+
+def raise_jexception(exc: Any, msg: str = "unhandled Java exception: ") -> None:
+    """Convert Java/JPype exceptions to ordinary Python RuntimeError."""
+    from ixmp.backend.jdbc import _EXCEPTION_VERBOSE
+
+    # Try to re-raise as a ValueError for bad model or scenario name
+    arg = exc.args[0] if isinstance(exc.args[0], str) else ""
+    if match := re.search(r"getting '([^']*)' in table '([^']*)'", arg):
+        param = match.group(2).lower()
+        if param in {"model", "scenario"}:
+            raise ValueError(f"{param}={repr(match.group(1))}") from None
+
+    # Other exceptions
+    if _EXCEPTION_VERBOSE:
+        msg += "\n\n" + exc.stacktrace()
+    else:
+        msg += exc.message()
+
+    raise RuntimeError(msg) from None
+
+
+def start_jvm(jvmargs: str | list[str] | None = None) -> None:
+    """Start the Java Virtual Machine via JPype_.
+
+    Parameters
+    ----------
+    jvmargs : str or list of str, optional
+        Additional arguments for launching the JVM, passed to :func:`jpype.startJVM`.
+
+        For instance, to set the maximum heap space to 4 GiB, give
+        ``jvmargs=['-Xmx4G']``. See the `JVM documentation`_ for a list of options.
+
+        .. _`JVM documentation`: https://docs.oracle.com/javase/7/docs
+           /technotes/tools/windows/java.html)
+    """
+    import jpype
+
+    from ixmp.model.gams import gams_info
+
+    if jvmargs is None:
+        jvmargs = []
+    if jpype.isJVMStarted():
+        return
+
+    # Base directory for the classpath and library path
+    base = Path(__file__).parent
+
+    # Arguments
+    args = jvmargs if isinstance(jvmargs, list) else [jvmargs]
+
+    # Append path to directories containing arch-specific libraries
+    uname = platform.uname()
+    paths = [
+        gams_info().java_api_dir,  # GAMS system directory
+        base.joinpath(uname.machine),  # Subdirectory of ixmp/backend/jdbc
+    ]
+    sep = ";" if uname.system == "Windows" else ":"
+    args.append(f"-Djava.library.path={sep.join(map(str, paths))}")
+
+    # Keyword arguments
+    kwargs = dict(
+        # Use ixmp.jar and related Java JAR files
+        classpath=str(base.joinpath("*")),
+        # For JPype 0.7 (raises a warning) and 0.8 (default is False). 'True' causes
+        # Java string objects to be converted automatically to Python str(), as expected
+        # by ixmp Python code.
+        convertStrings=True,
+    )
+
+    log.debug(f"JAVA_HOME: {os.environ.get('JAVA_HOME', '(not set)')}")
+    log.debug(f"jpype.getDefaultJVMPath: {jpype.getDefaultJVMPath()}")
+    log.debug(f"args to startJVM: {args} {kwargs}")
+
+    try:
+        jpype.startJVM(*args, **kwargs)
+    except FileNotFoundError as e:  # pragma: no cover
+        # Not covered by tests. jpype.getDefaultJVMPath() tries an extensive set of
+        # methods to find the JVM; it would require excessive effort to defeat these.
+        raise FileNotFoundError(
+            "This error may occur because you have not installed or configured a Java"
+            "Runtime Environment. See the install documentation."
+        ) from e
+
+    # Set up proxy for referencing Java classes
+    java.setup()
+
+
+def to_pylist(jlist: Any) -> list[Any]:
+    """Convert Java list types to :class:`list`."""
+    try:
+        return list(jlist[:])
+    except Exception:
+        # java.LinkedList
+        return list(jlist.toArray()[:])
+
+
+def to_jlist(
+    arg: str | Iterable[float | int | str],
+    convert: Callable[..., Any] | None = None,
+) -> Any:
+    """Convert :class:`list` *arg* to java.LinkedList.
+
+    Parameters
+    ----------
+    arg : Collection or Iterable or str
+    convert : callable, optional
+        If supplied, every element of `arg` is passed through `convert` before being
+        added.
+
+    Returns
+    -------
+    java.util.LinkedList
+    """
+    # Previously JPype1 (prior to 1.0) could take single argument in addAll method of
+    # Java collection. As string implements Sequence contract in Python we need to
+    # convert it explicitly to list here.
+    if isinstance(arg, str):
+        arg = [arg]
+
+    if convert is not None:
+        return java.util.LinkedList(list(map(convert, arg)))
+    elif isinstance(arg, Sequence):
+        # Sized collection can be used directly
+        return java.util.LinkedList(arg)
+    elif isinstance(arg, Iterable):
+        # Transfer items from an iterable, generator, etc. to the LinkedList
+        return java.util.LinkedList(list(arg))
+    else:
+        raise ValueError(arg)
+
+
+@overload
+def unwrap(v: list[bool | float | str]) -> list[bool | float | str]: ...
+
+
+@overload
+def unwrap(v: bool | float | str) -> bool | float | str: ...
+
+
+def unwrap(v: Any) -> bool | float | str | list[bool | float | str]:
+    """Unwrap meta numeric value or list of values (BigDecimal -> Double)."""
+    if isinstance(v, java.math.BigDecimal):
+        _v: float = v.doubleValue()
+        return _v
+    elif isinstance(v, java.util.ArrayList):
+        return [unwrap(elt) for elt in v]
+    else:
+        # NOTE In truth, this value might only be a compatible Java type
+        else_v: bool | str = v
+        return else_v
+
+
+def wrap(value: Any) -> bool | float | int | str | list[bool | float | str]:
+    if isinstance(value, (str, bool)):
+        return value
+    elif isinstance(value, (int, float)):
+        # NOTE In truth, BigDecimal seems to return a Java type compatible with both
+        # float and int
+        _value: float | int = java.math.BigDecimal(value)
+        return _value
+    elif isinstance(value, (Sequence, Iterable)):
+        jlist = java.util.ArrayList()
+        jlist.addAll([wrap(elt) for elt in value])
+        return cast(list[bool | float | str], jlist)
+    else:
+        raise ValueError(f"Cannot use value {value} as metadata")

--- a/ixmp/backend/jdbc/options.py
+++ b/ixmp/backend/jdbc/options.py
@@ -1,0 +1,254 @@
+import os
+import re
+from collections.abc import Sequence
+from dataclasses import asdict, dataclass, field
+from enum import Enum, auto
+from pathlib import Path, PurePosixPath
+from typing import Any, NoReturn
+
+#: Default URL-end property/value pairs for HyperSQL databases, used by
+#: :attr:`.full_url`.
+#:
+#: See `Chapter 14. Properties <https://www.hsqldb.org/doc/guide/dbproperties-chapt.html#dpc_db_operations>`_
+#: in the HyperSQL documentation for description of this setting. This avoids
+#: performance issues instantiating :class:`.Platform` instances connected to databases
+#: with large amounts of data. See :issue:`643` and :issue:`433` for details.
+HSQLDB_DEFAULT_PROPS = ["hsqldb.default_table_type=cached"]
+
+
+class DRIVER(Enum):
+    """JDBC drivers supported with :class:`JDBCBackend`.
+
+    See :attr:`.Options.driver`.
+    """
+
+    #: HyperSQL.
+    hsqldb = auto()
+    #: Oracle.
+    oracle = auto()
+
+    @classmethod
+    def from_str(cls, value: "str | DRIVER") -> "DRIVER":
+        """Maybe convert :class:`str` to an enumeration member."""
+        try:
+            return cls[value] if isinstance(value, str) else value
+        except KeyError:
+            raise ValueError(f"unrecognized/unsupported JDBC driver {value!r}")
+
+
+@dataclass
+class Options:
+    """Options and configuration for :class:`JDBCBackend`.
+
+    .. autosummary::
+
+       driver
+       path
+       url
+       user
+       password
+       extra_properties
+       jvmargs
+    """
+
+    #: JDBC driver to use. See :class:`DRIVER`.
+    driver: DRIVER
+    #: Path to a local HyperSQL database. Invalid with :any:`DRIVER.oracle`.
+    path: os.PathLike[str] | None = None
+    #: Partial or compelte JDBC URL, for example
+    #: "database-server.example.com:PORT:SCHEMA". See :ref:`configuration`.
+    url: str = ""
+    #: Database username.
+    user: str = ""
+    #: Database user password.
+    password: str = ""
+    #: Arbitrary additional JDBC properties.
+    extra_properties: dict[str, str] = field(default_factory=dict)
+    #: Java Virtual Machine arguments. See :func:`.start_jvm`.
+    jvmargs: str | list[str] = ""
+
+    def __post_init__(self) -> None:
+        # Maybe convert a str to a DRIVER member
+        self.driver = DRIVER.from_str(self.driver)
+
+        # Check consistency of fields
+        if self.driver is DRIVER.oracle and (self.path or not self.url):
+            raise ValueError("use JDBCBackend(driver='oracle', url=…)")
+        elif self.driver is DRIVER.hsqldb and not self.path and not self.url:
+            raise ValueError(
+                "use JDBCBackend(driver='hsqldb', path=…) or "
+                "JDBCBackend(driver='hsqldb', url=…)"
+            )
+
+        # Remaining arguments are for the JVM
+        if isinstance(self.jvmargs, list):
+            self.jvmargs, *extra = self.jvmargs or [""]
+            if extra:
+                raise ValueError(f"Extra arguments for JDBCBackend: {extra!r}")
+
+    @property
+    def full_url(self) -> str:
+        """The full JDBC URL for the connection.
+
+        With :any:`DRIVER.hsqldb` and :attr:`path` set (or the "file:" protocol in
+        :attr:`url`), the :data:`HSQLDB_DEFAULT_PROPS` are appended to the constructed
+        URL, *unless* the user explicitly has specified the same properties.
+        """
+        result = ["jdbc", self.driver.name]
+        match self.driver:
+            case DRIVER.oracle:
+                result.extend(["thin", f"@{self.url}"])
+            case DRIVER.hsqldb:
+                if self.path:
+                    proto = "file"
+                    # Convert Windows paths to use forward slashes
+                    db = str(PurePosixPath(Path(self.path).resolve())).replace("\\", "")
+                    props = HSQLDB_DEFAULT_PROPS.copy()
+                elif match := re.fullmatch(
+                    "(jdbc:hsqldb:)?(?P<proto>file|mem):(?P<db>[^;]+)(;(?P<props>.*))?",
+                    self.url,
+                ):
+                    proto, db, all_props = match.group("proto", "db", "props")
+                    props = all_props.split(";") if all_props else []
+                else:
+                    raise ValueError(f"Cannot construct a JDBC URL for {self}")
+
+                # Use cached tables by default for non-memory databases
+                if proto == "file" and not any(
+                    HSQLDB_DEFAULT_PROPS[0].partition("=")[0] in p for p in props
+                ):
+                    props.append(HSQLDB_DEFAULT_PROPS[0])
+
+                result.append(proto)
+                result.append(db + ((";".join([""] + props)) if props else ""))
+
+        return ":".join(result)
+
+    @property
+    def properties(self) -> Any:
+        """Return a :py:`java.util.Properties` instance for an ixmp (Java) Platform."""
+        from .jvm import java
+
+        result = java.util.Properties()
+
+        for key, value in (
+            {
+                "jdbc.driver": {
+                    DRIVER.hsqldb: "org.hsqldb.jdbcDriver",
+                    DRIVER.oracle: "oracle.jdbc.driver.OracleDriver",
+                }[self.driver],
+                "jdbc.url": self.full_url,
+                "jdbc.user": self.user or "ixmp",
+                "jdbc.pwd": self.password or "ixmp",
+                # commented: This has no effect, apparently because ixmp_source Platform
+                # class fails to pass the property on to HyperSQL
+                # "hsqldb.default_table_type": "cached",
+            }
+            | self.extra_properties
+        ).items():
+            result.setProperty(key, value)
+
+        return result
+
+    @classmethod
+    def handle_config(cls, args: Sequence[Any], **kw: Any) -> dict[str, str]:
+        """Handle CLI arguments to :program:`ixmp platform add [name] ...`.
+
+        Parameters
+        ----------
+        args
+            Positional arguments. These override any `kw`, and may be in the form of:
+
+            1. :py:`("oracle", url, user, password, [jvmargs])`
+            2. :py:`("hsqldb", path, [jvmargs])` for a file-backed HyperSQL database.
+            3. :py:`("hsqldb",)`. with :attr:`url` supplied via `kwargs`, for instance
+               "jdbc:hsqldb:mem://foo" for an in-memory database.
+
+        Returns
+        -------
+        dict
+            Representation of `args` and `kw` suitable for :file:`config.json`.
+        """
+        # Make a list copy of `args` to avoid mutating
+        args = list(args)
+
+        # Shorthands for exception formatting
+        exp, got = " expected for JDBCBackend", f"; got {args}, {kw!r}"
+
+        def _raise(text: str) -> NoReturn:
+            raise ValueError(f"{text}{exp}{got}")
+
+        # First argument: driver
+        try:
+            driver = DRIVER.from_str(args.pop(0))
+        except IndexError:
+            _raise("≥1 positional argument (driver)")
+        else:
+            exp += f"(driver={driver.name!r})"
+
+        # Remaining arguments
+        match driver:
+            case DRIVER.oracle:
+                if len(args) < 3:
+                    _raise("3–4 arguments (URL, user, password, [jvmargs])")
+
+                kw["url"], kw["user"], kw["password"], *kw["jvmargs"] = args
+            case DRIVER.hsqldb:
+                try:
+                    kw["path"] = Path(args.pop(0)).resolve()
+                except IndexError:
+                    if "url" not in kw:
+                        _raise("either positional path or url= keyword argument")
+                kw["jvmargs"] = args
+
+        # Convert from a Config instance back to a dict
+        result = dict()
+        for key, value in asdict(cls(driver, **kw)).items():
+            if key == "driver":
+                result["driver"] = value.name  # String name of enumeration value
+            elif value:
+                result[key] = value  # Non-empty item
+
+        return result
+
+    @classmethod
+    def from_file(cls, path: os.PathLike[str], jvmargs: str | list[str]) -> "Options":
+        """Read database connection properties from a file at `path`.
+
+        Lines in `path` of the form "key = value" are parsed and returned as a new
+        Options instance. The following keys are mapped to fields:
+
+        - "jdbc.driver" → :attr:`driver`.
+        - "jdbc.pwd" → :attr:`password`.
+        - "jdbc.url" → :attr:`url`.
+        - "jdbc.user" → :attr:`user`.
+
+        All others are stored in :attr:`extra_properties`.
+
+        Raises
+        ------
+        FileNotFoundError
+            if `path` does not exist or is not a readable file.
+        """
+        path = Path(path)
+        if not path.exists() and path.is_file():
+            raise FileNotFoundError(path)
+
+        args: dict[str, Any] = dict(path=None, extra_properties={})
+        expr = re.compile(r"^(?:jdbc\.)?([\w\.]+)\s*=\s*(.+)\s*")
+        for match in filter(None, map(expr.fullmatch, path.read_text().splitlines())):
+            name, value = match.group(1), match.group(2)
+            match name:
+                case "driver":
+                    args[name] = DRIVER.hsqldb if "hsqldb" in value else DRIVER.oracle
+                case "pwd":
+                    args["password"] = value  # Change name
+                case "url" | "user":
+                    args[name] = value  # Store
+                case _:
+                    args["extra_properties"][name] = value  # Store
+
+        if "url" not in args:
+            raise ValueError(f"File {path} contains no database URL")
+
+        return cls(**args, jvmargs=jvmargs)

--- a/ixmp/testing/__init__.py
+++ b/ixmp/testing/__init__.py
@@ -223,6 +223,9 @@ def pytest_sessionstart(session: pytest.Session) -> None:
     db_name = PG_NAME_NONE
 
     if "ixmp4" in backends:
+        # Silence noisy debug logging from ixmp4 → litestar → polyfactory → faker
+        logging.getLogger("faker").setLevel(logging.INFO)
+
         # Connect to a PostgreSQL server and create a test database for this worker
         from sqlalchemy import create_engine, text
         from sqlalchemy.exc import OperationalError

--- a/ixmp/testing/resource.py
+++ b/ixmp/testing/resource.py
@@ -73,7 +73,7 @@ def memory_usage(message: str = "", reset: bool = False) -> MemInfo:
     """
     import memory_profiler
 
-    from ixmp.backend.jdbc import java
+    from ixmp.backend.jdbc.jvm import java
 
     global _COUNT, _PREV, _RT
 
@@ -85,7 +85,7 @@ def memory_usage(message: str = "", reset: bool = False) -> MemInfo:
 
     try:
         # Get the Java runtime
-        runtime = _RT or java.Runtime.getRuntime()
+        runtime = _RT or java.lang.Runtime.getRuntime()
     except AttributeError:
         # JVM not loaded
         runtime = None

--- a/ixmp/tests/backend/jdbc/test_options.py
+++ b/ixmp/tests/backend/jdbc/test_options.py
@@ -1,0 +1,24 @@
+import re
+from pathlib import Path
+
+from ixmp.backend.jdbc.options import DRIVER, Options
+
+
+class TestOptions:
+    def test_default_table_types_duplicate(self, tmp_path: Path) -> None:
+        """ "hsqldb.default_table_type=cached" is added by default, at most once."""
+        expr = re.compile("jdbc:hsqldb:file:[^;]*;hsqldb.default_table_type=cached")
+
+        # Using a path
+        assert expr.fullmatch(Options(DRIVER.hsqldb, path=tmp_path).full_url)
+
+        # Using a URL
+        assert expr.fullmatch(Options(DRIVER.hsqldb, url="file:foo").full_url)
+
+        # Using a URL with the parameter already added
+        opt = Options(DRIVER.hsqldb, url="file:foo;hsqldb.default_table_type=cached")
+        assert expr.fullmatch(opt.full_url)
+
+        # Existing property with default value is not overridden
+        opt = Options(DRIVER.hsqldb, url="file:foo;hsqldb.default_table_type=memory")
+        assert not expr.fullmatch(opt.full_url) and "=cached" not in opt.full_url

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -2,7 +2,6 @@ import gc
 import logging
 import os
 import platform
-import re
 from collections.abc import Generator
 from sys import getrefcount
 from typing import TYPE_CHECKING, Any, TypedDict
@@ -16,7 +15,7 @@ from pytest import raises
 
 import ixmp
 import ixmp.backend.jdbc
-from ixmp.backend.jdbc import DRIVER, Options, java
+from ixmp.backend.jdbc.options import DRIVER
 from ixmp.testing import DATA, MARK, add_random_model_data, bool_param_id, make_dantzig
 from ixmp.testing.resource import memory_usage
 from ixmp.util.ixmp4 import is_ixmp4backend
@@ -41,26 +40,6 @@ if TYPE_CHECKING:
 log = logging.getLogger(__name__)
 
 
-class TestOptions:
-    def test_default_table_types_duplicate(self, tmp_path: "Path") -> None:
-        """ "hsqldb.default_table_type=cached" is added by default, at most once."""
-        expr = re.compile("jdbc:hsqldb:file:[^;]*;hsqldb.default_table_type=cached")
-
-        # Using a path
-        assert expr.fullmatch(Options(DRIVER.hsqldb, path=tmp_path).full_url)
-
-        # Using a URL
-        assert expr.fullmatch(Options(DRIVER.hsqldb, url="file:foo").full_url)
-
-        # Using a URL with the parameter already added
-        opt = Options(DRIVER.hsqldb, url="file:foo;hsqldb.default_table_type=cached")
-        assert expr.fullmatch(opt.full_url)
-
-        # Existing property with default value is not overridden
-        opt = Options(DRIVER.hsqldb, url="file:foo;hsqldb.default_table_type=memory")
-        assert not expr.fullmatch(opt.full_url) and "=cached" not in opt.full_url
-
-
 @pytest.mark.flaky(
     reruns=5,
     rerun_delay=2,
@@ -79,7 +58,7 @@ def test_jvm_warn(recwarn: pytest.WarningsRecorder) -> None:
     """
 
     # Start the JVM for the first time in the test session
-    from ixmp.backend.jdbc import start_jvm
+    from ixmp.backend.jdbc.jvm import start_jvm
 
     start_jvm()
 
@@ -643,6 +622,7 @@ def test_reload_cycle(
     """
     # NB coverage is omitted because this test is not included in the standard
     #    suite
+    from ixmp.backend.jdbc.jvm import java
 
     # Clone reload_cycle_scenario onto a new Platform for this test
     platform_args: "PlatformInitKwargs" = dict(
@@ -658,7 +638,7 @@ def test_reload_cycle(
     mp = None
 
     # GC before cycling
-    java.System.gc()
+    java.lang.System.gc()
 
     # Set the garbage collection behaviour of JDBCBackend
     ixmp.backend.jdbc._GC_AGGRESSIVE = gc

--- a/ixmp/tests/backend/test_jdbc.py
+++ b/ixmp/tests/backend/test_jdbc.py
@@ -2,7 +2,8 @@ import gc
 import logging
 import os
 import platform
-from collections.abc import Callable, Generator
+import re
+from collections.abc import Generator
 from sys import getrefcount
 from typing import TYPE_CHECKING, Any, TypedDict
 
@@ -15,7 +16,7 @@ from pytest import raises
 
 import ixmp
 import ixmp.backend.jdbc
-from ixmp.backend.jdbc import DRIVER_CLASS, java
+from ixmp.backend.jdbc import DRIVER, Options, java
 from ixmp.testing import DATA, MARK, add_random_model_data, bool_param_id, make_dantzig
 from ixmp.testing.resource import memory_usage
 from ixmp.util.ixmp4 import is_ixmp4backend
@@ -38,6 +39,26 @@ if TYPE_CHECKING:
 
 
 log = logging.getLogger(__name__)
+
+
+class TestOptions:
+    def test_default_table_types_duplicate(self, tmp_path: "Path") -> None:
+        """ "hsqldb.default_table_type=cached" is added by default, at most once."""
+        expr = re.compile("jdbc:hsqldb:file:[^;]*;hsqldb.default_table_type=cached")
+
+        # Using a path
+        assert expr.fullmatch(Options(DRIVER.hsqldb, path=tmp_path).full_url)
+
+        # Using a URL
+        assert expr.fullmatch(Options(DRIVER.hsqldb, url="file:foo").full_url)
+
+        # Using a URL with the parameter already added
+        opt = Options(DRIVER.hsqldb, url="file:foo;hsqldb.default_table_type=cached")
+        assert expr.fullmatch(opt.full_url)
+
+        # Existing property with default value is not overridden
+        opt = Options(DRIVER.hsqldb, url="file:foo;hsqldb.default_table_type=memory")
+        assert not expr.fullmatch(opt.full_url) and "=cached" not in opt.full_url
 
 
 @pytest.mark.flaky(
@@ -227,7 +248,7 @@ class TestJDBCBackend:
         # Make `mp` think it is connected to an Oracle database
         # NOTE mp inside this class only knows one backend
         assert isinstance(mp._backend, ixmp.backend.jdbc.JDBCBackend)
-        mp._backend._properties["jdbc.driver"] = DRIVER_CLASS["oracle"]
+        mp._backend._options.driver = DRIVER.oracle
 
         # TimeSeries object and data to add
         ts = ixmp.TimeSeries(mp, "model name", "scenario name", version="new")
@@ -279,10 +300,13 @@ def test_pass_properties() -> None:
 
 
 def test_invalid_properties_file(test_data_path: "Path") -> None:
-    # HyperSQL creates a file with a .properties suffix for every file-based
-    # database, but these files do not contain the information needed to
-    # instantiate a database connection
-    with pytest.raises(ValueError, match="Config file contains no database URL"):
+    """An exception is raised for an invalid :file:`.properties` file.
+
+    HyperSQL creates a file with a .properties suffix for every file-based database, but
+    these files files do not contain the information needed to instantiate a database
+    connection.
+    """
+    with pytest.raises(ValueError, match="File .* contains no database URL"):
         ixmp.Platform(dbprops=test_data_path / "hsqldb.properties")
 
 
@@ -329,32 +353,22 @@ def test_cache_arg(arg: bool, request: pytest.FixtureRequest) -> None:
     assert len(mp._backend._cache) == (1 if arg else 0)
 
 
-# This variable formerly had 'warns' as the third element in some tuples, to
-# test for deprecation warnings.
 INIT_PARAMS: tuple[
-    tuple[
-        list[str],
-        "TestInitKwargs",
-        Callable[..., Any],
-        type[TypeError] | type[ValueError],
-        str | None,
-    ],
+    tuple[list[str], "TestInitKwargs", type[Exception], str | None],
     ...,
 ] = (
     # Handled in JDBCBackend:
     (
         ["nonexistent.properties"],
         dict(),
-        raises,
         ValueError,
-        "platform name " r"'nonexistent.properties' not among \['default'",
+        r"platform name 'nonexistent.properties' not among \['default'",
     ),
-    (["nonexistent.properties"], dict(name="default"), raises, TypeError, None),
+    (["nonexistent.properties"], dict(name="default"), TypeError, None),
     # Using the dbtype keyword argument
     (
         [],
         dict(dbtype="HSQLDB"),
-        raises,
         TypeError,
         r"JDBCBackend\(\) got an unexpected keyword argument 'dbtype'",
     ),
@@ -362,38 +376,34 @@ INIT_PARAMS: tuple[
     (
         [],
         dict(backend="jdbc", driver="oracle", path="foo/bar"),
-        raises,
         ValueError,
         None,
     ),
     # …with driver='oracle' and no url
-    ([], dict(backend="jdbc", driver="oracle"), raises, ValueError, None),
+    ([], dict(backend="jdbc", driver="oracle"), ValueError, None),
     # …with driver='hsqldb' and no path
-    ([], dict(backend="jdbc", driver="hsqldb"), raises, ValueError, None),
+    ([], dict(backend="jdbc", driver="hsqldb"), ValueError, None),
     # …with driver='hsqldb' and url
     (
         [],
         dict(backend="jdbc", driver="hsqldb", url="example.com:1234:SCHEMA"),
-        raises,
         ValueError,
         None,
     ),
 )
 
 
-@pytest.mark.parametrize("args,kwargs,action,kind,match", INIT_PARAMS)
-def test_init(
+@pytest.mark.parametrize("args, kwargs,  kind, match", INIT_PARAMS)
+def test_init_raises(
     tmp_env: os._Environ[str],
     args: list[str],
     kwargs: "TestInitKwargs",
-    action: Callable[..., Any],
-    kind: type[TypeError] | type[ValueError],
+    kind: type[Exception],
     match: str | None,
 ) -> None:
-    """Semantics for JDBCBackend.__init__()."""
-    # NOTE Triggering some errors on purpose
-    with action(kind, match=match):
-        ixmp.Platform(*args, **kwargs)  # type: ignore[misc]
+    """Certain arguments to JDBCBackend.__init__() raise certain exceptions."""
+    with pytest.raises(kind, match=match):
+        ixmp.Platform(*args, **kwargs)  # type: ignore [misc]
 
 
 def test_gh_216(test_mp: "Platform", request: pytest.FixtureRequest) -> None:

--- a/ixmp/tests/test_cli.py
+++ b/ixmp/tests/test_cli.py
@@ -64,7 +64,7 @@ def test_main(ixmp_cli: Runner, test_mp: "Platform", tmp_path: Path) -> None:
     # because temp.properties is empty)
     result = ixmp_cli.invoke(cmd[2:])
     assert result.exception
-    assert "Config file contains no database URL" in result.exception.args[0]
+    assert "temp.properties contains no database URL" in result.exception.args[0]
 
     # --url argument can be given
     cmd = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -132,7 +132,7 @@ ignore_missing_imports = true
 
 [tool.pytest]
 addopts = [
-  '-m "not rixmp and not performance"',
+  "-m (not rixmp and not performance)",
   # Disable faulthandler plugin on Windows to prevent spurious console noise; see
   # - https://github.com/jpype-project/jpype/issues/561
   # - https://github.com/iiasa/ixmp/issues/229


### PR DESCRIPTION
Closes #643:
- [x] Ensure that `hsqldb.default_table_type=cached` is set by default, unless explicitly set to another value by the used.
- [x] Mention this option in the documentation.

Also:
- Work around pandas-dev/pandas-stubs#1787, which caused failures of the "code quality" CI job on scheduled runs.
- Bump GAMS 45.7.0 → 48.7.0 in "pytest" CI workflow. The older version appears to no longer be available for download; this caused failures of the "pytest" CI job on scheduled runs.
  - Also update the GAMS_LICENSE secret in the repo settings to the latest 8-line version.
- Cherry-pick one commit from #644. This obviates that PR.
- Silence noisy logging from 'faker' in tests.
- Use parentheses in default pytest -m option. This caused pytest errors on my local machine.
- Quiet cleanup exceptions in `JDBCBackend.close_db()`

## How to review

- Read the diff and note that the CI checks all pass.
- View the preview build of the documentation and look at a certain page.

## PR checklist

- [x] Continuous integration checks all ✅
- [x] Add or expand tests; coverage checks both ✅
- [x] Add, expand, or update documentation.
- [x] Update release notes.
